### PR TITLE
Update repository paths for switchboard in Chart.lock and Chart.yaml

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -20,8 +20,8 @@ dependencies:
 - name: influxdb2
   repository: https://helm.influxdata.com/
   version: 2.1.1
-- name: charts/switchboard
-  repository: oci://ghcr.io/borchero
+- name: switchboard
+  repository: oci://ghcr.io/borchero/charts
   version: 0.5.8
-digest: sha256:02f3e792630e7a16439e7f3dbd82213d142cddc0f6bc68501239576d0c6173a8
-generated: "2023-08-22T11:12:35.868747+01:00"
+digest: sha256:d40aecd8dc00ecadaa8188718d7f5ddc0d9cd7b811761688cd6a5743c71602a4
+generated: "2023-08-22T11:25:06.863286+01:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -46,8 +46,7 @@ dependencies:
     version: 2.1.1
     repository: https://helm.influxdata.com/
     condition: influxdb2.enabled
-  - name: charts/switchboard
-    alias: switchboard
+  - name: switchboard
     version: 0.5.8
-    repository: oci://ghcr.io/borchero
+    repository: oci://ghcr.io/borchero/charts
     condition: switchboard.enabled


### PR DESCRIPTION
The repository paths for 'switchboard' in Chart.lock and Chart.yaml files have been updated. The change resulted in the removal of 'charts/' from all repository URLs and in updates to the 'digest' and 'generated' fields in Chart.lock. It seems the previous path was directing to an incorrect or non-existent location, and hence the paths were corrected to point to the right locations.