### PR TITLE
Bootstrap the shared git repos

### DIFF
--- a/templates/configdb/configdb.yaml
+++ b/templates/configdb/configdb.yaml
@@ -86,6 +86,8 @@ spec:
               value: sv1configdb
             - name: PGDATABASE
               value: configdb
+            - name: VERBOSE
+              value: ALL
           volumeMounts:
             - mountPath: /config/krb5-conf
               name: krb5-conf

--- a/templates/dumps.yaml
+++ b/templates/dumps.yaml
@@ -593,7 +593,8 @@ data:
           "3668660f-f949-4657-be76-21967144c1a2",
           "55870092-91b6-4d5e-828f-7637d080bf1c",
           "12ecb694-b4b9-4d2a-927e-d100019f7ebe",
-          "b2d8d437-5060-4202-bcc2-bd2beda09651"
+          "b2d8d437-5060-4202-bcc2-bd2beda09651",
+          "7fd8a8c1-6050-4950-97bd-a35bb83ff750"
         ],
         "b419cbc2-ab0f-4311-bd9e-f0591f7e88cb": [
           "a461ef62-0560-4be2-8d97-1a56916ce4f8"
@@ -627,6 +628,9 @@ data:
           },
           "b2d8d437-5060-4202-bcc2-bd2beda09651": {
             "name": "Git: push to repo"
+          },
+          "7fd8a8c1-6050-4950-97bd-a35bb83ff750": {
+            "name": "Git: manage repo storage"
           },
           "a461ef62-0560-4be2-8d97-1a56916ce4f8": {
             "name": "Git hosting service account"
@@ -1248,7 +1252,8 @@ data:
           "3668660f-f949-4657-be76-21967144c1a2",
           "55870092-91b6-4d5e-828f-7637d080bf1c",
           "12ecb694-b4b9-4d2a-927e-d100019f7ebe",
-          "b2d8d437-5060-4202-bcc2-bd2beda09651"
+          "b2d8d437-5060-4202-bcc2-bd2beda09651",
+          "7fd8a8c1-6050-4950-97bd-a35bb83ff750"
         ]
       }
     }

--- a/templates/dumps.yaml
+++ b/templates/dumps.yaml
@@ -18,6 +18,7 @@
 {{$classDef_softGateway := "5bee4d24-32e1-44f8-b953-1f86ff4b3e87" | quote}}
 {{$classDef_serviceRequirement := "b419cbc2-ab0f-4311-bd9e-f0591f7e88cb" | quote}}
 {{$classDef_gitRepoGroup := "b03d4dfe-7e78-4252-8e62-af594cf316c9" | quote}}
+{{$classDef_gitRepo := "d25f2afc-1ab8-4d27-b51b-d02314624e3e" | quote}}
 {{$classDef_edgeClusterAccount := "97756c9a-38e6-4238-b78c-3df6f227a6c9" | quote}}
 {{$classDef_edgeClusterTemplate := "f9be0334-0ff7-43d3-9d8a-188d3e4d472b" | quote}}
 
@@ -108,6 +109,7 @@
 
 {{$gitRepoGroup_remoteClusters := "736697bd-3637-4340-8d8a-f4a457d6f483" | quote}}
 {{$gitRepoGroup_sharedRepositories := "9c16e08a-a659-4f02-877f-2949dc4ec7b9" | quote}}
+{{$gitRepo_sharedFluxSystem := "8a3c0860-9e41-48b8-b02f-780a0e582be6" | quote}}
 
 {{$edgeClusterTemplate_cellGateway := "71648ac2-f2a6-4777-92ac-f7852be68efc" | quote}}
 
@@ -891,6 +893,7 @@ data:
         {{$classDef_edgeClusterAccount}},
         {{$classDef_edgeClusterTemplate}},
         {{$classDef_gitRepoGroup}},
