### PR TITLE
Allow manual setup of the Kerberos KDB.

### DIFF
--- a/templates/identity/kdc.yaml
+++ b/templates/identity/kdc.yaml
@@ -64,7 +64,11 @@ spec:
         - name: kdb-init
           image: "{{ .Values.identity.identity.image.registry }}/{{ .Values.identity.identity.image.repository }}:{{ .Values.identity.identity.image.tag }}"
           command: ["/bin/sh"]
+          {{- if .Values.identity.identity.manualInit }}
+          args: [ "-c", "while test ! -f /tmp/KDB-INIT-COMPLETE; do sleep 5; done" ]
+          {{- else }}
           args: [ "/usr/sbin/init-kdb.sh" ]
+          {{- end }}
           #args: ["-c", "while true; do sleep 10; done"]
           env:
             - name: KRB5_CONFIG

--- a/values.yaml
+++ b/values.yaml
@@ -31,6 +31,12 @@ identity:
       tag: v1.0.0
       # @ignore
       pullPolicy: IfNotPresent
+    # If this is set to true, the kdb-init container will not set up the
+    # KDB but will sit and wait. This can be used to halt startup of the
+    # KDC until a restore from backup can be performed. Be aware that
+    # this will halt startup of the KDC every time the pod starts until
+    # the setting is changed.
+    manualInit: false
   krbKeysOperator:
     # -- A comma-separated list of namespaces that the KerberosKey Operator should watch for KerberosKey resources in. Defaults to the release namespace if not specified
     namespaces: ""


### PR DESCRIPTION
Add a values.yaml setting to make the kdb-init container sit and wait instead of proceeding with KDB setup. This allows an administrator to perform a manual restore from backup before the KDC starts up.