### PR TITLE
Fix some invalid generated YAML.

### DIFF
--- a/templates/auth/principals/operators.yaml
+++ b/templates/auth/principals/operators.yaml
@@ -23,4 +23,4 @@ metadata:
 spec:
     type: Random
     principal: op1pgadmin@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
-{{- end -}}
+{{- end }}

--- a/templates/auth/principals/service-clients.yaml
+++ b/templates/auth/principals/service-clients.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   type: Random
   principal: sv1auth@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
-{{- end -}}
+{{- end }}
 ---
 {{- if .Values.cmdesc.enabled }}
 apiVersion: factoryplus.app.amrc.co.uk/v1
@@ -33,7 +33,7 @@ metadata:
 spec:
   type: Random
   principal: sv1cmdesc@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
-{{- end -}}
+{{- end }}
 ---
 {{- if .Values.configdb.enabled }}
 apiVersion: factoryplus.app.amrc.co.uk/v1
@@ -44,7 +44,7 @@ metadata:
 spec:
   type: Random
   principal: sv1configdb@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
-{{- end -}}
+{{- end }}
 ---
 {{- if .Values.directory.enabled }}
 apiVersion: factoryplus.app.amrc.co.uk/v1
@@ -55,7 +55,7 @@ metadata:
 spec:
   type: Random
   principal: sv1directory@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
-{{- end -}}
+{{- end }}
 ---
 {{- if .Values.mqtt.enabled }}
 apiVersion: factoryplus.app.amrc.co.uk/v1
@@ -66,7 +66,7 @@ metadata:
 spec:
   type: Password
   principal: sv1mqtt@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
-{{- end -}}
+{{- end }}
 ---
 {{- if .Values.manager.enabled }}
 apiVersion: factoryplus.app.amrc.co.uk/v1
@@ -78,7 +78,7 @@ spec:
   type: Random
   principal: sv1manager@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
   secret: manager-keytab/client-keytab
-{{- end -}}
+{{- end }}
 ---
 {{- if .Values.warehouse.enabled }}
 apiVersion: factoryplus.app.amrc.co.uk/v1
@@ -89,4 +89,4 @@ metadata:
 spec:
   type: Random
   principal: sv1warehouse@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
-{{- end -}}
+{{- end }}

--- a/templates/auth/principals/services.yaml
+++ b/templates/auth/principals/services.yaml
@@ -21,7 +21,7 @@ spec:
   principal: HTTP/auth.{{ .Release.Namespace }}.svc.cluster.local@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
   additionalPrincipals:
     - HTTP/auth.{{.Values.acs.baseUrl | required "values.acs.baseUrl is required"}}@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
-{{- end -}}
+{{- end }}
 ---
 {{- if .Values.cmdesc.enabled }}
 apiVersion: factoryplus.app.amrc.co.uk/v1
@@ -34,7 +34,7 @@ spec:
   principal: HTTP/cmdesc.{{ .Release.Namespace }}.svc.cluster.local@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
   additionalPrincipals:
     - HTTP/cmdesc.{{.Values.acs.baseUrl | required "values.acs.baseUrl is required"}}@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
-{{- end -}}
+{{- end }}
 ---
 {{- if .Values.configdb.enabled }}
 apiVersion: factoryplus.app.amrc.co.uk/v1
@@ -47,7 +47,7 @@ spec:
   principal: HTTP/configdb.{{ .Release.Namespace }}.svc.cluster.local@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
   additionalPrincipals:
     - HTTP/configdb.{{.Values.acs.baseUrl | required "values.acs.baseUrl is required"}}@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
-{{- end -}}
+{{- end }}
 ---
 {{- if .Values.directory.enabled }}
 apiVersion: factoryplus.app.amrc.co.uk/v1
@@ -60,7 +60,7 @@ spec:
   principal: HTTP/directory.{{ .Release.Namespace }}.svc.cluster.local@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
   additionalPrincipals:
     - HTTP/directory.{{.Values.acs.baseUrl | required "values.acs.baseUrl is required"}}@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
-{{- end -}}
+{{- end }}
 ---
 {{- if .Values.mqtt.enabled }}
 apiVersion: factoryplus.app.amrc.co.uk/v1
@@ -73,7 +73,7 @@ spec:
   principal: mqtt/mqtt.{{ .Release.Namespace }}.svc.cluster.local@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
   additionalPrincipals:
     - mqtt/mqtt.{{.Values.acs.baseUrl | required "values.acs.baseUrl is required"}}@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
-{{- end -}}
+{{- end }}
 ---
 {{- if .Values.manager.enabled }}
 apiVersion: factoryplus.app.amrc.co.uk/v1
@@ -87,7 +87,7 @@ spec:
   additionalPrincipals:
     - HTTP/manager.{{.Values.acs.baseUrl | required "values.acs.baseUrl is required"}}@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
   secret: manager-keytab/keytab
-{{- end -}}
+{{- end }}
 ---
 {{- if .Values.postgres.enabled }}
 apiVersion: factoryplus.app.amrc.co.uk/v1
@@ -98,7 +98,7 @@ metadata:
 spec:
   type: Random
   principal: postgres/postgres.{{ .Release.Namespace }}.svc.cluster.local@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
-{{- end -}}
+{{- end }}
 ---
 {{- if .Values.warehouse.enabled }}
 apiVersion: factoryplus.app.amrc.co.uk/v1
@@ -111,4 +111,4 @@ spec:
   principal: HTTP/warehouse.{{ .Release.Namespace }}.svc.cluster.local@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
   additionalPrincipals:
     - HTTP/warehouse.{{.Values.acs.baseUrl | required "values.acs.baseUrl is required"}}@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
-{{- end -}}
+{{- end }}


### PR DESCRIPTION
Excessive chomping on Helm templates was causing the YAML divider `---` to end up appended to the end of the previous line.