### PR TITLE
Fix the syntax error in dumps.yaml template file

### DIFF
--- a/templates/dumps.yaml
+++ b/templates/dumps.yaml
@@ -753,7 +753,7 @@ data:
           },
           {{$application_edgeClusterStatus}}: {
             "name": "Edge cluster status"
-          },
+          }
         },
         "dbd8a535-52ba-4f6e-b4f8-9b71aefe09d3": {
           "bdb13634-0b3d-4e38-a065-9d88c12ee78d": {
@@ -903,8 +903,8 @@ data:
       "objects": {
         {{$classDef_application}}: [
           {{$application_edgeClusterTemplate}},
-          {{$application_gitRepoConfiguration}}
-          {{$application_edgeClusterStatus}}
+          {{$application_gitRepoConfiguration}},
+          {{$application_edgeClusterStatus}},
           {{$application_edgeDeployment}}
         ],
         {{$classDef_serviceAccount}}: [


### PR DESCRIPTION
The previous version of the file had misplaced commas in the object definitions in "dumps.yaml" template. This commit fixes the syntax by correctly placing commas at the end of each object in the array.