### PR TITLE
Update the Manager to v1.0.7

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -112,7 +112,7 @@ manager:
     # -- The repository of the Manager component
     repository: acs-manager
     # -- The tag of the Manager component
-    tag: v1.0.6
+    tag: v1.0.7
     # @ignore
     pullPolicy: IfNotPresent
   edge:


### PR DESCRIPTION
v1.0.7 of the Manager includes a fix to config generation that ensures that edge agents have all they need to properly create the `is_transient` state.