### PR TITLE
Helm changes needed for the Edge Deployment operator

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -36,6 +36,14 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Define the image for a container.
+*/}}
+{{- define "amrc-connectivity-stack.image" -}}
+image: {{ .image.registry }}/{{ .image.repository }}:{{ .image.tag }}
+imagePullPolicy: {{ .image.pullPolicy }}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "amrc-connectivity-stack.labels" -}}

--- a/templates/auth/auth.yaml
+++ b/templates/auth/auth.yaml
@@ -52,8 +52,7 @@ spec:
                   key: admin
           command: [ 'sh', '-c', 'until curl -X PUT -o /dev/null -w "%{http_code}" -u "admin:${PASSWORD}" -H "Content-Type: application/json" --data-raw "{ \"url\": \"http://auth.{{.Release.Namespace}}.svc.cluster.local\" }" http://directory.{{.Release.Namespace}}.svc.cluster.local/v1/service/cab2642a-f7d9-42e5-8845-8f35affe1fd4/advertisment/1e1989ab-14e4-42bd-8171-495230acc406 | grep -E "2[0-9]{2}" > /dev/null; do sleep 10; done' ]
         - name: db-init
-          image: "{{ .Values.auth.image.registry }}/{{ .Values.auth.image.repository }}:{{ .Values.auth.image.tag }}"
-          imagePullPolicy: Always
+{{ include "amrc-connectivity-stack.image" .Values.auth | indent 10 }}
           command: [ "/usr/bin/k5start", "-Uf", "/keytabs/dbadmin", "/usr/local/bin/psql" ]
           args: [ "-w", "-q", "-f", "/home/node/app/sql/migrate.sql" ]
           env:
@@ -76,8 +75,7 @@ spec:
               name: krb5-keytabs-dbinit
 
         - name: load-dumps
-          image: "{{ .Values.auth.image.registry }}/{{ .Values.auth.image.repository }}:{{ .Values.auth.image.tag }}"
-          imagePullPolicy: Always
+{{ include "amrc-connectivity-stack.image" .Values.auth | indent 10 }}
           command: [ "/usr/bin/k5start", "-Uf", "/keytabs/client" ]
           args: [ "npm", "run", "load-dump", "/dumps" ]
           env:
@@ -101,8 +99,7 @@ spec:
 
       containers:
         - name: webapi
-          image: "{{ .Values.auth.image.registry }}/{{ .Values.auth.image.repository }}:{{ .Values.auth.image.tag }}"
-          imagePullPolicy: Always
+{{ include "amrc-connectivity-stack.image" .Values.auth | indent 10 }}
           env:
             - name: KRB5_CONFIG
               value: /config/krb5-conf/krb5.conf

--- a/templates/cmdesc/cmdesc.yaml
+++ b/templates/cmdesc/cmdesc.yaml
@@ -32,7 +32,7 @@ spec:
 
       containers:
         - name: mqtt
-          image: "{{ .Values.cmdesc.image.registry }}/{{ .Values.cmdesc.image.repository }}:{{ .Values.cmdesc.image.tag }}"
+{{ include "amrc-connectivity-stack.image" .Values.cmdesc | indent 10 }}
           command: [ "/usr/bin/k5start", "-Uf", "/keytabs/client" ]
           args: [ "npm", "start" ]
           env:

--- a/templates/configdb/configdb.yaml
+++ b/templates/configdb/configdb.yaml
@@ -51,7 +51,7 @@ spec:
                   key: admin
           command: [ 'sh', '-c', 'until curl -X PUT -o /dev/null -w "%{http_code}" -u "admin:${PASSWORD}" -H "Content-Type: application/json" --data-raw "{ \"url\": \"http://configdb.{{.Release.Namespace}}.svc.cluster.local\" }" http://directory.{{.Release.Namespace}}.svc.cluster.local/v1/service/af15f175-78a0-4e05-97c0-2a0bb82b9f3b/advertisment/36861e8d-9152-40c4-8f08-f51c2d7e3c25 | grep -E "2[0-9]{2}" > /dev/null; do sleep 10; done' ]
         - name: db-init
