### PR TITLE
Tidy up for release

### DIFF
--- a/templates/cluster-manager/clusters.yaml
+++ b/templates/cluster-manager/clusters.yaml
@@ -1,21 +1,21 @@
-{{- if .Values.clusters.enabled }}
+{{- if .Values.clusterManager.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: clusters
+  name: cluster-manager
   namespace: {{ .Release.Namespace }}
   labels:
-    component: clusters
+    component: cluster-manager
 spec:
   replicas: 1
   selector:
     matchLabels:
-      component: clusters
+      component: cluster-manager
   template:
     metadata:
       labels:
-        component: clusters
-        factory-plus.service: clusters
+        component: cluster-manager
+        factory-plus.service: cluster-manager
     spec:
       volumes:
         - name: krb5-conf
@@ -23,22 +23,22 @@ spec:
             name: krb5-conf
         - name: keytabs
           secret:
-            secretName: clusters-keytabs
+            secretName: cluster-manager-keytabs
         - name: data
           emptyDir:
         - name: kubeseal-certs
           emptyDir:
 
       containers:
-        - name: clusters
-{{ include "amrc-connectivity-stack.image" .Values.clusters | indent 10 }}
+        - name: cluster-manager
+{{ include "amrc-connectivity-stack.image" .Values.clusterManager | indent 10 }}
           command: [ "/usr/bin/k5start", "-Uf", "/keytabs/client" ]
           args: ["node", "bin/edge-deployment.js"]
           env:
             - name: PORT
               value: "8080"
             - name: VERBOSE
-              value: {{.Values.clusters.verbosity | quote | required "values.clusters.verbosity is required!"}}
+              value: {{.Values.clusterManager.verbosity | quote | required "values.clusterManager.verbosity is required!"}}
             - name: KRB5_CONFIG
               value: /config/krb5-conf/krb5.conf
             - name: SERVER_KEYTAB
@@ -52,7 +52,7 @@ spec:
             - name: GIT_CHECKOUTS_DIR
               value: /data
             - name: GIT_EMAIL
-              value: sv1clusters@{{.Values.acs.baseUrl | required "values.acs.baseUrl is required"}}
+              value: sv1clustermanager@{{.Values.acs.baseUrl | required "values.acs.baseUrl is required"}}
             - name: KUBESEAL_TEMP
               value: /cert
             - name: KRBKEYS_IMAGE
@@ -76,7 +76,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: clusters
+  name: cluster-manager
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
@@ -84,5 +84,5 @@ spec:
       port: 80
       targetPort: 8080
   selector:
-    factory-plus.service: clusters
+    factory-plus.service: cluster-manager
 {{- end -}}

--- a/templates/cluster-manager/ingress.yaml
+++ b/templates/cluster-manager/ingress.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.clusters.enabled }}
+{{ if .Values.clusterManager.enabled }}
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
@@ -11,7 +11,7 @@ spec:
     - match: Host(`clusters.{{.Values.acs.baseUrl | required "values.acs.baseUrl is required"}}`)
       kind: Rule
       services:
-        - name: clusters
+        - name: cluster-manager
           port: 80
           namespace: {{ .Release.Namespace }}
   {{- if .Values.acs.secure }}

--- a/templates/cluster-manager/krbkeys.yaml
+++ b/templates/cluster-manager/krbkeys.yaml
@@ -1,13 +1,13 @@
-{{- if .Values.clusters.enabled }}
+{{- if .Values.clusterManager.enabled }}
 apiVersion: factoryplus.app.amrc.co.uk/v1
 kind: KerberosKey
 metadata:
-  name: sv1clusters
+  name: sv1clustermanager
   namespace: {{ .Release.Namespace }}
 spec:
   type: Random
-  principal: sv1clusters@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
-  secret: clusters-keytabs/client
+  principal: sv1clustermanager@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
+  secret: cluster-manager-keytabs/client
 ---
 apiVersion: factoryplus.app.amrc.co.uk/v1
 kind: KerberosKey
