### PR TITLE
Expose all images and add imagePullSecrets

### DIFF
--- a/templates/auth/auth.yaml
+++ b/templates/auth/auth.yaml
@@ -17,6 +17,10 @@ spec:
         component: auth
         factory-plus.service: auth
     spec:
+      {{- with .Values.acs.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: krb5-conf
           configMap:
@@ -43,7 +47,7 @@ spec:
 
       initContainers:
         - name: register-with-directory
-          image: appropriate/curl:latest
+          image: "{{ .Values.acs.curl.image.registry }}/{{ .Values.acs.curl.image.repository }}:{{ .Values.acs.curl.image.tag }}"
           env:
             - name: PASSWORD
               valueFrom:

--- a/templates/configdb/configdb.yaml
+++ b/templates/configdb/configdb.yaml
@@ -17,6 +17,10 @@ spec:
         component: configdb
         factory-plus.service: configdb
     spec:
+      {{- with .Values.acs.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: krb5-conf
           configMap:
@@ -42,7 +46,7 @@ spec:
 
       initContainers:
         - name: register-with-directory
-          image: appropriate/curl:latest
+          image: "{{ .Values.acs.curl.image.registry }}/{{ .Values.acs.curl.image.repository }}:{{ .Values.acs.curl.image.tag }}"
           env:
             - name: PASSWORD
               valueFrom:

--- a/templates/manager/database/database.yaml
+++ b/templates/manager/database/database.yaml
@@ -6,8 +6,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
 
 spec:
+  {{- with .Values.acs.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   replicas: 1
-  image: postgres:14.3
+  image: "{{ .Values.postgres.image.registry }}/{{ .Values.postgres.image.repository }}:{{ .Values.postgres.image.tag }}"
 
   database:
     size: 1Gi

--- a/templates/manager/meilisearch.yaml
+++ b/templates/manager/meilisearch.yaml
@@ -15,13 +15,17 @@ spec:
         component: manager-meilisearch
         factory-plus.service: manager-meilisearch
     spec:
+      {{- with .Values.acs.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: manager-meilisearch-storage
           persistentVolumeClaim:
             claimName: manager-meilisearch-pvc
       containers:
         - name: meilisearch
-          image: getmeili/meilisearch:v0.30.0
+          image: "{{ .Values.manager.meilisearch.image.registry }}/{{ .Values.manager.meilisearch.image.repository }}:{{ .Values.manager.meilisearch.image.tag }}"
           volumeMounts:
             - mountPath: "/data.ms"
               name: manager-meilisearch-storage

--- a/templates/manager/redis.yaml
+++ b/templates/manager/redis.yaml
@@ -17,9 +17,13 @@ spec:
         component: manager-redis
         factory-plus.service: manager-redis
     spec:
+      {{- with .Values.acs.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: redis
-          image: redis:alpine
+          image: "{{ .Values.manager.redis.image.registry }}/{{ .Values.manager.redis.image.repository }}:{{ .Values.manager.redis.image.tag }}"
           volumeMounts:
             - mountPath: "/data"
               name: manager-redis-storage

--- a/templates/postgres/postgres.yaml
+++ b/templates/postgres/postgres.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
 
 spec:
+  {{- with .Values.acs.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   replicas: 1
   image: {{ include "amrc-connectivity-stack.image-name" .Values.postgres }}
 

--- a/templates/support/kubegres/kubegres.yaml
+++ b/templates/support/kubegres/kubegres.yaml
@@ -311,13 +311,17 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      {{- with .Values.acs.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - args:
             - --secure-listen-address=0.0.0.0:8443
             - --upstream=http://127.0.0.1:8080/
             - --logtostderr=true
             - --v=0
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+          image: "{{ .Values.kubegres.kubeProxy.image.registry }}/{{ .Values.kubegres.kubeProxy.image.repository }}:{{ .Values.kubegres.kubeProxy.image.tag }}"
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443
@@ -341,7 +345,7 @@ spec:
             - --leader-elect
           command:
             - /manager
-          image: reactivetechio/kubegres:1.16
+          image: "{{ .Values.kubegres.kubegres.image.registry }}/{{ .Values.kubegres.kubegres.image.repository }}:{{ .Values.kubegres.kubegres.image.tag }}"
           livenessProbe:
             httpGet:
               path: /healthz

--- a/values.yaml
+++ b/values.yaml
@@ -8,6 +8,16 @@ acs:
   # -- The name of the secret holding the wildcard certificate for the above domain.
   tlsSecretName: factoryplus-tls
   cacheMaxAge: 300
+  # -- Image pull secrets for Docker images
+  imagePullSecrets: []
+
+  # Curl service used by auth and configdb
+  curl:
+    # @ignore
+    image:
+      registry: docker.io
+      repository: appropriate/curl
+      tag: latest
 
 identity:
   # -- Whether or not to enable the Identity component
@@ -133,6 +143,17 @@ manager:
   meilisearch:
     # -- The key that the manager uses to connect to the Meilisearch search engine
     key: masterKey
+    # @ignore
+    image:
+      registry: docker.io
+      repository: getmeili/meilisearch
+      tag: v0.30.0
+  # @ignore
+  redis:
+    image:
+      registry: docker.io
+      repository: redis
+      tag: alpine
   # -- A string used to customise the branding of the manager
   name: Factory+ Manager
   # -- The environment that the manager is running in
@@ -141,6 +162,19 @@ manager:
   debug: false
   # -- The minimum log level that the manager will log messages at
   logLevel: warning
+
+# @ignore
+kubegres:
+  kubeProxy:
+    image:
+      registry: gcr.io
+      repository: kubebuilder/kube-rbac-proxy:v0.13.0
+      tag: v0.13.0
+  kubegres:
+    image:
+      registry: docker.io
+      repository: reactivetechio/kubegres:1.16
+      tag: 1.16
 
 cmdesc:
   # -- Whether or not to enable the Commands component


### PR DESCRIPTION
This is a potential solution to #89 it makes two changes:

1. Adds the ability to define `imagePullSecrets` for images that are in private registries
2. Exposes some of the images that were previously hardcoded

It also changes the version of the `postgres` container used by the manager service from `14.3` to `14.10`, but that could be changed if needed. It just seems to make sense to use the same version for both containers.

Run in an isolated cluster and seems to all be functioning with no errors.