-          image: "{{ .Values.configdb.image.registry }}/{{ .Values.configdb.image.repository }}:{{ .Values.configdb.image.tag }}"
+{{ include "amrc-connectivity-stack.image" .Values.configdb | indent 10 }}
           command: [ "/usr/bin/k5start", "-Uf", "/keytabs/dbadmin", "/usr/local/bin/psql" ]
           args: [ "-w", "-q", "-f", "/home/node/app/sql/migrate.sql" ]
           env:
@@ -74,7 +74,7 @@ spec:
               name: krb5-keytabs-dbinit
 
         - name: load-dumps
-          image: "{{ .Values.configdb.image.registry }}/{{ .Values.configdb.image.repository }}:{{ .Values.configdb.image.tag }}"
+{{ include "amrc-connectivity-stack.image" .Values.configdb | indent 10 }}
           command: [ "/usr/bin/k5start", "-Uf", "/keytabs/client" ]
           args: [ "npm", "run", "load-dump", "/dumps" ]
           env:
@@ -96,7 +96,7 @@ spec:
 
       containers:
         - name: webapi
-          image: "{{ .Values.configdb.image.registry }}/{{ .Values.configdb.image.repository }}:{{ .Values.configdb.image.tag }}"
+{{ include "amrc-connectivity-stack.image" .Values.configdb | indent 10 }}
           env:
             - name: KRB5_CONFIG
               value: /config/krb5-conf/krb5.conf

--- a/templates/configdb/configdb.yaml
+++ b/templates/configdb/configdb.yaml
@@ -112,7 +112,7 @@ spec:
             - name: DEVICE_UUID
               value: 36861e8d-9152-40c4-8f08-f51c2d7e3c25
             - name: SPARKPLUG_ADDRESS
-              value: AMRC-Service-Config_DB/Config_DB
+              value: {{ .Values.acs.organisation }}-Service-Core/Config_DB
             - name: PORT
               value: "8080"
             - name: PGHOST
@@ -127,7 +127,7 @@ spec:
               value: "10"
             # If this is set it names a principal which overrides all ACLs. This should be turned off in production.
             - name: ROOT_PRINCIPAL
-              value: fplusadmin@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
+              value: admin@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
             # This is the value published via MQTT. It is also used by the editor so it needs to be externally resolvable.
             - name: HTTP_API_URL
               value: "{{ .Values.acs.secure | ternary "https://" "http://" }}configdb.{{.Values.acs.baseUrl | required "values.acs.baseUrl is required"}}"

--- a/templates/directory/directory-mqtt.yaml
+++ b/templates/directory/directory-mqtt.yaml
@@ -71,7 +71,7 @@ spec:
             - name: DEVICE_UUID
               value: 5cc3b068-938f-4bb2-8ceb-64338a02fbeb
             - name: SPARKPLUG_ADDRESS
-              value: {{ .Values.acs.organisation | required "values.acs.organisation is required!" }}-Service-DIR-Directory/Directory
+              value: {{ .Values.acs.organisation | required "values.acs.organisation is required!" }}-Service-Core/Directory
             - name: PORT
               value: "8080"
             - name: PGHOST