@@ -19,5 +19,5 @@ spec:
   principal: HTTP/clusters.{{ .Release.Namespace }}.svc.cluster.local@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
   additionalPrincipals:
     - HTTP/clusters.{{.Values.acs.baseUrl | required "values.acs.baseUrl is required"}}@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
-  secret: clusters-keytabs/server
+  secret: cluster-manager-keytabs/server
 {{- end }}

--- a/templates/dumps.yaml
+++ b/templates/dumps.yaml
@@ -94,8 +94,8 @@
 {{$permission_git_pullFromRepo := "12ecb694-b4b9-4d2a-927e-d100019f7ebe" | quote}}
 {{$permission_git_pushToRepo := "b2d8d437-5060-4202-bcc2-bd2beda09651" | quote}}
 
-{{$permission_clusters_manageClusters := "a40acff8-0c61-4251-bef3-d8d53e50cdd0" | quote}}
-{{$permission_clusters_manageSecrets := "07fba27a-0d01-4c07-875b-d25345261d3a" | quote}}
+{{$permission_clusterManager_manageClusters := "a40acff8-0c61-4251-bef3-d8d53e50cdd0" | quote}}
+{{$permission_clusterManager_manageSecrets := "07fba27a-0d01-4c07-875b-d25345261d3a" | quote}}
 
 {{$permissionGroup_authorisation := "50b727d4-3faa-40dc-b347-01c99a226c58" | quote}}
 {{$permissionGroup_configStore := "c43c7157-a50b-4d2a-ac1a-86ff8e8e88c1" | quote}}
@@ -103,7 +103,7 @@
 {{$permissionGroup_directory := "58b5da47-d098-44f7-8c1d-6e4bd800e718" | quote}}
 {{$permissionGroup_commands := "9584ee09-a35a-4278-bc13-21a8be1f007c" | quote}}
 {{$permissionGroup_git := "c0c55c78-116e-4526-8ff4-e4595251f76c" | quote}}
-{{$permissionGroup_clusters := "9e07fd33-6400-4662-92c4-4dff1f61f990" | quote}}
+{{$permissionGroup_clusterManager := "9e07fd33-6400-4662-92c4-4dff1f61f990" | quote}}
 
 {{$role_administrator := "4c09402f-9923-4c82-a6f2-02bda21aace4" | quote}}
 {{$role_commandEscalation := "dbd0c099-6c59-4bc6-aa92-4ba8a9b543f4" | quote}}
@@ -135,7 +135,7 @@
 {{$serviceAccount_mqtt := "2f42daeb-4521-4522-8e19-85dfb73db88e" | quote}}
 {{$serviceAccount_krbkeys := "a04b4195-7db4-4480-b3f3-4d22c08b96ea" | quote}}
 {{$serviceAccount_git := "626df296-8156-4c67-8aed-aac70161aa8b" | quote}}
-{{$serviceAccount_clusters := "127cde3c-773a-4f61-b0ba-7412a2695253" | quote}}
+{{$serviceAccount_clusterManager := "127cde3c-773a-4f61-b0ba-7412a2695253" | quote}}
 {{$userGroup_administrators := "10fc06b7-02f5-45f1-b419-a486b6bc13ba" | quote}}
 {{$userGroup_sparkplugNode := "1d3121a0-aade-4376-8fa3-57ba1460ba76" | quote}}
 {{$user_admin := "d53f476a-29dd-4d79-b614-5b7fe9bc8acf" | quote}}
@@ -662,7 +662,7 @@ data:
         }
       }
     }
-  # This is copied directly from acs-clusters.
+  # This is copied directly from acs-cluster-manager.
   # DO NOT EDIT HERE, make a PR to edit dumps/edge-deploy-configdb.yaml
   # in that repo and then pull the result back in.
   clusters: |
