### PR TITLE
Add Loki as Grafana datasource configuration

### DIFF
--- a/templates/grafana/grafana-datasource-influxdb.yaml
+++ b/templates/grafana/grafana-datasource-influxdb.yaml
@@ -10,11 +10,6 @@ data:
     # config file version
     apiVersion: 1
 
-    # list of datasources that should be deleted from the database
-    deleteDatasources:
-       - name: InfluxDB
-         orgId: 1
-
     # list of datasources to insert/update depending
     # what's available in the database
     datasources:

--- a/templates/grafana/grafana-datasource-loki.yaml
+++ b/templates/grafana/grafana-datasource-loki.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasource-loki
+  namespace: {{ .Release.Namespace }}
+  labels:
+    grafana_datasource: "1"
+data:
+  datasource.yaml: |-
+    # config file version
+    apiVersion: 1
+    # list of datasources to insert/update depending
+    # what's available in the database
+    datasources:
+      # <string, required> name of the datasource. Required
+      - name: Loki
+        # <string, required> datasource type. Required
+        type: loki
+        # <string, required> access mode. proxy or direct (Server or Browser in the UI). Required
+        access: proxy
+        # <int> org id. will default to orgId 1 if not specified
+        orgId: 1
+        # <string> custom UID which can be used to reference this datasource in other parts of the configuration, if not specified will be generated automatically
+        uid: loki
+        # <string> url
+        url: http://loki:3100
+        # <bool> mark as default datasource. Max one per org
+        isDefault: false
+        version: 1
+        editable: true


### PR DESCRIPTION
This commit adds a new configuration for Loki as a datasource in Grafana. This will allow us to query and visualize log data from Loki directly in Grafana.