--- a/templates/dumps.yaml
+++ b/templates/dumps.yaml
@@ -497,11 +497,11 @@ data:
         {{$application_sparkplugAddressInformation}}: {
           {{$serviceAccount_directory}}: {
             "node_id": "Directory",
-            "group_id": "{{ .Values.acs.organisation }}-Service-DIR-Directory"
+            "group_id": "{{ .Values.acs.organisation }}-Service-Core"
           },
           {{$serviceAccount_configStore}}: {
             "node_id": "Config_DB",
-            "group_id": "{{ .Values.acs.organisation }}-Service-Config_DB"
+            "group_id": "{{ .Values.acs.organisation }}-Service-Core"
           },
           {{$serviceAccount_commandEscalation}}: {
             "node_id": "Command_Escalation",

--- a/templates/dumps.yaml
+++ b/templates/dumps.yaml
@@ -108,6 +108,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     component: configdb
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "20"
+    "helm.sh/resource-policy": keep
 data:
   # Pre-seed required
   bootstrap: |
@@ -535,6 +539,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "20"
+    "helm.sh/resource-policy": keep
   labels:
     component: auth
 data:

--- a/templates/identity/krb-keys-operator.yaml
+++ b/templates/identity/krb-keys-operator.yaml
@@ -42,7 +42,7 @@ spec:
               value: /config/krb5-conf/krb5.conf
             # The k8s namespaces to watch for KerberosKey objects. This should be a comma-separated list.
             - name: WATCH_NAMESPACES
-              value: {{ .Release.Namespace }}
+              value: {{ coalesce .Values.identity.krbKeysOperator.namespaces .Release.Namespace }}
             # The default secrets below are only used for KerberosKeys in this namespace. For other namespaces the
             # secret must be explicitly specified.
             - name: DEFAULT_NAMESPACE

--- a/templates/identity/krb-keys-operator.yaml
+++ b/templates/identity/krb-keys-operator.yaml
@@ -28,18 +28,24 @@ spec:
             items:
               - path: client
                 key: op1krbkeys
+        - name: krb5-ccache
+          emptyDir:
       containers:
         - name: operator
-          image: "{{ .Values.identity.krbKeysOperator.image.registry }}/{{ .Values.identity.krbKeysOperator.image.repository }}:{{ .Values.identity.krbKeysOperator.image.tag }}"
-          command: [
-            "/usr/bin/k5start",
-                   "-Uf", "/keytabs/client",
-            # For some reason k5start wants these separately...
-                   "-S", "kadmin", "-I", "admin" ]
-          args: [ "/bin/sh", "/home/krbkeys/bin/krb-keys.sh" ]
+{{ include "amrc-connectivity-stack.image" .Values.identity.krbKeysOperator | indent 10 }}
+          command: [ "/bin/sh", "/home/krbkeys/bin/krb-keys.sh" ]
+          args: []
           env:
             - name: KRB5_CONFIG
               value: /config/krb5-conf/krb5.conf
+            - name: KRB5CCNAME
+              value: /ccache/krbkeys
+            - name: KADMIN_CCNAME
+              value: /ccache/kadmin
+            - name: DIRECTORY_URL
+              value: http://directory.{{ .Release.Namespace }}.svc.cluster.local
+            - name: VERBOSE
+              value: "1"
             # The k8s namespaces to watch for KerberosKey objects. This should be a comma-separated list.
             - name: WATCH_NAMESPACES
               value: {{ coalesce .Values.identity.krbKeysOperator.namespaces .Release.Namespace }}
@@ -62,6 +68,41 @@ spec:
           volumeMounts:
             - mountPath: /config/krb5-conf
               name: krb5-conf
+            - mountPath: /ccache
+              name: krb5-ccache
+        - name: tgt-creds
+{{ include "amrc-connectivity-stack.image" .Values.identity.krbKeysOperator | indent 10 }}
+          command: ["/usr/bin/k5start", "-Uf", "/keytabs/client", "-K", "5"]
+          args: []
+          env:
+            - name: KRB5_CONFIG
+              value: /config/krb5-conf/krb5.conf
+            - name: KRB5CCNAME
+              value: /ccache/krbkeys
+          volumeMounts:
+            - mountPath: /config/krb5-conf
+              name: krb5-conf
             - mountPath: /keytabs
               name: krb5-keytabs
+            - mountPath: /ccache
+              name: krb5-ccache
+        - name: kadmin-creds
+{{ include "amrc-connectivity-stack.image" .Values.identity.krbKeysOperator | indent 10 }}
+          command: [
+            "/usr/bin/k5start", "-K", "5",
+            "-Uf", "/keytabs/client", 
+            "-S", "kadmin", "-I", "admin" ]
+          args: []
+          env:
+            - name: KRB5_CONFIG
+              value: /config/krb5-conf/krb5.conf
+            - name: KRB5CCNAME
+              value: /ccache/kadmin
+          volumeMounts:
+            - mountPath: /config/krb5-conf
+              name: krb5-conf
+            - mountPath: /keytabs
+              name: krb5-keytabs
+            - mountPath: /ccache
+              name: krb5-ccache
 {{- end -}}

--- a/templates/identity/krb5-conf.yaml
+++ b/templates/identity/krb5-conf.yaml
@@ -15,6 +15,13 @@ data:
     [domain_realm]
         cluster.local = {{ .Values.identity.realm | required "values.identity.realm is required!" }}
             {{.Values.acs.baseUrl | required "values.acs.baseUrl is required"}} = {{ .Values.identity.realm | required "values.identity.realm is required!" }}
+{{- range .Values.identity.crossRealm }}
+{{- $realm := .realm }}
+        {{ .domain }} = {{ $realm }}
+{{- range .otherDomains }}
+        {{ . }} = {{ $realm }}
+{{- end }}
+{{- end }}
 
     [realms]
             {{ .Values.identity.realm | required "values.identity.realm is required!" }} = {
@@ -22,4 +29,11 @@ data:
             admin_server = kadmin.{{ .Release.Namespace }}.svc.cluster.local
             disable_encrypted_timestamp = true
         }
+{{- range .Values.identity.crossRealm }}
+        {{ .realm }} = {
+            kdc = kdc.{{ .domain }}
+            admin_server = kadmin.{{ .domain }}
+            disable_encrypted_timestamp = true
+        }
+{{- end }}
 {{- end -}}

--- a/templates/identity/rbac.yaml
+++ b/templates/identity/rbac.yaml
@@ -20,16 +20,19 @@ rules:
       verbs: [list, get, create, update, delete, watch, patch]
   -   apiGroups: [""]
       resources: [secrets]
-      verbs: [get, create, update, patch]
+      verbs: [get, create, update, delete, patch]
   -   apiGroups: [bitnami.com]
       resources: [sealedsecrets]
-      verbs: [create, delete]
+      verbs: [get, create, update, delete, patch]
   -   apiGroups: [""]
       resources: [configmaps]
       verbs: [get]
   -   apiGroups: [""]
       resources: [namespaces]
       verbs: [get,list]
+  -   apiGroups: [""]
+      resources: [events]
+      verbs: [create]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/templates/manager/env/manager-config.yaml
+++ b/templates/manager/env/manager-config.yaml
@@ -7,6 +7,7 @@ metadata:
 data:
   APP_NAME: {{.Values.manager.name | quote | required "values.manager.name is required!"}}
   APP_ENV: {{.Values.manager.env | quote | required "values.manager.env is required!"}}
+  APP_NAMESPACE: {{ .Release.Namespace | quote }}
   APP_ORGANISATION: {{.Values.acs.organisation | quote | required "values.acs.organisation is required!"}}
   APP_DEBUG: {{.Values.manager.debug | quote | required "values.manager.debug is required!"}}
   VITE_BRANDING_NAME: {{.Values.manager.name | quote | required "values.manager.name is required!"}}

--- a/templates/mqtt/mqtt.yaml
+++ b/templates/mqtt/mqtt.yaml
@@ -43,7 +43,7 @@ spec:
           command: [ 'sh', '-c', 'until curl -X PUT -o /dev/null -w "%{http_code}" -u "sv1mqtt:${PASSWORD}" -H "Content-Type: application/json" --data-raw "{ \"url\": \"mqtt://mqtt.{{.Release.Namespace}}.svc.cluster.local\" }" http://directory.{{.Release.Namespace}}.svc.cluster.local/v1/service/feb27ba3-bd2c-4916-9269-79a61ebc4a47/advertisment | grep -E "2[0-9]{2}" > /dev/null; do sleep 10; done' ]
       containers:
         - name: hivemq
-          image: "{{ .Values.mqtt.image.registry }}/{{ .Values.mqtt.image.repository }}:{{ .Values.mqtt.image.tag }}"
+{{ include "amrc-connectivity-stack.image" .Values.mqtt | indent 10 }}
           env:
             - name: SERVER_KEYTAB
               value: /keytabs/server


### PR DESCRIPTION
This is the version of the helm chart currently running on my dev cluster, that `edge` and `git` are deployed over the top of.