### PR TITLE
Update logLevel in influxDB ingester to a configurable value

### DIFF
--- a/templates/warehouse/influxdb-ingester.yaml
+++ b/templates/warehouse/influxdb-ingester.yaml
@@ -40,7 +40,7 @@ spec:
             - name: CLIENT_KEYTAB
               value: /keytabs/client
             - name: LOG_LEVEL
-              value: info
+              value: {{ .Values.warehouse.ingester.logLevel | required "values.warehouse.ingester.logLevel" }}
             - name: DIRECTORY_URL
               value: http://directory.{{ .Release.Namespace }}.svc.cluster.local
             - name: INFLUX_URL

--- a/values.yaml
+++ b/values.yaml
@@ -147,6 +147,7 @@ warehouse:
   # -- Whether or not to enable the Warehouse component
   ingester:
     enabled: true
+    logLevel: info
     image:
       # -- The registry of the Warehouse component
       registry: ghcr.io/amrc-factoryplus


### PR DESCRIPTION
The value for the `LOG_LEVEL` in the `influxdb-ingester` configuration was hardcoded to `info`. This change replaces it with a value from `Values.warehouse.ingester.logLevel` making it configurable. With this change, we can easily modify the `LOG_LEVEL` without altering the codebase, just by changing a value in the environment configuration.