### PR TITLE
Deploy the new EDO

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -38,8 +38,12 @@ Create chart name and version as used by the chart label.
 {{/*
 Define the image for a container.
 */}}
+{{- define "amrc-connectivity-stack.image-name" -}}
+{{- .image.registry }}/{{ .image.repository }}:{{ .image.tag }}
+{{- end }}
+
 {{- define "amrc-connectivity-stack.image" -}}
-image: {{ .image.registry }}/{{ .image.repository }}:{{ .image.tag }}
+image: {{ include "amrc-connectivity-stack.image-name" . }}
 imagePullPolicy: {{ .image.pullPolicy }}
 {{- end }}
 

--- a/templates/dumps.yaml
+++ b/templates/dumps.yaml
@@ -675,7 +675,9 @@ data:
         }
       }
     }
-  # This is copied directory from acs-edge-deployment.
+  # This is copied directly from acs-edge-deployment.
+  # DO NOT EDIT HERE, make a PR to edit dumps/edge-deploy-configdb.yaml
+  # in that repo and then pull the result back in.
   edo: |
     {
       "service": "af15f175-78a0-4e05-97c0-2a0bb82b9f3b",
@@ -748,15 +750,6 @@ data:
           },
           "8cd08563-7c3c-44fd-af4d-15c0fa6dadcb": {
             "name": "Edge flux roles"
-          },
-          {{$application_edgeDeployment}}: {
-            "name": "Edge deployment"
-          },
-          {{$application_edgeClusterStatus}}: {
-            "name": "Edge cluster status"
-          },
-          {{$application_edgeClusterConfiguration}}: {
-            "name": "Edge cluster configuration"
           }
         },
         "dbd8a535-52ba-4f6e-b4f8-9b71aefe09d3": {
@@ -951,6 +944,15 @@ data:
           },
           {{$edgeClusterTemplate_cellGateway}}: {
               "name": "Cell gateway"
+          },
+          {{$application_edgeDeployment}}: {
+            "name": "Edge deployment"
+          },
+          {{$application_edgeClusterStatus}}: {
+            "name": "Edge cluster status"
+          },
+          {{$application_edgeClusterConfiguration}}: {
+            "name": "Edge cluster configuration"
           }
         },
         {{$application_gitRepoConfiguration}}: {
@@ -1324,6 +1326,8 @@ data:
       }
     }
   # This is copied directly from acs-edge-deployment.
+  # DO NOT EDIT HERE, make a PR to edit dumps/edge-deploy-auth.yaml
+  # in that repo and then pull the result back in.
   edo: |
     {
       "service": "cab2642a-f7d9-42e5-8845-8f35affe1fd4",

--- a/templates/dumps.yaml
+++ b/templates/dumps.yaml
@@ -1324,6 +1324,21 @@ data:
         },
         {
           "principal": "26d192cf-73c1-4c14-93cf-1e63743bab08",
+          "permission": "4a339562-cd57-408d-9d1a-6529a383ea4b",
+          "target": "72804a19-636b-4836-b62b-7ad1476f2b86"
+        },
+        {
+          "principal": "26d192cf-73c1-4c14-93cf-1e63743bab08",
+          "permission": "4a339562-cd57-408d-9d1a-6529a383ea4b",
+          "target": "729fe070-5e67-4bc7-94b5-afd75cb42b03"
+        },
+        {
+          "principal": "26d192cf-73c1-4c14-93cf-1e63743bab08",
+          "permission": "4a339562-cd57-408d-9d1a-6529a383ea4b",
+          "target": "88436128-09a3-4c9c-b7f4-b0e495137265"
+        },
+        {
+          "principal": "26d192cf-73c1-4c14-93cf-1e63743bab08",
           "permission": "6c799ccb-d2ad-4715-a2a7-3c8728d6c0bf",
           "target": "64a8bfa9-7772-45c4-9d1a-9e6290690957"
         },

