### PR TITLE
Add Edge Deployment Operator (EDO) Auth & ConfigDB seeds

### DIFF
--- a/templates/auth/principals/service-clients.yaml
+++ b/templates/auth/principals/service-clients.yaml
@@ -112,5 +112,5 @@ metadata:
 spec:
   type: Random
   principal: sv1edge@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
-  secret: edge-keytabs/client
+  secret: edo-keytabs/client
 {{- end }}

--- a/templates/auth/principals/services.yaml
+++ b/templates/auth/principals/services.yaml
@@ -138,5 +138,5 @@ spec:
   principal: HTTP/edge.{{ .Release.Namespace }}.svc.cluster.local@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
   additionalPrincipals:
     - HTTP/edge.{{.Values.acs.baseUrl | required "values.acs.baseUrl is required"}}@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
-  secret: edge-keytabs/server
+  secret: edo-keytabs/server
 {{- end }}

--- a/templates/edo/dumps.yaml
+++ b/templates/edo/dumps.yaml
@@ -1,0 +1,387 @@
+# Only run this if the ConfigMaps don't already exist
+
+# ====================================================
+# Ensure that well-known UUIDs are used where required
+# ----------------------------------------------------
+# ⚠ Do not change these!
+# ====================================================
+
+{{$wildcard := "00000000-0000-0000-0000-000000000000" | quote}}
+
+{{$classDef_edgeCluster := "f24d354d-abc1-4e32-98e1-0667b3e40b61" | quote}}
+{{$classDef_edgeClusterTemplate := "f9be0334-0ff7-43d3-9d8a-188d3e4d472b" | quote}}
+{{$classDef_application := "d319bd87-f42b-4b66-be4f-f82ff48b93f0" | quote}}
+{{$classDef_serviceFunction := "265d481f-87a7-4f93-8fc6-53fa64dc11bb" | quote}}
+{{$classDef_permissionGroup := "ac0d5288-6136-4ced-a372-325fbbcdd70d" | quote}}
+{{$classDef_permission := "8ae784bb-c4b5-4995-9bf6-799b3c7f21ad" | quote}}
+{{$classDef_serviceRequirement := "b419cbc2-ab0f-4311-bd9e-f0591f7e88cb" | quote}}
+
+{{$application_gitRepoConfiguration := "38d62a93-b6b4-4f63-bad4-d433e3eaff29" | quote}}
+{{$application_edgeClusterConfiguration := "bdb13634-0b3d-4e38-a065-9d88c12ee78d" | quote}}
+{{$application_edgeClusterTemplate := "72804a19-636b-4836-b62b-7ad1476f2b86" | quote}}
+{{$application_generalObjectInformation := "64a8bfa9-7772-45c4-9d1a-9e6290690957" | quote}}
+{{$application_applicationConfigSchema := "dbd8a535-52ba-4f6e-b4f8-9b71aefe09d3" | quote}}
+
+{{$service_authorisation := "cab2642a-f7d9-42e5-8845-8f35affe1fd4" | quote}}
+{{$service_configStore := "af15f175-78a0-4e05-97c0-2a0bb82b9f3b" | quote}}
+{{$service_edo := "2706aa43-a826-441e-9cec-cd3d4ce623c2" | quote}}
+
+{{$serviceAccount_edgeDeploymentServiceAccount := "26d192cf-73c1-4c14-93cf-1e63743bab08" | quote}}
+
+{{$serviceRequirement_edgeFluxAccount := "4eeb8156-856d-4251-a4a4-4c1b2f3d3e2c" | quote}}
+{{$serviceRequirement_edgeClusterRepositories := "3a58340c-d4ec-453d-99c3-0cf6ab7d8fa9" | quote}}
+{{$serviceRequirement_edgeFluxRoles := "8cd08563-7c3c-44fd-af4d-15c0fa6dadcb" | quote}}
+{{$serviceRequirement_gitServiceAccount := "a461ef62-0560-4be2-8d97-1a56916ce4f8" | quote}}
+
+{{$permission_directory_advertiseService := "4db4c39a-f18d-4e83-aeb0-5af2c14ddc2b" | quote}}
+
+{{$permission_git_createRepo := "3668660f-f949-4657-be76-21967144c1a2" | quote}}
+{{$permission_git_pullFromRepo := "12ecb694-b4b9-4d2a-927e-d100019f7ebe" | quote}}
+{{$permission_git_pushToRepo := "b2d8d437-5060-4202-bcc2-bd2beda09651" | quote}}
+
+{{$permission_auth_readACLEntry := "ba566181-0e8a-405b-b16e-3fb89130fbee" | quote}}
+{{$permission_auth_manageKerberosMappings := "327c4cc8-9c46-4e1e-bb6b-257ace37b0f6" | quote}}
+{{$permission_auth_manageACLsPerPermission := "3a41f5ce-fc08-4669-9762-ec9e71061168" | quote}}
+{{$permission_auth_manageGroups := "be9b6d47-c845-49b2-b9d5-d87b83f11c3b" | quote}}
+
+{{$permission_configStore_readConfigForApp := "4a339562-cd57-408d-9d1a-6529a383ea4b" | quote}}
+{{$permission_configStore_writeConfigForApp := "6c799ccb-d2ad-4715-a2a7-3c8728d6c0bf" | quote}}
+{{$permission_configStore_manageObjects := "f0b7917b-d475-4888-9d5a-2af96b3c26b6" | quote}}
+
+{{$permission_edge_manageClusters := "a40acff8-0c61-4251-bef3-d8d53e50cdd0" | quote}}
+{{$permission_edge_manageSecrets := "07fba27a-0d01-4c07-875b-d25345261d3a" | quote}}
+
+{{$permissionGroup_edo_all := "9e07fd33-6400-4662-92c4-4dff1f61f990" | quote}}
+
+
+# Auth EDO Dumps
+{{- if not (lookup "v1" "ConfigMap" .Release.Namespace "auth-edo-dumps") }}
+{{ if and .Values.auth.enabled .Values.edo.enabled }}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: auth-json-dumps
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "20"
+    "helm.sh/resource-policy": keep
+  labels:
+    component: auth
+data:
+  # Pre-seed required ACEs, Groups and Principals
+  bootstrap: |
+    {
+      "service": {{$service_authorisation}},
+      "version": 1,
+      "aces": [
+        {
+          "principal": {{$serviceAccount_edgeDeploymentServiceAccount}},
+          "permission": {{$permission_directory_advertiseService}},
+          "target": {{$service_edo}}
+        },
+        {
+          "principal": {{$serviceAccount_edgeDeploymentServiceAccount}},
+          "permission": {{$permission_auth_readACLEntry}},
+          "target": {{$permissionGroup_edo_all}}
+        },
+        {
+          "principal": {{$serviceAccount_edgeDeploymentServiceAccount}},
+          "permission": {{$permission_auth_manageKerberosMappings}},
+          "target": {{$wildcard}}
+        },
+        {
+          "principal": {{$serviceAccount_edgeDeploymentServiceAccount}},
+          "permission": {{$permission_configStore_readConfigForApp}},
+          "target": {{$application_gitRepoConfiguration}}
+        },
+        {
+          "principal": {{$serviceAccount_edgeDeploymentServiceAccount}},
+          "permission": {{$permission_configStore_readConfigForApp}},
+          "target": {{$application_edgeClusterConfiguration}}
+        },
+        {
+          "principal": {{$serviceAccount_edgeDeploymentServiceAccount}},
+          "permission": {{$permission_configStore_readConfigForApp}},
+          "target": {{$application_edgeClusterTemplate}}
+        },
+        {
+          "principal": {{$serviceAccount_edgeDeploymentServiceAccount}},
+          "permission": {{$permission_configStore_writeConfigForApp}},
+          "target": {{$application_generalObjectInformation}}
+        },
+        {
+          "principal": {{$serviceAccount_edgeDeploymentServiceAccount}},
+          "permission": {{$permission_configStore_writeConfigForApp}},
+          "target": {{$application_edgeClusterConfiguration}}
+        },
+        {
+          "principal": {{$serviceAccount_edgeDeploymentServiceAccount}},
+          "permission": {{$permission_configStore_manageObjects}},
+          "target": {{$serviceRequirement_edgeFluxAccount}}
+        },
+        {
+          "principal": {{$serviceAccount_edgeDeploymentServiceAccount}},
+          "permission": {{$permission_configStore_manageObjects}},
+          "target": {{$classDef_edgeCluster}}
+        },
+        {
+          "principal": {{$serviceAccount_edgeDeploymentServiceAccount}},
+          "permission": {{$permission_auth_manageACLsPerPermission}},
+          "target": {{$permission_git_pullFromRepo}}
+        },
+        {
+          "principal": {{$serviceAccount_edgeDeploymentServiceAccount}},
+          "permission": {{$permission_auth_manageGroups}},
+          "target": {{$serviceRequirement_edgeFluxRoles}}
+        },
+        {
+          "principal": {{$serviceAccount_edgeDeploymentServiceAccount}},
+          "permission": {{$permission_git_createRepo}},
+          "target": {{$serviceRequirement_edgeClusterRepositories}}
+        },
+        {
+          "principal": {{$serviceAccount_edgeDeploymentServiceAccount}},
+          "permission": {{$permission_git_pullFromRepo}},
+          "target": {{$serviceRequirement_edgeClusterRepositories}}
+        },
+        {
+          "principal": {{$serviceAccount_edgeDeploymentServiceAccount}},
+          "permission": {{$permission_git_pushToRepo}},
+          "target": {{$serviceRequirement_edgeClusterRepositories}}
+        }
+      ],
+      "groups": {
+          {{$permissionGroup_edo_all}}: [
+            {{$permission_edge_manageClusters}},
+            {{$permission_edge_manageSecrets}}
+          ]
+      }
+    }
+
+{{end}}
+{{end}}
+
+
+# ConfigDB EDO Dumps
+{{- if not (lookup "v1" "ConfigMap" .Release.Namespace "configdb-edo-dumps") }}
+{{ if and .Values.configdb.enabled .Values.edo.enabled }}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: configdb-edo-dumps
+  namespace: {{ .Release.Namespace }}
+  labels:
+    component: configdb
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "20"
+    "helm.sh/resource-policy": keep
+data:
+  # Pre-seed required
+  bootstrap: |
+    {
+      "service": {{$service_configStore}},
+      "version": 1,
+      "classes": [
+        {{$classDef_edgeCluster}},
+        {{$classDef_edgeClusterTemplate}}
+      ],
+      "objects": {
+        {{$classDef_application}}: [
+          {{$application_edgeClusterConfiguration}},
+          {{$application_edgeClusterTemplate}}
+        ],
+        {{$classDef_serviceFunction}}: [
+          {{$service_edo}}
+        ],
+        {{$classDef_permissionGroup}}: [
+          {{$permissionGroup_edo_all}}
+        ],
+        {{$classDef_permission}}: [
+          {{$permission_edge_manageClusters}},
+          {{$permission_edge_manageSecrets}}
+        ],
+        {{$classDef_serviceRequirement}}: [
+          {{$serviceAccount_edgeDeploymentServiceAccount}},
+          {{$serviceRequirement_edgeClusterRepositories}},
+          {{$serviceRequirement_edgeFluxAccount}},
+          {{$serviceRequirement_edgeFluxRoles}}
+        ]
+      },
+      "configs": {
+        {{$application_generalObjectInformation}}: {
+          {{$application_edgeClusterConfiguration}}: {
+            "name": "Edge cluster configuration"
+          },
+          {{$application_edgeClusterTemplate}}: {
+            "name": "Edge cluster template"
+          },
+          {{$classDef_edgeCluster}}: {
+            "name": "Edge cluster"
+          },
+          {{$classDef_edgeClusterTemplate}}: {
+            "name": "Edge cluster template"
+          },
+          {{$service_edo}}: {
+            "name": "Edge Deployment Operator"
+          },
+          {{$permissionGroup_edo_all}}: {
+            "name": "Edge Deployment permissions"
+          },
+          {{$permission_edge_manageClusters}}: {
+            "name": "Edge: Manage clusters"
+          },
+          {{$permission_edge_manageSecrets}}: {
+            "name": "Edge: Manage secrets"
+          },
+          {{$serviceAccount_edgeDeploymentServiceAccount}}: {
+            "name": "Edge Deployment service account"
+          },
+          {{$serviceRequirement_edgeClusterRepositories}}: {
+            "name": "Edge cluster repositories"
+          },
+          {{$serviceRequirement_edgeFluxAccount}}: {
+            "name": "Edge flux accounts"
+          },
+          {{$serviceRequirement_edgeFluxRoles}}: {
+            "name": "Edge flux roles"
+          }
+        },
+        {{$application_applicationConfigSchema}}: {
+          {{$application_edgeClusterConfiguration}}: {
+            "title": "Edge cluster configuration",
+            "type": "object",
+            "required": [
+              "namespace"
+            ],
+            "properties": {
+              "namespace": {
+                "description": "The k8s namespace to deploy to.",
+                "type": "string"
+              },
+              "flux": {
+                "description": "The URL of the Git repo driving this cluster.",
+                "type": "string"
+              },
+              "kubeseal_cert": {
+                "description": "The PEM-encoded X509 certificate used by the sealed-secrets operator on the edge cluster.\n",
+                "type": "string"
+              }
+            }
+          },
+          {{$application_edgeClusterTemplate}}: {
+            "title": "Edge cluster template",
+            "description": "A template to drive the creation of an edge cluster. Some values are subject to template expansion; `%n` is expanded to the name of the cluster as supplied to the Edge Deployment Operator.\n",
+            "type": "object",
+            "required": [
+              "name",
+              "cluster",
+              "flux",
+              "repository"
+            ],
+            "properties": {
+              "name": {
+                "description": "The name used to locate this template.",
+                "type": "string"
+              },
+              "cluster": {
+                "description": "Configuration of the k8s cluster.",
+                "type": "object",
+                "required": [
+                  "namespace"
+                ],
+                "properties": {
+                  "namespace": {
+                    "description": "The namespace to deploy to.",
+                    "type": "string"
+                  }
+                }
+              },
+              "flux": {
+                "description": "Configuration of the Flux service account.",
+                "type": "object",
+                "required": [
+                  "class",
+                  "username"
+                ],
+                "properties": {
+                  "class": {
+                    "description": "ConfigDB class to create the account under.",
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "username": {
+                    "description": "Template for the Kerberos UPN of the service account.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "General Info name for the service account.",
+                    "type": "string"
+                  },
+                  "groups": {
+                    "description": "Auth groups to add the service account to.",
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              },
+              "repository": {
+                "description": "Configuration of the cluster git repo.",
+                "required": [
+                  "group",
+                  "branch",
+                  "interval"
+                ],
+                "properties": {
+                  "group": {
+                    "description": "The repo group to create the repo in. The repo itself will be named with the name of the cluster.\n",
+                    "type": "string"
+                  },
+                  "branch": {
+                    "description": "The branch name to use.",
+                    "type": "string"
+                  },
+                  "interval": {
+                    "description": "The sync interval. This is in the interval format accepted by Flux.\n",
+                    "type": "string"
+                  },
+                  "links": {
+                    "description": "Other repos to sync from. Appropriate Flux manifests will be committed to the cluster repo to enable this.\n",
+                    "type": "object",
+                    "propertyNames": {
+                      "description": "The UUID of the repo to sync from.",
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "additionalProperties": {
+                      "type": "object",
+                      "required": [
+                        "branch",
+                        "interval"
+                      ],
+                      "properties": {
+                        "branch": {
+                          "type": "string"
+                        },
+                        "interval": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+{{end}}
+{{end}}

--- a/templates/edo/dumps.yaml
+++ b/templates/edo/dumps.yaml
@@ -26,7 +26,7 @@
 {{$service_configStore := "af15f175-78a0-4e05-97c0-2a0bb82b9f3b" | quote}}
 {{$service_edo := "2706aa43-a826-441e-9cec-cd3d4ce623c2" | quote}}
 
-{{$serviceAccount_edgeDeploymentServiceAccount := "26d192cf-73c1-4c14-93cf-1e63743bab08" | quote}}
+{{$serviceRequirement_edgeDeploymentServiceAccount := "26d192cf-73c1-4c14-93cf-1e63743bab08" | quote}}
 
 {{$serviceRequirement_edgeFluxAccount := "4eeb8156-856d-4251-a4a4-4c1b2f3d3e2c" | quote}}
 {{$serviceRequirement_edgeClusterRepositories := "3a58340c-d4ec-453d-99c3-0cf6ab7d8fa9" | quote}}
@@ -75,77 +75,77 @@ data:
       "version": 1,
       "aces": [
         {
-          "principal": {{$serviceAccount_edgeDeploymentServiceAccount}},
+          "principal": {{$serviceRequirement_edgeDeploymentServiceAccount}},
           "permission": {{$permission_directory_advertiseService}},
           "target": {{$service_edo}}
         },
         {
-          "principal": {{$serviceAccount_edgeDeploymentServiceAccount}},
+          "principal": {{$serviceRequirement_edgeDeploymentServiceAccount}},
           "permission": {{$permission_auth_readACLEntry}},
           "target": {{$permissionGroup_edo_all}}
         },
         {
-          "principal": {{$serviceAccount_edgeDeploymentServiceAccount}},
+          "principal": {{$serviceRequirement_edgeDeploymentServiceAccount}},
           "permission": {{$permission_auth_manageKerberosMappings}},
           "target": {{$wildcard}}
         },
         {
-          "principal": {{$serviceAccount_edgeDeploymentServiceAccount}},
+          "principal": {{$serviceRequirement_edgeDeploymentServiceAccount}},
           "permission": {{$permission_configStore_readConfigForApp}},
           "target": {{$application_gitRepoConfiguration}}
         },
         {
-          "principal": {{$serviceAccount_edgeDeploymentServiceAccount}},
+          "principal": {{$serviceRequirement_edgeDeploymentServiceAccount}},
           "permission": {{$permission_configStore_readConfigForApp}},
           "target": {{$application_edgeClusterConfiguration}}
         },
         {
-          "principal": {{$serviceAccount_edgeDeploymentServiceAccount}},
+          "principal": {{$serviceRequirement_edgeDeploymentServiceAccount}},
           "permission": {{$permission_configStore_readConfigForApp}},
           "target": {{$application_edgeClusterTemplate}}
         },
         {
-          "principal": {{$serviceAccount_edgeDeploymentServiceAccount}},
+          "principal": {{$serviceRequirement_edgeDeploymentServiceAccount}},
           "permission": {{$permission_configStore_writeConfigForApp}},
           "target": {{$application_generalObjectInformation}}
         },
         {
-          "principal": {{$serviceAccount_edgeDeploymentServiceAccount}},
+          "principal": {{$serviceRequirement_edgeDeploymentServiceAccount}},
           "permission": {{$permission_configStore_writeConfigForApp}},
           "target": {{$application_edgeClusterConfiguration}}
         },
         {
-          "principal": {{$serviceAccount_edgeDeploymentServiceAccount}},
+          "principal": {{$serviceRequirement_edgeDeploymentServiceAccount}},
           "permission": {{$permission_configStore_manageObjects}},
           "target": {{$serviceRequirement_edgeFluxAccount}}
         },
         {
-          "principal": {{$serviceAccount_edgeDeploymentServiceAccount}},
+          "principal": {{$serviceRequirement_edgeDeploymentServiceAccount}},
           "permission": {{$permission_configStore_manageObjects}},
           "target": {{$classDef_edgeCluster}}
         },
         {
-          "principal": {{$serviceAccount_edgeDeploymentServiceAccount}},
+          "principal": {{$serviceRequirement_edgeDeploymentServiceAccount}},
           "permission": {{$permission_auth_manageACLsPerPermission}},
           "target": {{$permission_git_pullFromRepo}}
         },
         {
-          "principal": {{$serviceAccount_edgeDeploymentServiceAccount}},
+          "principal": {{$serviceRequirement_edgeDeploymentServiceAccount}},
           "permission": {{$permission_auth_manageGroups}},
           "target": {{$serviceRequirement_edgeFluxRoles}}
         },
         {
-          "principal": {{$serviceAccount_edgeDeploymentServiceAccount}},
+          "principal": {{$serviceRequirement_edgeDeploymentServiceAccount}},
           "permission": {{$permission_git_createRepo}},
           "target": {{$serviceRequirement_edgeClusterRepositories}}
         },
         {
-          "principal": {{$serviceAccount_edgeDeploymentServiceAccount}},
+          "principal": {{$serviceRequirement_edgeDeploymentServiceAccount}},
           "permission": {{$permission_git_pullFromRepo}},
           "target": {{$serviceRequirement_edgeClusterRepositories}}
         },
         {
-          "principal": {{$serviceAccount_edgeDeploymentServiceAccount}},
+          "principal": {{$serviceRequirement_edgeDeploymentServiceAccount}},
           "permission": {{$permission_git_pushToRepo}},
           "target": {{$serviceRequirement_edgeClusterRepositories}}
         }
@@ -201,7 +201,7 @@ data:
           {{$permission_edge_manageSecrets}}
         ],
         {{$classDef_serviceRequirement}}: [
-          {{$serviceAccount_edgeDeploymentServiceAccount}},
+          {{$serviceRequirement_edgeDeploymentServiceAccount}},
           {{$serviceRequirement_edgeClusterRepositories}},
           {{$serviceRequirement_edgeFluxAccount}},
           {{$serviceRequirement_edgeFluxRoles}}
@@ -233,7 +233,7 @@ data:
           {{$permission_edge_manageSecrets}}: {
             "name": "Edge: Manage secrets"
           },
-          {{$serviceAccount_edgeDeploymentServiceAccount}}: {
+          {{$serviceRequirement_edgeDeploymentServiceAccount}}: {
             "name": "Edge Deployment service account"
           },
           {{$serviceRequirement_edgeClusterRepositories}}: {

--- a/templates/edo/dumps.yaml
+++ b/templates/edo/dumps.yaml
@@ -84,6 +84,16 @@ data:
     {
       "service": {{$service_authorisation}},
       "version": 1,
+      "principals": [
+        {
+          "uuid": {{$serviceAccount_edo}},
+          "kerberos": "sv1edo@{{ .Values.identity.realm }}"
+        },
+        {
+          "uuid": {{$serviceAccount_git}},
+          "kerberos": "sv1git@{{ .Values.identity.realm }}"
+        },
+      ]
       "aces": [
         {
           "principal": {{$serviceRequirement_edgeDeploymentServiceAccount}},

--- a/templates/edo/dumps.yaml
+++ b/templates/edo/dumps.yaml
@@ -64,8 +64,6 @@ metadata:
   name: auth-json-dumps
   namespace: {{ .Release.Namespace }}
   annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "20"
     "helm.sh/resource-policy": keep
   labels:
     component: auth
@@ -176,8 +174,6 @@ metadata:
   labels:
     component: configdb
   annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "20"
     "helm.sh/resource-policy": keep
 data:
   # Pre-seed required

--- a/templates/edo/dumps.yaml
+++ b/templates/edo/dumps.yaml
@@ -9,12 +9,15 @@
 {{$wildcard := "00000000-0000-0000-0000-000000000000" | quote}}
 
 {{$classDef_edgeCluster := "f24d354d-abc1-4e32-98e1-0667b3e40b61" | quote}}
+{{$classDef_edgeClusterAccount := "97756c9a-38e6-4238-b78c-3df6f227a6c9" | quote}}
 {{$classDef_edgeClusterTemplate := "f9be0334-0ff7-43d3-9d8a-188d3e4d472b" | quote}}
 {{$classDef_application := "d319bd87-f42b-4b66-be4f-f82ff48b93f0" | quote}}
 {{$classDef_serviceFunction := "265d481f-87a7-4f93-8fc6-53fa64dc11bb" | quote}}
+{{$classDef_clientRole := "1c567e3c-5519-4418-8682-6086f22fbc13" | quote}}
 {{$classDef_permissionGroup := "ac0d5288-6136-4ced-a372-325fbbcdd70d" | quote}}
 {{$classDef_permission := "8ae784bb-c4b5-4995-9bf6-799b3c7f21ad" | quote}}
 {{$classDef_serviceRequirement := "b419cbc2-ab0f-4311-bd9e-f0591f7e88cb" | quote}}
+{{$classDef_gitRepoGroup := "b03d4dfe-7e78-4252-8e62-af594cf316c9" | quote}}
 
 {{$application_gitRepoConfiguration := "38d62a93-b6b4-4f63-bad4-d433e3eaff29" | quote}}
 {{$application_edgeClusterConfiguration := "bdb13634-0b3d-4e38-a065-9d88c12ee78d" | quote}}
@@ -27,11 +30,10 @@
 {{$service_edo := "2706aa43-a826-441e-9cec-cd3d4ce623c2" | quote}}
 
 {{$serviceRequirement_edgeDeploymentServiceAccount := "26d192cf-73c1-4c14-93cf-1e63743bab08" | quote}}
-
-{{$serviceRequirement_edgeFluxAccount := "4eeb8156-856d-4251-a4a4-4c1b2f3d3e2c" | quote}}
+{{$serviceRequirement_gitServiceAccount := "a461ef62-0560-4be2-8d97-1a56916ce4f8" | quote}}
+{{$serviceRequirement_edgeFluxAccounts := "4eeb8156-856d-4251-a4a4-4c1b2f3d3e2c" | quote}}
 {{$serviceRequirement_edgeClusterRepositories := "3a58340c-d4ec-453d-99c3-0cf6ab7d8fa9" | quote}}
 {{$serviceRequirement_edgeFluxRoles := "8cd08563-7c3c-44fd-af4d-15c0fa6dadcb" | quote}}
-{{$serviceRequirement_gitServiceAccount := "a461ef62-0560-4be2-8d97-1a56916ce4f8" | quote}}
 
 {{$permission_directory_advertiseService := "4db4c39a-f18d-4e83-aeb0-5af2c14ddc2b" | quote}}
 
@@ -52,6 +54,15 @@
 {{$permission_edge_manageSecrets := "07fba27a-0d01-4c07-875b-d25345261d3a" | quote}}
 
 {{$permissionGroup_edo_all := "9e07fd33-6400-4662-92c4-4dff1f61f990" | quote}}
+
+{{$serviceAccount_git := "626df296-8156-4c67-8aed-aac70161aa8b" | quote}}
+{{$serviceAccount_edo := "127cde3c-773a-4f61-b0ba-7412a2695253" | quote}}
+
+{{$gitRepoGroup_remoteClusters := "736697bd-3637-4340-8d8a-f4a457d6f483" | quote}}
+{{$gitRepoGroup_sharedRepositories := "9c16e08a-a659-4f02-877f-2949dc4ec7b9" | quote}}
+
+{{$clientRole_edgeFlux := "34ee0e7f-8c9c-4f6d-aad7-4ed700bc77da" | quote}}
+
 
 
 # Auth EDO Dumps
@@ -117,7 +128,7 @@ data:
         {
           "principal": {{$serviceRequirement_edgeDeploymentServiceAccount}},
           "permission": {{$permission_configStore_manageObjects}},
-          "target": {{$serviceRequirement_edgeFluxAccount}}
+          "target": {{$serviceRequirement_edgeFluxAccounts}}
         },
         {
           "principal": {{$serviceRequirement_edgeDeploymentServiceAccount}},
@@ -148,13 +159,34 @@ data:
           "principal": {{$serviceRequirement_edgeDeploymentServiceAccount}},
           "permission": {{$permission_git_pushToRepo}},
           "target": {{$serviceRequirement_edgeClusterRepositories}}
-        }
+        },
+        {
+          "principal": {{$clientRole_edgeFlux}},
+          "permission": {{$permission_git_pullFromRepo}},
+          "target": {{$gitRepoGroup_sharedRepositories}}
+        },
       ],
       "groups": {
           {{$permissionGroup_edo_all}}: [
             {{$permission_edge_manageClusters}},
             {{$permission_edge_manageSecrets}}
-          ]
+          ],
+
+          {{$serviceRequirement_gitServiceAccount}}: [
+            {{$serviceAccount_git}}
+          ],
+          {{$serviceRequirement_edgeDeploymentServiceAccount}}: [
+            {{$serviceAccount_edo}}
+          ],
+          {{$serviceRequirement_edgeClusterRepositories}}: [
+            {{$gitRepoGroup_remoteClusters}}
+          ],
+          {{$serviceRequirement_edgeFluxAccounts}}: [
+            {{$classDef_edgeClusterAccount}}
+          ],
+          {{$serviceRequirement_edgeFluxRoles}}: [
+            {{$clientRole_edgeFlux}}
+          ],
       }
     }
 
@@ -187,6 +219,7 @@ data:
       ],
       "objects": {
         {{$classDef_application}}: [
+          {{$application_gitRepoConfiguration}},
           {{$application_edgeClusterConfiguration}},
           {{$application_edgeClusterTemplate}}
         ],
@@ -203,8 +236,15 @@ data:
         {{$classDef_serviceRequirement}}: [
           {{$serviceRequirement_edgeDeploymentServiceAccount}},
           {{$serviceRequirement_edgeClusterRepositories}},
-          {{$serviceRequirement_edgeFluxAccount}},
+          {{$serviceRequirement_edgeFluxAccounts}},
           {{$serviceRequirement_edgeFluxRoles}}
+        ],
+        {{$classDef_gitRepoGroup}}: [
+          {{$gitRepoGroup_remoteClusters}}
+          {{$gitRepoGroup_sharedRepositories}}
+        ],
+        {{$classDef_clientRole}}: [
+          {{$clientRole_edgeFlux}}
         ]
       },
       "configs": {
@@ -239,11 +279,29 @@ data:
           {{$serviceRequirement_edgeClusterRepositories}}: {
             "name": "Edge cluster repositories"
           },
-          {{$serviceRequirement_edgeFluxAccount}}: {
+          {{$serviceRequirement_edgeFluxAccounts}}: {
             "name": "Edge flux accounts"
           },
           {{$serviceRequirement_edgeFluxRoles}}: {
             "name": "Edge flux roles"
+          },
+          {{$classDef_gitRepoGroup}}: {
+            "name": "Git repository group"
+          },
+          {{$application_gitRepoConfiguration}}: {
+            "name": "Git repository configuration"
+          },
+          {{$gitRepoGroup_sharedRepositories}}: {
+            "name": "Shared repositories"
+          },
+          {{$gitRepoGroup_remoteClusters}}: {
+            "name": "Remote clusters"
+          },
+          {{$classDef_edgeClusterAccount}}: {
+            "name": "Edge cluster account"
+          },
+          {{$clientRole_edgeFlux}}: {
+            "name": "Role: Edge Flux"
           }
         },
         {{$application_applicationConfigSchema}}: {

--- a/templates/edo/dumps.yaml
+++ b/templates/edo/dumps.yaml
@@ -64,6 +64,7 @@
 {{$clientRole_edgeFlux := "34ee0e7f-8c9c-4f6d-aad7-4ed700bc77da" | quote}}
 
 {{$gitRepoConfiguration_sharedFluxSystem := "8a3c0860-9e41-48b8-b02f-780a0e582be6" | quote}}
+{{$edgeClusterTemplate_cellGateway := "71648ac2-f2a6-4777-92ac-f7852be68efc" | quote}}
 
 
 
@@ -315,9 +316,12 @@ data:
           {{$clientRole_edgeFlux}}: {
             "name": "Role: Edge Flux"
           },
-            {{$gitRepoConfiguration_sharedFluxSystem}}: {
-                "name": "Git repo shared/flux-system"
-            }
+          {{$gitRepoConfiguration_sharedFluxSystem}}: {
+              "name": "Git repo shared/flux-system"
+          },
+          {{$edgeClusterTemplate_cellGateway}}: {
+              "name": "Cell gateway"
+          }
         },
         {{$application_applicationConfigSchema}}: {
           {{$application_edgeClusterConfiguration}}: {
@@ -460,6 +464,33 @@ data:
             "path": "shared/flux-system"
           }
         },
+        {{$application_edgeClusterTemplate}}: {
+          {{$edgeClusterTemplate_cellGateway}}: {
+            "flux": {
+                "name": "Edge flux: %n",
+                "class": "97756c9a-38e6-4238-b78c-3df6f227a6c9",
+                "groups": [
+                    "34ee0e7f-8c9c-4f6d-aad7-4ed700bc77da"
+                ],
+                "username": "op1flux/%n"
+            },
+            "name": "cell-gateway",
+            "cluster": {
+                "namespace": "fplus-edge"
+            },
+            "repository": {
+                "group": "cluster",
+                "links": {
+                    "8a3c0860-9e41-48b8-b02f-780a0e582be6": {
+                        "branch": "main",
+                        "interval": "3h0m0s"
+                    }
+                },
+                "branch": "main",
+                "interval": "5m0s"
+            }
+        }
+        }
       }
     }
 

--- a/templates/edo/dumps.yaml
+++ b/templates/edo/dumps.yaml
@@ -63,6 +63,8 @@
 
 {{$clientRole_edgeFlux := "34ee0e7f-8c9c-4f6d-aad7-4ed700bc77da" | quote}}
 
+{{$gitRepoConfiguration_sharedFluxSystem := "8a3c0860-9e41-48b8-b02f-780a0e582be6" | quote}}
+
 
 
 # Auth EDO Dumps
@@ -312,7 +314,10 @@ data:
           },
           {{$clientRole_edgeFlux}}: {
             "name": "Role: Edge Flux"
-          }
+          },
+            {{$gitRepoConfiguration_sharedFluxSystem}}: {
+                "name": "Git repo shared/flux-system"
+            }
         },
         {{$application_applicationConfigSchema}}: {
           {{$application_edgeClusterConfiguration}}: {
@@ -443,7 +448,18 @@ data:
               }
             }
           }
-        }
+        },
+        {{$application_gitRepoConfiguration}}: {
+          {{$gitRepoGroup_remoteClusters}}: {
+              "path": "cluster"
+          },
+          {{$gitRepoGroup_sharedRepositories}}: {
+              "path": "shared"
+          },
+          {{$gitRepoConfiguration_sharedFluxSystem}}: {
+            "path": "shared/flux-system"
+          }
+        },
       }
     }
 

--- a/templates/edo/edge.yaml
+++ b/templates/edo/edge.yaml
@@ -2,20 +2,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: edge
+  name: edge-deployment-operator
   namespace: {{ .Release.Namespace }}
   labels:
-    component: edge
+    component: edge-deployment-operator
 spec:
   replicas: 1
   selector:
     matchLabels:
-      component: edge
+      component: edge-deployment-operator
   template:
     metadata:
       labels:
-        component: edge
-        factory-plus.service: edge
+        component: edge-deployment-operator
+        factory-plus.service: edge-deployment-operator
     spec:
       serviceAccountName: edge-deployment-operator
       volumes:
@@ -24,14 +24,14 @@ spec:
             name: krb5-conf
         - name: keytabs
           secret:
-            secretName: edge-keytabs
+            secretName: edo-keytabs
         - name: data
           emptyDir:
         - name: kubeseal-certs
           emptyDir:
 
       containers:
-        - name: edge
+        - name: edge-deployment-operator
 {{ include "amrc-connectivity-stack.image" .Values.edo | indent 10 }}
           command: [ "/usr/bin/k5start", "-Uf", "/keytabs/client" ]
           args: ["npm", "run", "start"]
@@ -39,23 +39,23 @@ spec:
             - name: PORT
               value: "8080"
             - name: VERBOSE
-              value: {{.Values.edo.verbosity | quote | required "values.edge.verbosity is required!"}}
+              value: {{.Values.edo.verbosity | quote | required "values.edo.verbosity is required!"}}
             - name: KRB5_CONFIG
               value: /config/krb5-conf/krb5.conf
             - name: SERVER_KEYTAB
               value: /keytabs/server
             - name: HOSTNAME
-              value: edge.{{ .Release.Namespace }}.svc.cluster.local
+              value: edo.{{ .Release.Namespace }}.svc.cluster.local
             - name: REALM
               value: {{ .Values.identity.realm | required "values.identity.realm is required!" }}
             - name: GIT_CHECKOUTS_DIR
               value: /data
             - name: GIT_EMAIL
-              value: sv1edge@{{.Values.acs.baseUrl | required "values.acs.baseUrl is required"}}
+              value: sv1edo@{{.Values.acs.baseUrl | required "values.acs.baseUrl is required"}}
             - name: KUBESEAL_TEMP
               value: /cert
             - name: HTTP_API_URL
-              value: http://edge.{{ .Release.Namespace }}.svc.cluster.local
+              value: http://edo.{{ .Release.Namespace }}.svc.cluster.local
             - name: DIRECTORY_URL
               value: http://directory.{{ .Release.Namespace }}.svc.cluster.local
           volumeMounts:
@@ -71,7 +71,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: edge
+  name: edge-deployment-operator
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
@@ -79,5 +79,5 @@ spec:
       port: 80
       targetPort: 8080
   selector:
-    factory-plus.service: edge
+    factory-plus.service: edge-deployment-operator
 {{- end -}}

--- a/values.yaml
+++ b/values.yaml
@@ -116,6 +116,7 @@ manager:
     repository: acs-edge
     # -- The tag of the Edge Agent component
     tag: v1.0.5
+
   meilisearch:
     # -- The key that the manager uses to connect to the Meilisearch search engine
     key: masterKey
@@ -175,6 +176,7 @@ git:
 edo:
   # -- Whether or not to enable the Edge Deployment Operator (EDO) component
   enabled: true
+  verbosity: "1"
   image:
     # -- The registry of the EDO component
     registry: ghcr.io/amrc-factoryplus


### PR DESCRIPTION
Adjusted the EDO to use more specific names and modified the service account names to reflect a clearer role. Added verbosity value for EDO, change to integrate with the logging level. Fixed the 'edge-keytabs' to be 'edo-keytabs' as required. Added 'edo/dumps.yaml', a script for dumping pre-seed required aces, groups, principals and ConfigDB resources. Also changed the principal names to be more identifiable. These modifications make the EDO easier to identify and configure, and meet the appropriate security requirements.