### PR TITLE
Remove code to conditionally apply CRDs

### DIFF
--- a/crds/kerberos-keys-crd.yaml
+++ b/crds/kerberos-keys-crd.yaml
@@ -1,4 +1,3 @@
-{{ if .Values.identity.enabled }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -88,4 +87,3 @@ spec:
                                     pattern: "^[a-z0-9.-]+/[a-zA-Z0-9._-]+$"
             subresources:
                 status: {}
-{{- end -}}

--- a/crds/kubegres-crd.yaml
+++ b/crds/kubegres-crd.yaml
@@ -1,4 +1,3 @@
-{{ if .Values.postgres.enabled }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -2114,4 +2113,3 @@ spec:
       storage: true
       subresources:
         status: {}
-{{- end -}}


### PR DESCRIPTION
It appears as though Helm control structures can't be used outside the templates directory (unsurprisingly!), so we can't apply them to the CRDs.

@amrc-benmorrow this may cause issues if the CRD already exists on a cluster.