@@ -802,7 +802,7 @@ data:
           {{$application_edgeClusterConfiguration}}
         ],
         {{$classDef_serviceAccount}}: [
-          {{$serviceAccount_clusters}}
+          {{$serviceAccount_clusterManager}}
         ],
         {{$classDef_gitRepoGroup}}: [
           {{$gitRepoGroup_remoteClusters}},
@@ -820,8 +820,8 @@ data:
       },
       "configs": {
         {{$application_generalObjectInformation}}: {
-          {{$serviceAccount_clusters}}: {
-            "name": "Clusters"
+          {{$serviceAccount_clusterManager}}: {
+            "name": "Cluster Manager"
           },
           {{$gitRepoGroup_sharedRepositories}}: {
             "name": "Shared repositories"
@@ -1051,7 +1051,7 @@ data:
         },
         {
           "principal": {{$serviceAccount_manager}},
-          "permission": {{$permission_clusters_manageClusters}},
+          "permission": {{$permission_clusterManager_manageClusters}},
           "target": {{$special_wildcard}}
         },
         {
@@ -1277,8 +1277,8 @@ data:
           ]
       }
     }
-  # This is copied directly from acs-edge-deployment.
-  # DO NOT EDIT HERE, make a PR to edit dumps/edge-deploy-auth.yaml
+  # This is copied directly from acs-cluster-manager
+  # DO NOT EDIT HERE, make a PR to edit dumps/clusters-auth.yaml
   # in that repo and then pull the result back in.
   clusters: |
     {
@@ -1395,8 +1395,8 @@ data:
       "version": 1,
       "principals": [
         {
-          "uuid": {{$serviceAccount_clusters}},
-          "kerberos": "sv1clusters@{{ .Values.identity.realm }}"
+          "uuid": {{$serviceAccount_clusterManager}},
+          "kerberos": "sv1clustermanager@{{ .Values.identity.realm }}"
         }
       ],
       "aces": [
@@ -1407,7 +1407,7 @@ data:
         },
         {
           "principal": {{$serviceAccount_krbkeys}},
-          "permission": {{$permission_clusters_manageSecrets}},
+          "permission": {{$permission_clusterManager_manageSecrets}},
           "target": {{$special_wildcard}}
         },
         {
@@ -1418,7 +1418,7 @@ data:
       ],
       "groups": {
         {{$serviceRequirement_edgeDeploymentServiceAccount}}: [
-          {{$serviceAccount_clusters}}
+          {{$serviceAccount_clusterManager}}
         ],
         {{$serviceRequirement_edgeClusterRepositories}}: [
           {{$gitRepoGroup_remoteClusters}}
@@ -1430,7 +1430,7 @@ data:
           {{$role_edgeFlux}}
         ],
         {{$role_administrator}}: [
-          {{$permissionGroup_clusters}}
+          {{$permissionGroup_clusterManager}}
         ]
       }
     }

--- a/templates/dumps.yaml
+++ b/templates/dumps.yaml
@@ -19,7 +19,6 @@
 {{$classDef_gitRepoGroup := "b03d4dfe-7e78-4252-8e62-af594cf316c9" | quote}}
 {{$classDef_gitRepo := "d25f2afc-1ab8-4d27-b51b-d02314624e3e" | quote}}
 {{$classDef_edgeClusterAccount := "97756c9a-38e6-4238-b78c-3df6f227a6c9" | quote}}
-{{$classDef_edgeClusterTemplate := "f9be0334-0ff7-43d3-9d8a-188d3e4d472b" | quote}}
 {{$classDef_edgeCluster := "f24d354d-abc1-4e32-98e1-0667b3e40b61" | quote}}
 
 {{$special_wildcard := "00000000-0000-0000-0000-000000000000" | quote}}
@@ -33,7 +32,6 @@
 {{$application_commandEscalation := "60e99f28-67fe-4344-a6ab-b1edb8b8e810" | quote}}
 {{$application_gitRepoConfiguration := "38d62a93-b6b4-4f63-bad4-d433e3eaff29" | quote}}
 {{$application_edgeClusterConfiguration := "bdb13634-0b3d-4e38-a065-9d88c12ee78d" | quote}}
-{{$application_edgeClusterTemplate := "72804a19-636b-4836-b62b-7ad1476f2b86" | quote}}
 {{$application_edgeClusterStatus := "747a62c9-1b66-4a2e-8dd9-0b70a91b6b75" | quote}}
 {{$application_edgeDeployment := "f2b9417a-ef7f-421f-b387-bb8183a48cdb" | quote}}
 {{$application_helmChartTemplate := "729fe070-5e67-4bc7-94b5-afd75cb42b03" | quote}}
@@ -117,8 +115,6 @@
 {{$gitRepoGroup_remoteClusters := "736697bd-3637-4340-8d8a-f4a457d6f483" | quote}}
 {{$gitRepoGroup_sharedRepositories := "9c16e08a-a659-4f02-877f-2949dc4ec7b9" | quote}}
 {{$gitRepo_sharedFluxSystem := "8a3c0860-9e41-48b8-b02f-780a0e582be6" | quote}}
-
-{{$edgeClusterTemplate_cellGateway := "71648ac2-f2a6-4777-92ac-f7852be68efc" | quote}}
 
 # XXX These are currently all fixed UUIDs which will end up identical
 # between installations. This is incorrect: these represent the accounts
@@ -788,14 +784,12 @@ data:
       "classes": [
         {{$classDef_serviceAccount}},
         {{$classDef_edgeClusterAccount}},
-        {{$classDef_edgeClusterTemplate}},
         {{$classDef_gitRepoGroup}},
         {{$classDef_gitRepo}},
         {{$classDef_clientRole}}
       ],
       "objects": {
         {{$classDef_application}}: [
-          {{$application_edgeClusterTemplate}},
           {{$application_gitRepoConfiguration}},
           {{$application_edgeClusterStatus}},
           {{$application_edgeDeployment}},
@@ -813,9 +807,6 @@ data:
         ],
         {{$classDef_clientRole}}: [
           {{$role_edgeFlux}}
-        ],
-        {{$classDef_edgeClusterTemplate}}: [
-          {{$edgeClusterTemplate_cellGateway}}
         ]
       },
       "configs": {
@@ -838,9 +829,6 @@ data:
           {{$role_edgeFlux}}: {
             "name": "Role: Edge Flux"
           },
-          {{$edgeClusterTemplate_cellGateway}}: {
-              "name": "Cell gateway"
-          },
           {{$application_edgeDeployment}}: {
             "name": "Edge deployment"
           },
@@ -860,33 +848,6 @@ data:
           },
           {{$gitRepo_sharedFluxSystem}}: {
             "path": "shared/flux-system"
-          }
-        },
-        {{$application_edgeClusterTemplate}}: {
-          {{$edgeClusterTemplate_cellGateway}}: {
-            "flux": {
-                "name": "Edge flux: %n",
-                "class": {{$classDef_edgeClusterAccount}},
-                "groups": [
-                    {{$role_edgeFlux}}
-                ],
-                "username": "op1flux/%n"
-            },
-            "name": "cell-gateway",
-            "cluster": {
-                "namespace": "fplus-edge"
-            },
-            "repository": {
-                "group": "cluster",
-                "links": {
-                    {{$gitRepo_sharedFluxSystem}}: {
-                        "branch": "main",
-                        "interval": "3h0m0s"
-                    }
-                },
-                "branch": "main",
-                "interval": "5m0s"
-            }
           }
         }
       }