+        {{$classDef_gitRepo}},
         {{$classDef_clientRole}}
       ],
       "objects": {
@@ -903,6 +906,9 @@ data:
         {{$classDef_gitRepoGroup}}: [
           {{$gitRepoGroup_remoteClusters}},
           {{$gitRepoGroup_sharedRepositories}}
+        ],
+        {{$classDef_gitRepo}}: [
+          {{$gitRepo_sharedFluxSystem}}
         ],
         {{$classDef_clientRole}}: [
           {{$role_edgeFlux}}
@@ -922,6 +928,9 @@ data:
           {{$gitRepoGroup_remoteClusters}}: {
             "name": "Remote clusters"
           },
+          {{$gitRepo_sharedFluxSystem}}: {
+            "name": "Shared git repo: flux system"
+          },
           {{$classDef_edgeClusterAccount}}: {
             "name": "Edge cluster account"
           },
@@ -938,6 +947,9 @@ data:
           },
           {{$gitRepoGroup_sharedRepositories}}: {
               "path": "shared"
+          },
+          {{$gitRepo_sharedFluxSystem}}: {
+            "path": "shared/flux-system"
           }
         },
         {{$application_edgeClusterTemplate}}: {
@@ -957,7 +969,7 @@ data:
             "repository": {
                 "group": "cluster",
                 "links": {
-                    "8a3c0860-9e41-48b8-b02f-780a0e582be6": {
+                    {{$gitRepo_sharedFluxSystem}}: {
                         "branch": "main",
                         "interval": "3h0m0s"
                     }

--- a/templates/dumps.yaml
+++ b/templates/dumps.yaml
@@ -898,7 +898,8 @@ data:
       ],
       "objects": {
         {{$classDef_application}}: [
-          {{$application_edgeClusterTemplate}}
+          {{$application_edgeClusterTemplate}},
+          {{$application_gitRepoConfiguration}}
         ],
         {{$classDef_serviceAccount}}: [
           {{$serviceAccount_edo}}

--- a/templates/service-setup.yaml
+++ b/templates/service-setup.yaml
@@ -1,0 +1,39 @@
+# This manifest runs a Job whenever the Helm chart is installed or
+# upgraded. This Job pulls in an image with configuration to load into
+# the F+ services which is specific to deployment decisions made by ACS.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: service-setup
+  annotations:
+    helm.sh/hook: post-install, post-upgrade
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    spec:
+      restartPolicy: OnFailure
+      volumes:
+        - name: git-checkouts
+          emptyDir:
+      containers:
+        - name: service-setup
+{{ include "amrc-connectivity-stack.image" .Values.serviceSetup | indent 10 }}
+          env:
+            - name: DIRECTORY_URL
+              value: http://directory.{{ .Release.Namespace }}.svc.cluster.local
+            - name: SERVICE_USERNAME
+              value: admin
+            - name: SERVICE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: krb5-passwords
+                  key: admin
+            - name: VERBOSE
+              value: ALL
+            - name: GIT_CHECKOUTS
+              value: /data
+          volumeMounts:
+            - mountPath: /data
+              name: git-checkouts
+            

--- a/values.yaml
+++ b/values.yaml
@@ -177,7 +177,7 @@ git:
     # -- The repository of the Git component
     repository: acs-git
     # -- The tag of the Git component
-    tag: v0.0.1
+    tag: v0.0.2
     # @ignore
     pullPolicy: IfNotPresent
   # -- Possible values are either 1 to enable all possible debugging, or a comma-separated list of debug tags (the tags printed before the log lines). No logging is specified as an empty string.

--- a/values.yaml
+++ b/values.yaml
@@ -84,6 +84,16 @@ configdb:
     # @ignore
     pullPolicy: IfNotPresent
 
+# -- The service-setup component loads ACS-specific configuration into
+# the ACS services when the Helm chart is deployed or upgraded.
+serviceSetup:
+  enabled: true
+  image:
+    registry: ghcr.io/amrc-factoryplus
+    repository: acs-service-setup
+    tag: v0.0.1
+    pullPolicy: IfNotPresent
+
 mqtt:
   # -- Whether or not to enable the MQTT component
   enabled: true


### PR DESCRIPTION
Create a Helm post-install and post-upgrade Job which pulls in the acs-service-setup image to configure the services for ACS. Currently this means pre-populating the `shared/flux-system` git repo.

Precreate the shared git repo in the ConfigDB. Update the git server version to a version which creates repos based on ConfigDB entries.