### PR TITLE
Fix InfluxDB PDB enabled typo

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -341,6 +341,6 @@ influxdb2:
         echo "Creating mapping for bucket ${DOCKER_INFLUXDB_INIT_BUCKET_ID} in org ${DOCKER_INFLUXDB_INIT_ORG}"
         influx v1 dbrp create --bucket-id ${DOCKER_INFLUXDB_INIT_BUCKET_ID} --db default --rp default --default --org ${DOCKER_INFLUXDB_INIT_ORG}
   pdb:
-    enabled: false
+    create: false
 switchboard:
   enabled: false


### PR DESCRIPTION
(cherry picked from commit 48866ed8d5060dd263ae6c004c5d26c926a1a70d)