--- a/values.yaml
+++ b/values.yaml
@@ -81,7 +81,7 @@ directory:
     # -- The repository of the Directory component
     repository: acs-directory
     # -- The tag of the Directory component
-    tag: v1.1.2
+    tag: v1.1.3-dev.1
     # @ignore
     pullPolicy: IfNotPresent
 
@@ -94,7 +94,7 @@ configdb:
     # -- The repository of the Configuration Store component
     repository: acs-configdb
     # -- The tag of the Configuration Store component
-    tag: v1.8.1
+    tag: v1.8.2-dev.1
     # @ignore
     pullPolicy: IfNotPresent
 
@@ -146,7 +146,7 @@ manager:
     # -- The repository of the Manager component
     repository: acs-manager
     # -- The tag of the Manager component
-    tag: v2.0.0-dev.9
+    tag: v2.0.0-dev.15
     # @ignore
     pullPolicy: IfNotPresent
   edge:
@@ -188,7 +188,7 @@ cmdesc:
     # -- The repository of the Commands component
     repository: acs-cmdesc
     # -- The tag of the Commands component
-    tag: v1.0.1
+    tag: v1.0.2-dev.2
     # @ignore
     pullPolicy: IfNotPresent
   # -- Possible values are either 1 to enable all possible debugging, or a comma-separated list of debug tags (the tags printed before the log lines). No logging is specified as an empty string.
