### PR TITLE
Tweaks for better production behaviour

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -43,6 +43,24 @@ image: {{ .image.registry }}/{{ .image.repository }}:{{ .image.tag }}
 imagePullPolicy: {{ .image.pullPolicy }}
 {{- end }}
 
+{{/* Go templates are just awful grrr */}}
+{{/* Get a service-specific or default value */}}
+{{- define "_acs.with-default" }}
+{{- $top := index . 0 }}
+{{- $srv := index . 1 }}
+{{- $key := index . 2 }}
+{{- coalesce (get (get $top.Values $srv) $key) 
+    (get $top.Values.acs $key) }}
+{{- end }}
+
+{{/*
+Specify cache-control max-age for a service.
+*/}}
+{{- define "amrc-connectivity-stack.cache-max-age" }}
+- name: CACHE_MAX_AGE
+  value: {{ include "_acs.with-default" (append . "cacheMaxAge") | quote }}
+{{- end }}
+
 {{/*
 Common labels
 */}}

--- a/templates/auth/auth.yaml
+++ b/templates/auth/auth.yaml
@@ -77,7 +77,7 @@ spec:
         - name: load-dumps
 {{ include "amrc-connectivity-stack.image" .Values.auth | indent 10 }}
           command: [ "/usr/bin/k5start", "-Uf", "/keytabs/client" ]
-          args: [ "npm", "run", "load-dump", "/dumps" ]
+          args: [ "node", "bin/load-dump.js", "/dumps" ]
           env:
             - name: KRB5_CONFIG
               value: /config/krb5-conf/krb5.conf
@@ -100,6 +100,8 @@ spec:
       containers:
         - name: webapi
 {{ include "amrc-connectivity-stack.image" .Values.auth | indent 10 }}
+          command: ["/usr/bin/k5start", "-Uf", "/keytabs/client"]
+          args: ["node", "bin/authn.js"]
           env:
             - name: KRB5_CONFIG
               value: /config/krb5-conf/krb5.conf
@@ -123,8 +125,7 @@ spec:
               value: auth
             - name: VERBOSE
               value: "1"
-            - name: CACHE_MAX_AGE
-              value: "10"
+{{ include "amrc-connectivity-stack.cache-max-age" (list . "auth") | indent 12 }}
             # These are currently only used for the editor. They need to be resolvable by the
             # user's browser, so in-cluster names will not work.
             - name: HTTP_API_URL

--- a/templates/cmdesc/cmdesc.yaml
+++ b/templates/cmdesc/cmdesc.yaml
@@ -34,7 +34,7 @@ spec:
         - name: cmdesc
 {{ include "amrc-connectivity-stack.image" .Values.cmdesc | indent 10 }}
           command: [ "/usr/bin/k5start", "-Uf", "/keytabs/client" ]
-          args: [ "npm", "start" ]
+          args: [ "node", "bin/cmdescd.js" ]
           env:
             - name: KRB5_CONFIG
               value: /config/krb5-conf/krb5.conf
@@ -58,8 +58,7 @@ spec:
               value: http://cmdesc.{{ .Release.Namespace }}.svc.cluster.local
             - name: PORT
               value: "8080"
-            - name: CACHE_MAX_AGE
-              value: "0"
+{{ include "amrc-connectivity-stack.cache-max-age" (list . "cmdesc") | indent 12 }}
             - name: DIRECTORY_URL
               value: http://directory.{{ .Release.Namespace }}.svc.cluster.local
           volumeMounts:

--- a/templates/configdb/configdb.yaml
+++ b/templates/configdb/configdb.yaml
@@ -76,7 +76,7 @@ spec:
         - name: load-dumps
 {{ include "amrc-connectivity-stack.image" .Values.configdb | indent 10 }}
           command: [ "/usr/bin/k5start", "-Uf", "/keytabs/client" ]
-          args: [ "npm", "run", "load-dump", "/dumps" ]
+          args: [ "node", "bin/load-dump.js", "/dumps" ]
           env:
             - name: KRB5_CONFIG
               value: /config/krb5-conf/krb5.conf
@@ -97,6 +97,8 @@ spec:
       containers:
         - name: webapi
 {{ include "amrc-connectivity-stack.image" .Values.configdb | indent 10 }}
+          command: ["/usr/bin/k5start", "-Uf", "/keytabs/client"]
+          args: ["node", "bin/api.js"]
           env:
             - name: KRB5_CONFIG
               value: /config/krb5-conf/krb5.conf
@@ -123,8 +125,7 @@ spec:
               value: configdb
             - name: VERBOSE
               value: "1"
-            - name: CACHE_MAX_AGE
-              value: "10"
+{{ include "amrc-connectivity-stack.cache-max-age" (list . "configdb") | indent 12 }}
             # If this is set it names a principal which overrides all ACLs. This should be turned off in production.
             - name: ROOT_PRINCIPAL
               value: admin@{{ .Values.identity.realm | required "values.identity.realm is required!" }}

--- a/templates/directory/directory-mqtt.yaml
+++ b/templates/directory/directory-mqtt.yaml
@@ -64,7 +64,7 @@ spec:
         - name: mqtt
 {{ include "amrc-connectivity-stack.image" .Values.directory | indent 10 }}
           command: [ "/usr/bin/k5start", "-Uf", "/keytabs/client" ]
-          args: [ "npm", "run", "mqtt" ]
+          args: [ "node", "bin/directory-mqtt" ]
           env:
             - name: KRB5_CONFIG
               value: /config/krb5-conf/krb5.conf

--- a/templates/directory/directory-webapi.yaml
+++ b/templates/directory/directory-webapi.yaml
@@ -68,7 +68,7 @@ spec:
         - name: webapi
 {{ include "amrc-connectivity-stack.image" .Values.directory | indent 10 }}
           command: [ "/usr/bin/k5start", "-Uf", "/keytabs/client" ]
-          args: [ "npm", "run", "webapi" ]
+          args: [ "node", "bin/directory-webapi" ]
           env:
             - name: KRB5_CONFIG
               value: /config/krb5-conf/krb5.conf
@@ -89,8 +89,7 @@ spec:
               value: directory
             - name: VERBOSE
               value: "1"
-            - name: CACHE_MAX_AGE
-              value: "120"
+{{ include "amrc-connectivity-stack.cache-max-age" (list . "directory") | indent 12 }}
             # If this is set it names a principal which overrides all ACLs. This should be turned off in production.
             - name: ROOT_PRINCIPAL
               value: admin@{{ .Values.identity.realm | required "values.identity.realm is required!" }}

--- a/values.yaml
+++ b/values.yaml
@@ -7,6 +7,7 @@ acs:
   secure: true
   # -- The name of the secret holding the wildcard certificate for the above domain.
   tlsSecretName: factoryplus-tls
+  cacheMaxAge: 300
 
 identity:
   # -- Whether or not to enable the Identity component


### PR DESCRIPTION
* The cache expiration time on the service responses is much too short for production. Adjust it to something longer, and configurable.
* Avoid running commands with `npm run`. This fails to pass SIGTERM down to its child which is causing pods to fail to exit properly.

Cherry-picked from 0900f91071e62248d535848c0c46133bf8a6acc2.