--- a/templates/dumps.yaml
+++ b/templates/dumps.yaml
@@ -692,8 +692,9 @@ data:
       ],
       "objects": {
         "d319bd87-f42b-4b66-be4f-f82ff48b93f0": [
+          "5b47881c-b012-4040-945c-eacafca539b2",
           "bdb13634-0b3d-4e38-a065-9d88c12ee78d",
-          "72804a19-636b-4836-b62b-7ad1476f2b86",
+          "f6c67e6f-e48e-4f69-b4bb-bfbddcc2a517",
           "dbd8a535-52ba-4f6e-b4f8-9b71aefe09d3"
         ],
         "265d481f-87a7-4f93-8fc6-53fa64dc11bb": [
@@ -709,14 +710,21 @@ data:
         "b419cbc2-ab0f-4311-bd9e-f0591f7e88cb": [
           "26d192cf-73c1-4c14-93cf-1e63743bab08",
           "3a58340c-d4ec-453d-99c3-0cf6ab7d8fa9",
+          "979f7fd9-bbc7-4810-a774-6082c7394db6",
           "4eeb8156-856d-4251-a4a4-4c1b2f3d3e2c",
           "8cd08563-7c3c-44fd-af4d-15c0fa6dadcb"
         ]
       },
       "configs": {
         "64a8bfa9-7772-45c4-9d1a-9e6290690957": {
+          "5b47881c-b012-4040-945c-eacafca539b2": {
+            "name": "EDO global config"
+          },
           "bdb13634-0b3d-4e38-a065-9d88c12ee78d": {
             "name": "Edge cluster configuration"
+          },
+          "f6c67e6f-e48e-4f69-b4bb-bfbddcc2a517": {
+            "name": "Edge cluster setup status"
           },
           "72804a19-636b-4836-b62b-7ad1476f2b86": {
             "name": "Edge cluster template"
@@ -745,6 +753,9 @@ data:
           "3a58340c-d4ec-453d-99c3-0cf6ab7d8fa9": {
             "name": "Edge cluster repositories"
           },
+          "979f7fd9-bbc7-4810-a774-6082c7394db6": {
+            "name": "EDO-managed groups"
+          },
           "4eeb8156-856d-4251-a4a4-4c1b2f3d3e2c": {
             "name": "Edge flux accounts"
           },
@@ -753,131 +764,64 @@ data:
           }
         },
         "dbd8a535-52ba-4f6e-b4f8-9b71aefe09d3": {
+          "5b47881c-b012-4040-945c-eacafca539b2": {
+            "title": "Edge Deployment Operator global config",
+            "type": "object",
+            "additionalProperties": false,
+            "$defs": {
+              "uuid-and-path": {
+                "type": "object",
+                "required": [
+                  "uuid"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "uuid": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "path": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "properties": {
+              "git": {
+                "type": "object"
+              },
+              "repo": {
+                "description": "Well-known git repository UUIDs",
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/$defs/uuid-and-path"
+                }
+              },
+              "group": {
+                "description": "Auth service groups",
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/$defs/uuid-and-path"
+                }
+              }
+            }
+          },
           "bdb13634-0b3d-4e38-a065-9d88c12ee78d": {
             "title": "Edge cluster configuration",
             "type": "object",
             "required": [
+              "name",
               "namespace"
             ],
+            "additionalProperties": false,
             "properties": {
+              "name": {
+                "description": "A name for the cluster.",
+                "type": "string"
+              },
               "namespace": {
                 "description": "The k8s namespace to deploy to.",
                 "type": "string"
-              },
-              "flux": {
-                "description": "The URL of the Git repo driving this cluster.",
-                "type": "string"
-              },
-              "kubeseal_cert": {
-                "description": "The PEM-encoded X509 certificate used by the sealed-secrets operator on the edge cluster.\n",
-                "type": "string"
-              }
-            }
-          },
-          "72804a19-636b-4836-b62b-7ad1476f2b86": {
-            "title": "Edge cluster template",
-            "description": "A template to drive the creation of an edge cluster. Some values are subject to template expansion; `%n` is expanded to the name of the cluster as supplied to the Edge Deployment Operator.\n",
-            "type": "object",
-            "required": [
-              "name",
-              "cluster",
-              "flux",
-              "repository"
-            ],
-            "properties": {
-              "name": {
-                "description": "The name used to locate this template.",
-                "type": "string"
-              },
-              "cluster": {
-                "description": "Configuration of the k8s cluster.",
-                "type": "object",
-                "required": [
-                  "namespace"
-                ],
-                "properties": {
-                  "namespace": {
-                    "description": "The namespace to deploy to.",
-                    "type": "string"
-                  }
-                }
-              },
-              "flux": {
-                "description": "Configuration of the Flux service account.",
-                "type": "object",
-                "required": [
-                  "class",
-                  "username"
-                ],
-                "properties": {
-                  "class": {
-                    "description": "ConfigDB class to create the account under.",
-                    "type": "string",
-                    "format": "uuid"
-                  },
-                  "username": {
-                    "description": "Template for the Kerberos UPN of the service account.",
-                    "type": "string"
-                  },
-                  "name": {
-                    "description": "General Info name for the service account.",
-                    "type": "string"
-                  },
-                  "groups": {
-                    "description": "Auth groups to add the service account to.",
-                    "type": "array",
-                    "items": {
-                      "type": "string",
-                      "format": "uuid"
-                    }
-                  }
-                }
-              },
-              "repository": {
-                "description": "Configuration of the cluster git repo.",
-                "required": [
-                  "group",
-                  "branch",
-                  "interval"
-                ],
-                "properties": {
-                  "group": {
-                    "description": "The repo group to create the repo in. The repo itself will be named with the name of the cluster.\n",
-                    "type": "string"
-                  },
-                  "branch": {
-                    "description": "The branch name to use.",
-                    "type": "string"
-                  },
-                  "interval": {
-                    "description": "The sync interval. This is in the interval format accepted by Flux.\n",
-                    "type": "string"
-                  },
-                  "links": {
-                    "description": "Other repos to sync from. Appropriate Flux manifests will be committed to the cluster repo to enable this.\n",
-                    "type": "object",
-                    "propertyNames": {
-                      "description": "The UUID of the repo to sync from.",
-                      "type": "string",
-                      "format": "uuid"
-                    },
-                    "additionalProperties": {
-                      "type": "object",
-                      "required": [
-                        "branch",
-                        "interval"
-                      ],
-                      "properties": {
-                        "branch": {
-                          "type": "string"
-                        },
-                        "interval": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  }
-                }
               }
             }
           }
@@ -1350,8 +1294,23 @@ data:
         },
         {
           "principal": "26d192cf-73c1-4c14-93cf-1e63743bab08",
+          "permission": "3a41f5ce-fc08-4669-9762-ec9e71061168",
+          "target": "12ecb694-b4b9-4d2a-927e-d100019f7ebe"
+        },
+        {
+          "principal": "26d192cf-73c1-4c14-93cf-1e63743bab08",
+          "permission": "be9b6d47-c845-49b2-b9d5-d87b83f11c3b",
+          "target": "00000000-0000-0000-0000-000000000000"
+        },
+        {
+          "principal": "26d192cf-73c1-4c14-93cf-1e63743bab08",
           "permission": "4a339562-cd57-408d-9d1a-6529a383ea4b",
-          "target": "38d62a93-b6b4-4f63-bad4-d433e3eaff29"
+          "target": "64a8bfa9-7772-45c4-9d1a-9e6290690957"
+        },
+        {
+          "principal": "26d192cf-73c1-4c14-93cf-1e63743bab08",
+          "permission": "4a339562-cd57-408d-9d1a-6529a383ea4b",
+          "target": "5b47881c-b012-4040-945c-eacafca539b2"
         },
         {
           "principal": "26d192cf-73c1-4c14-93cf-1e63743bab08",
@@ -1361,7 +1320,7 @@ data:
         {
           "principal": "26d192cf-73c1-4c14-93cf-1e63743bab08",
           "permission": "4a339562-cd57-408d-9d1a-6529a383ea4b",
-          "target": "72804a19-636b-4836-b62b-7ad1476f2b86"
+          "target": "f6c67e6f-e48e-4f69-b4bb-bfbddcc2a517"
         },
         {
           "principal": "26d192cf-73c1-4c14-93cf-1e63743bab08",
@@ -1371,32 +1330,17 @@ data:
         {
           "principal": "26d192cf-73c1-4c14-93cf-1e63743bab08",
           "permission": "6c799ccb-d2ad-4715-a2a7-3c8728d6c0bf",
-          "target": "bdb13634-0b3d-4e38-a065-9d88c12ee78d"
+          "target": "f6c67e6f-e48e-4f69-b4bb-bfbddcc2a517"
+        },
+        {
+          "principal": "26d192cf-73c1-4c14-93cf-1e63743bab08",
+          "permission": "6c799ccb-d2ad-4715-a2a7-3c8728d6c0bf",
+          "target": "38d62a93-b6b4-4f63-bad4-d433e3eaff29"
         },
         {
           "principal": "26d192cf-73c1-4c14-93cf-1e63743bab08",
           "permission": "f0b7917b-d475-4888-9d5a-2af96b3c26b6",
-          "target": "4eeb8156-856d-4251-a4a4-4c1b2f3d3e2c"
-        },
-        {
-          "principal": "26d192cf-73c1-4c14-93cf-1e63743bab08",
-          "permission": "f0b7917b-d475-4888-9d5a-2af96b3c26b6",
-          "target": "f24d354d-abc1-4e32-98e1-0667b3e40b61"
-        },
-        {
-          "principal": "26d192cf-73c1-4c14-93cf-1e63743bab08",
-          "permission": "3a41f5ce-fc08-4669-9762-ec9e71061168",
-          "target": "12ecb694-b4b9-4d2a-927e-d100019f7ebe"
-        },
-        {
-          "principal": "26d192cf-73c1-4c14-93cf-1e63743bab08",
-          "permission": "be9b6d47-c845-49b2-b9d5-d87b83f11c3b",
-          "target": "8cd08563-7c3c-44fd-af4d-15c0fa6dadcb"
-        },
-        {
-          "principal": "26d192cf-73c1-4c14-93cf-1e63743bab08",
-          "permission": "3668660f-f949-4657-be76-21967144c1a2",
-          "target": "3a58340c-d4ec-453d-99c3-0cf6ab7d8fa9"
+          "target": "97756c9a-38e6-4238-b78c-3df6f227a6c9"
         },
         {
           "principal": "26d192cf-73c1-4c14-93cf-1e63743bab08",
@@ -1437,6 +1381,11 @@ data:
           "principal": {{$serviceAccount_krbkeys}},
           "permission": {{$permission_edo_manageSecrets}},
           "target": {{$classDef_wildcard}}
+        },
+        {
+          "principal": {{$serviceAccount_edo}},
+          "permission": {{$role_edgeNodeConsumer}},
+          "target": {{$serviceAccount_configStore}}
         }
       ],
       "groups": {

--- a/templates/edo/edge.yaml
+++ b/templates/edo/edge.yaml
@@ -58,6 +58,8 @@ spec:
               value: {{ include "amrc-connectivity-stack.image-name" .Values.identity.krbKeysOperator | quote }}
             - name: HTTP_API_URL
               value: http://edo.{{ .Release.Namespace }}.svc.cluster.local
+            - name: EXTERNAL_URL
+              value: "{{ .Values.acs.secure | ternary "https://" "http://" }}edo.{{.Values.acs.baseUrl | required "values.acs.baseUrl is required"}}"
             - name: DIRECTORY_URL
               value: http://directory.{{ .Release.Namespace }}.svc.cluster.local
           volumeMounts:

--- a/templates/edo/edge.yaml
+++ b/templates/edo/edge.yaml
@@ -54,6 +54,8 @@ spec:
               value: sv1edo@{{.Values.acs.baseUrl | required "values.acs.baseUrl is required"}}
             - name: KUBESEAL_TEMP
               value: /cert
+            - name: KRBKEYS_IMAGE
+              value: {{ include "amrc-connectivity-stack.image-name" .Values.identity.krbKeysOperator | quote }}
             - name: HTTP_API_URL
               value: http://edo.{{ .Release.Namespace }}.svc.cluster.local
             - name: DIRECTORY_URL

--- a/templates/identity/kdc.yaml
+++ b/templates/identity/kdc.yaml
@@ -186,6 +186,9 @@ data:
     admin           x
     op1krbkeys/*    x     */*1
     op1krbkeys/*    x     */*1/*
+    {{- range .Values.identity.kadminUsers }}
+    {{ .principal }} {{ .permission }} {{ .restrictions }}
+    {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/templates/service-setup.yaml
+++ b/templates/service-setup.yaml
@@ -33,6 +33,10 @@ spec:
               value: ALL
             - name: GIT_CHECKOUTS
               value: /data
+            - name: HELM_REPO_URL
+              value: {{ .Values.serviceSetup.helmUrl | quote }}
+            - name: HELM_REPO_REF
+              value: {{ .Values.serviceSetup.helmRef | quote }}
           volumeMounts:
             - mountPath: /data
               name: git-checkouts

--- a/values.yaml
+++ b/values.yaml
@@ -14,6 +14,11 @@ identity:
   enabled: true
   # -- The Kerberos realm for this Factory+ deployment.
   realm: FACTORYPLUS.MYORGANISATION.COM
+  # -- Kerberos UPNs to grant kadmin access. This needs to be list of
+  # objects with 'principal', 'permission' and (optionally)
+  # 'restrictions' properties; see the kadmin documentation for their
+  # meaning.
+  kadminUsers: []
   # -- Enable support for cross-realm authentication
   crossRealm: [ ]
   # crossRealm:

--- a/values.yaml
+++ b/values.yaml
@@ -98,8 +98,10 @@ serviceSetup:
   image:
     registry: ghcr.io/amrc-factoryplus
     repository: acs-service-setup
-    tag: v0.0.1
+    tag: v0.0.2
     pullPolicy: IfNotPresent
+  helmUrl: https://github.com/AMRC-FactoryPlus/edge-helm-charts.git
+  helmRef: v0.0.1
 
 mqtt:
   # -- Whether or not to enable the MQTT component


### PR DESCRIPTION
This is capable of configuring an edge cluster centrally from a ConfigDB entry, and can produce a bootstrap script to perform the edge steps of the bootstrap.

This PR **does not** include the proposed `edo` -> `clusters` renaming.

This version of the EDO requires ConfigDB entries that are not deployed by this PR. They will be deployed by a new version of acs-service-setup as they require per-deployment UUIDs.

Bootstrapping a cluster from the edge requires credentials for an admin account with kadmin rights. Using the `admin` account for this is not sensible, so, for now, allow kadmin ACLs to be configured from the values file.

Deploying this with no values changes requires a released version of the edge-helm-charts repo, to come shortly.