@@ -236,9 +236,9 @@ clusters:
     # -- The registry of the Clusters component
     registry: ghcr.io/amrc-factoryplus
     # -- The repository of the Clusters component
-    repository: acs-clusters
+    repository: acs-cluster-manager
     # -- The tag of the Clusters component
-    tag: v0.0.2
+    tag: v0.0.3-dev.1
     # @ignore
     pullPolicy: IfNotPresent
   verbosity: "ALL,!service,!token"

--- a/values.yaml
+++ b/values.yaml
@@ -81,7 +81,7 @@ directory:
     # -- The repository of the Directory component
     repository: acs-directory
     # -- The tag of the Directory component
-    tag: v1.1.3-dev.1
+    tag: v1.1.3
     # @ignore
     pullPolicy: IfNotPresent
 
@@ -94,7 +94,7 @@ configdb:
     # -- The repository of the Configuration Store component
     repository: acs-configdb
     # -- The tag of the Configuration Store component
-    tag: v1.8.2-dev.1
+    tag: v1.8.2
     # @ignore
     pullPolicy: IfNotPresent
 
@@ -188,7 +188,7 @@ cmdesc:
     # -- The repository of the Commands component
     repository: acs-cmdesc
     # -- The tag of the Commands component
-    tag: v1.0.2-dev.2
+    tag: v1.0.2
     # @ignore
     pullPolicy: IfNotPresent
   # -- Possible values are either 1 to enable all possible debugging, or a comma-separated list of debug tags (the tags printed before the log lines). No logging is specified as an empty string.
@@ -238,7 +238,7 @@ clusterManager:
     # -- The repository of the Clusters component
     repository: acs-cluster-manager
     # -- The tag of the Clusters component
-    tag: v0.0.3-dev.1
+    tag: v0.0.3
     # @ignore
     pullPolicy: IfNotPresent
   verbosity: "ALL,!service,!token"

--- a/values.yaml
+++ b/values.yaml
@@ -229,7 +229,7 @@ git:
   # -- Possible values are either 1 to enable all possible debugging, or a comma-separated list of debug tags (the tags printed before the log lines). No logging is specified as an empty string.
   verbosity: "ALL,!service,!token"
 
-clusters:
+clusterManager:
   # -- Whether or not to enable the Cluster Manager component
   enabled: true
   image:

--- a/values.yaml
+++ b/values.yaml
@@ -105,7 +105,7 @@ serviceSetup:
   image:
     registry: ghcr.io/amrc-factoryplus
     repository: acs-service-setup
-    tag: v0.0.2
+    tag: v3.0.0-dev.1
     pullPolicy: IfNotPresent
   # This section overrides the classes etc. installed into the ConfigDB
   config:
@@ -115,7 +115,7 @@ serviceSetup:
         name: Edge Helm charts
         url: https://github.com/AMRC-FactoryPlus/edge-helm-charts.git
         # The 'acs' branch will be updated to this tag/branch 
-        ref: v0.0.1
+        ref: v3.0.0-dev.1
     # Helm charts to deploy to the edge; these default to the charts
     # created automatically but can be overridden to customise
     helmChart:


### PR DESCRIPTION
* Update all the images to the latest versions.
* Rename `clusters` -> `cluster-manager`.
* Remove some redundant pieces from the dump files.
* Cut release of service-setup and edge-helm-charts.

Going forward the release tags of acs-service-setup and edge-helm-charts will be synced with this repo, so each release of ACS is accompanied by a matching release of the other two repos.