### PR TITLE
Update Helm tag version format

### DIFF
--- a/.github/workflows/publish-helm.yml
+++ b/.github/workflows/publish-helm.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Package Helm chart
         run: |
           TAG=${{ github.event.release.tag_name }}
-          helm package -u -d build --version=$TAG --app-version=$TAG .
+          helm package -u -d build --version=${TAG#v} --app-version=${TAG#v} .
       - uses: actions/upload-artifact@v3
         with:
           name: new-release


### PR DESCRIPTION
This commit modifies how the Helm package version is formatted in the GitHub actions workflow for publishing Helm charts. The change ensures that the 'v' prefix is stripped from the version tags. This conforms to the SemVer norm, thus maintaining consistency and compatibility with third-party tools expecting this standard format.