### PR TITLE
Update Switchboard chart and regenerate lock file

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -23,5 +23,5 @@ dependencies:
 - name: charts/switchboard
   repository: oci://ghcr.io/borchero
   version: 0.5.8
-digest: sha256:11312b538986616bdaffcc975898662c5138c4520b0b00e1ec5637bc8fa02936
-generated: "2023-08-22T10:56:16.835151+01:00"
+digest: sha256:02f3e792630e7a16439e7f3dbd82213d142cddc0f6bc68501239576d0c6173a8
+generated: "2023-08-22T11:12:35.868747+01:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -47,6 +47,7 @@ dependencies:
     repository: https://helm.influxdata.com/
     condition: influxdb2.enabled
   - name: charts/switchboard
+    alias: switchboard
     version: 0.5.8
     repository: oci://ghcr.io/borchero
     condition: switchboard.enabled


### PR DESCRIPTION
This commit introduces an alias for the Switchboard chart within the Chart.yaml file. Additionally, an updated digest and timestamp in the Chart.lock file indicate that it has been regenerated, presumably as a part of this change. This brings more clarity and organization to the helm charts.