### PR TITLE
Enable conditional Traefik middleware configuration

### DIFF
--- a/templates/auth/middleware/basic-auth-middleware.yaml
+++ b/templates/auth/middleware/basic-auth-middleware.yaml
@@ -1,4 +1,4 @@
-# Forward authentication to example.com
+{{- if .Values.traefik.enabled }}
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
@@ -9,3 +9,4 @@ spec:
     address: {{ .Values.acs.secure | ternary "https" "http" }}://auth.{{.Values.acs.baseUrl}}/authn/authenticate
     authResponseHeaders:
       - X-Auth-Principal
+{{- end }}


### PR DESCRIPTION
Updated the basic-auth-middleware.yaml file to enable conditional configuration of the Traefik middleware. This change helps to ensure the middleware is set up only when .Values.traefik is enabled, preventing a `resource mapping not found` error.