### PR TITLE
Updates to support the new HiveMQ plugin

### DIFF
--- a/templates/auth/principals/service-clients.yaml
+++ b/templates/auth/principals/service-clients.yaml
@@ -64,7 +64,7 @@ metadata:
   name: sv1mqtt
   namespace: {{ .Release.Namespace }}
 spec:
-  type: Password
+  type: Random
   principal: sv1mqtt@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
 {{- end }}
 ---

--- a/templates/mqtt/mqtt.yaml
+++ b/templates/mqtt/mqtt.yaml
@@ -28,47 +28,53 @@ spec:
             items:
               - path: server
                 key: mqtt.mqtt
+              - path: client
+                key: sv1mqtt
+        - name: krb5-ccache
+          emptyDir:
         - name: mqtt-conf
           configMap:
             name: mqtt-config
-      initContainers:
-        - name: register-with-directory
-          image: appropriate/curl:latest
-          env:
-            - name: PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: krb5-passwords
-                  key: sv1mqtt
-          command: [ 'sh', '-c', 'until curl -X PUT -o /dev/null -w "%{http_code}" -u "sv1mqtt:${PASSWORD}" -H "Content-Type: application/json" --data-raw "{ \"url\": \"mqtt://mqtt.{{.Release.Namespace}}.svc.cluster.local\" }" http://directory.{{.Release.Namespace}}.svc.cluster.local/v1/service/feb27ba3-bd2c-4916-9269-79a61ebc4a47/advertisment | grep -E "2[0-9]{2}" > /dev/null; do sleep 10; done' ]
       containers:
-        - name: hivemq
-{{ include "amrc-connectivity-stack.image" .Values.mqtt | indent 10 }}
-          env:
-            - name: SERVER_KEYTAB
-              value: /keytabs/server
-            # This needs to name a principal available in the keytab, used for verifying passwords.
-            - name: SERVER_PRINCIPAL
-              value: mqtt/mqtt.{{ .Release.Namespace }}.svc.cluster.local
-            # These should be discovered, but aren't yet in the Java client.
-            - name: AUTHN_URL
-              value: http://auth.{{ .Release.Namespace }}.svc.cluster.local
-            - name: CONFIGDB_URL
-              value: http://configdb.{{ .Release.Namespace }}.svc.cluster.local
-            # The Java client still only supports Basic auth.
-            - name: SERVICE_USERNAME
-              value: sv1mqtt
-            - name: SERVICE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: krb5-passwords
-                  key: sv1mqtt
+        - name: k5start
+{{ include "amrc-connectivity-stack.image" .Values.shell | indent 10 }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              chown 10000:10000 /ccache
+              k5start -Uf /keytabs/client -k /ccache/mqtt -K5 -o10000 -v
+          securityContext:
+            runAsUser: 0
           volumeMounts:
             - mountPath: /etc/krb5.conf
               name: krb5-conf
               subPath: krb5.conf
             - mountPath: /keytabs
               name: krb5-keytabs
+            - mountPath: /ccache
+              name: krb5-ccache
+        - name: hivemq
+{{ include "amrc-connectivity-stack.image" .Values.mqtt | indent 10 }}
+          env:
+            - name: KRB5CCNAME
+              value: "FILE:/ccache/mqtt"
+            - name: SERVER_KEYTAB
+              value: /keytabs/server
+            # This needs to name a principal available in the keytab, used for verifying passwords.
+            - name: SERVER_PRINCIPAL
+              value: mqtt/mqtt.{{ .Release.Namespace }}.svc.cluster.local
+            - name: DIRECTORY_URL
+              value: http://directory.{{ .Release.Namespace }}.svc.cluster.local
+            - name: MQTT_URL
+              value: "{{ .Values.acs.secure | ternary "mqtts://" "mqtt://" }}mqtt.{{.Values.acs.baseUrl | required "values.acs.baseUrl is required"}}"
+          volumeMounts:
+            - mountPath: /etc/krb5.conf
+              name: krb5-conf
+              subPath: krb5.conf
+            - mountPath: /keytabs
+              name: krb5-keytabs
+            - mountPath: /ccache
+              name: krb5-ccache
             - mountPath: /opt/hivemq/conf/config.xml
               name: mqtt-conf
               subPath: config.xml

--- a/values.yaml
+++ b/values.yaml
@@ -99,7 +99,7 @@ mqtt:
     # -- The repository of the MQTT component
     repository: acs-mqtt
     # -- The tag of the MQTT component
-    tag: v1.0.1
+    tag: v1.1.0
     # @ignore
     pullPolicy: IfNotPresent
 
@@ -168,6 +168,13 @@ warehouse:
       tag: v1.2.0
       # @ignore
       pullPolicy: IfNotPresent
+
+shell:
+  image:
+    registry: ghcr.io/amrc-factoryplus
+    repository: acs-krb-utils
+    tag: v0.0.1
+    pullPolicy: IfNotPresent
 
 minio:
   # -- Whether or not to enable MinIO


### PR DESCRIPTION
This supports asynchronous authentication requests and makes less use of the thread pool provided to extensions by HiveMQ. This is particularly important with HiveMQ CE, which only puts a single thread in that pool.

Cherry-picked from 2861d61691feae25ee7f05b15f6e405376fce827.