### PR TITLE
Automatically pull from external git repos

### DIFF
--- a/templates/dumps.yaml
+++ b/templates/dumps.yaml
@@ -1184,28 +1184,8 @@ data:
         },
         {
           "principal": "a461ef62-0560-4be2-8d97-1a56916ce4f8",
-          "permission": "f0b7917b-d475-4888-9d5a-2af96b3c26b6",
-          "target": "d25f2afc-1ab8-4d27-b51b-d02314624e3e"
-        },
-        {
-          "principal": "a461ef62-0560-4be2-8d97-1a56916ce4f8",
           "permission": "4a339562-cd57-408d-9d1a-6529a383ea4b",
           "target": "38d62a93-b6b4-4f63-bad4-d433e3eaff29"
-        },
-        {
-          "principal": "a461ef62-0560-4be2-8d97-1a56916ce4f8",
-          "permission": "6c799ccb-d2ad-4715-a2a7-3c8728d6c0bf",
-          "target": "38d62a93-b6b4-4f63-bad4-d433e3eaff29"
-        },
-        {
-          "principal": "a461ef62-0560-4be2-8d97-1a56916ce4f8",
-          "permission": "4a339562-cd57-408d-9d1a-6529a383ea4b",
-          "target": "64a8bfa9-7772-45c4-9d1a-9e6290690957"
-        },
-        {
-          "principal": "a461ef62-0560-4be2-8d97-1a56916ce4f8",
-          "permission": "6c799ccb-d2ad-4715-a2a7-3c8728d6c0bf",
-          "target": "64a8bfa9-7772-45c4-9d1a-9e6290690957"
         }
       ],
       "groups": {
@@ -1233,10 +1213,20 @@ data:
           {{$serviceRequirement_gitServiceAccount}}: [
             {{$serviceAccount_git}}
           ],
+          {{$userGroup_sparkplugNode}}: [
+            {{$serviceAccount_git}}
+          ],
           {{$role_administrator}}: [
             {{$permissionGroup_git}}
           ]
-      }
+      },
+      "aces": [
+        {
+          "principal": {{$serviceAccount_git}},
+          "permission": {{$role_edgeNodeConsumer}},
+          "target": {{$serviceAccount_configStore}}
+        }
+      ]
     }
   # This is copied directly from acs-cluster-manager
   # DO NOT EDIT HERE, make a PR to edit dumps/clusters-auth.yaml

--- a/templates/git/git.yaml
+++ b/templates/git/git.yaml
@@ -48,6 +48,25 @@ spec:
             - mountPath: /data
               name: data
 
+        - name: init-data
+{{ include "amrc-connectivity-stack.image" .Values.shell | indent 10 }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              echo "Setting up data directory"
+              if ! [ -d /data/repo ]
+              then
+                mkdir /data/repo
+                mv /data/*-*-*-*-* /data/repo/
+              fi
+              rm -f /data/changed
+              mkfifo /data/changed
+          securityContext:
+            runAsUser: 1000
+          volumeMounts:
+            - mountPath: /data
+              name: data
+
       containers:
         - name: git
 {{ include "amrc-connectivity-stack.image" .Values.git | indent 10 }}
@@ -59,7 +78,9 @@ spec:
             - name: VERBOSE
               value: {{.Values.git.verbosity | quote | required "values.git.verbosity is required!"}}
             - name: DATA_DIR
-              value: /data
+              value: /data/repo
+            - name: DATA_CHANGED_FIFO
+              value: /data/changed
             - name: GIT_EXEC_PATH
               value: /usr/libexec/git-core
             - name: KRB5_CONFIG

--- a/values.yaml
+++ b/values.yaml
@@ -155,7 +155,7 @@ visualiser:
     # -- The repository of the MQTT component
     repository: acs-visualiser
     # -- The tag of the MQTT component
-    tag: v1.0.3
+    tag: v1.0.4
     # @ignore
     pullPolicy: IfNotPresent
 

--- a/values.yaml
+++ b/values.yaml
@@ -114,8 +114,13 @@ serviceSetup:
       helm:
         name: Edge Helm charts
         url: https://github.com/AMRC-FactoryPlus/edge-helm-charts.git
-        # The 'acs' branch will be updated to this tag/branch 
+        # The 'acs' branch will be updated to this tag/branch, and then
+        # merged into main if main has not otherwise moved
         ref: v3.0.0-dev.8
+        # Interval to perform updates. 'never' will only update on git
+        # server startup and is suitable for tag refs which won't
+        # change.
+        interval: never
     # Helm charts to deploy to the edge; these default to the charts
     # created automatically but can be overridden to customise
     helmChart:

--- a/values.yaml
+++ b/values.yaml
@@ -186,12 +186,6 @@ manager:
       repository: getmeili/meilisearch
       tag: v0.30.0
       pullPolicy: IfNotPresent
-  redis:
-    image:
-      registry: docker.io
-      repository: redis
-      tag: alpine
-      pullPolicy: IfNotPresent
   # -- A string used to customise the branding of the manager
   name: Factory+ Manager
   # -- The environment that the manager is running in

--- a/values.yaml
+++ b/values.yaml
@@ -245,7 +245,7 @@ git:
     # -- The repository of the Git component
     repository: acs-git
     # -- The tag of the Git component
-    tag: v0.0.3
+    tag: v0.0.4-dev.1
     # @ignore
     pullPolicy: IfNotPresent
   # -- Possible values are either 1 to enable all possible debugging, or a comma-separated list of debug tags (the tags printed before the log lines). No logging is specified as an empty string.

--- a/values.yaml
+++ b/values.yaml
@@ -111,16 +111,21 @@ serviceSetup:
   config:
     # Git repos to mirror in the on-prem git server
     repoMirror:
+      # This repo is expected to hold the edge Helm charts
       helm:
         name: Edge Helm charts
-        url: https://github.com/AMRC-FactoryPlus/edge-helm-charts.git
-        # The 'acs' branch will be updated to this tag/branch, and then
-        # merged into main if main has not otherwise moved
-        ref: v3.0.0-dev.8
-        # Interval to perform updates. 'never' will only update on git
-        # server startup and is suitable for tag refs which won't
-        # change.
-        interval: never
+        # Branches to pull from external repos
+        pull:
+          acs:
+            url: https://github.com/AMRC-FactoryPlus/edge-helm-charts.git
+            # Pull this branch/tag
+            ref: v3.0.0-dev.8
+            # Merge to a local branch, if not otherwise moved
+            merge: main
+            # Interval to perform updates. 'never' will only update on git
+            # server startup and is suitable for tag refs which won't
+            # change.
+            interval: never
     # Helm charts to deploy to the edge; these default to the charts
     # created automatically but can be overridden to customise
     helmChart:


### PR DESCRIPTION
* Update the git server to automatically pull from external repos
* Update service-setup configuration to support this
* The git server now publishes the current state of all branches over Sparkplug
* Minor additional updates: update `vis`, remove old Manager redis values