### PR TITLE
Update deployment strategy in Grafana configuration

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -250,6 +250,8 @@ promtail:
 
 # @ignore
 grafana:
+  deploymentStrategy:
+    type: Recreate
   image:
     tag: 10.0.1
   enabled: true


### PR DESCRIPTION
Applied 'Recreate' deployment strategy type to the Grafana configuration in `values.yaml`. This update ensures that any change in the configuration would trigger a fresh deployment, replacing the previous version completely.