### PR TITLE
Redis recreate strategy

### DIFF
--- a/templates/manager/redis.yaml
+++ b/templates/manager/redis.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       component: manager-redis


### PR DESCRIPTION
Set redis to recreate to prevent Longhorn from trying to mount the volume to two pods.