### PR TITLE
Use chart version for images

### DIFF
--- a/deploy/templates/_helpers.tpl
+++ b/deploy/templates/_helpers.tpl
@@ -39,7 +39,8 @@ Create chart name and version as used by the chart label.
 Define the image for a container.
 */}}
 {{- define "amrc-connectivity-stack.image-name" -}}
-{{- .image.registry }}/{{ .image.repository }}:{{ .image.tag }}
+{{- $defaultTag := default .Release.Version .image.tag }}
+{{- .image.registry }}/{{ .image.repository }}:{{ $defaultTag }}
 {{- end }}
 
 {{- define "amrc-connectivity-stack.image" -}}

--- a/deploy/templates/_helpers.tpl
+++ b/deploy/templates/_helpers.tpl
@@ -39,7 +39,7 @@ Create chart name and version as used by the chart label.
 Define the image for a container.
 */}}
 {{- define "amrc-connectivity-stack.image-name" -}}
-{{- $defaultTag := default .Release.Version .image.tag }}
+{{- $defaultTag := coalesce .image.tag $.Values.acs.defaultTag $.Release.Version }}
 {{- .image.registry }}/{{ .image.repository }}:{{ $defaultTag }}
 {{- end }}
 

--- a/deploy/templates/identity/kdc.yaml
+++ b/deploy/templates/identity/kdc.yaml
@@ -48,7 +48,7 @@ spec:
         # Do as little work as possible as root... We need to chown the storage
         # as the default permissions will not be correct.
         - name: chown-storage
-          image: "{{ .Values.identity.identity.image.registry }}/{{ .Values.identity.identity.image.repository }}:{{ .Values.identity.identity.image.tag }}"
+          image: "{{ include "amrc-connectivity-stack.image-name" .Values.identity.identity }}"
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -65,7 +65,7 @@ spec:
 
         # Initialise the Kerberos database on first boot.
         - name: kdb-init
-          image: "{{ .Values.identity.identity.image.registry }}/{{ .Values.identity.identity.image.repository }}:{{ .Values.identity.identity.image.tag }}"
+          image: "{{ include "amrc-connectivity-stack.image-name" .Values.identity.identity }}"
           command: ["/bin/sh"]
           {{- if .Values.identity.identity.manualInit }}
           args: [ "-c", "while test ! -f /tmp/KDB-INIT-COMPLETE; do sleep 5; done" ]
@@ -90,7 +90,7 @@ spec:
         # principal to authenticate with...). It creates the Kerberos principal
         # needed and stashes its key in a K8s secret for use by the operator.
         - name: krbkeys
-          image: "{{ .Values.identity.krbKeysOperator.image.registry }}/{{ .Values.identity.krbKeysOperator.image.repository }}:{{ .Values.identity.krbKeysOperator.image.tag }}"
+          image: "{{ include "amrc-connectivity-stack.image-name" .Values.identity.krbKeysOperator }}"
           command: ["/usr/bin/python3", "-m", "amrc.factoryplus.krbkeys.bootstrap"]
           # We need to run as the 'kdc' user from the kdc
           # image. This user isn't the same UID as the default
@@ -125,7 +125,7 @@ spec:
       containers:
         # The KDC issues tickets to clients.
         - name: kdc
-          image: "{{ .Values.identity.identity.image.registry }}/{{ .Values.identity.identity.image.repository }}:{{ .Values.identity.identity.image.tag }}"
+          image: "{{ include "amrc-connectivity-stack.image-name" .Values.identity.identity }}"
           command: ["/usr/sbin/krb5kdc"]
           args: [ "-n" ]
           env:
@@ -144,7 +144,7 @@ spec:
         # Kadmind performs Kerberos database administration, including password
         # changes for users.
         - name: kadmind
-          image: "{{ .Values.identity.identity.image.registry }}/{{ .Values.identity.identity.image.repository }}:{{ .Values.identity.identity.image.tag }}"
+          image: "{{ include "amrc-connectivity-stack.image-name" .Values.identity.identity }}"
           command: ["/usr/sbin/kadmind"]
           args: [ "-nofork" ]
           env:

--- a/deploy/templates/identity/kdc.yaml
+++ b/deploy/templates/identity/kdc.yaml
@@ -48,7 +48,7 @@ spec:
         # Do as little work as possible as root... We need to chown the storage
         # as the default permissions will not be correct.
         - name: chown-storage
-          image: "{{ include "amrc-connectivity-stack.image-name" .Values.identity.identity }}"
+{{ include "amrc-connectivity-stack.image" .Values.identity.identity | indent 10 }}
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -65,7 +65,7 @@ spec:
 
         # Initialise the Kerberos database on first boot.
         - name: kdb-init
-          image: "{{ include "amrc-connectivity-stack.image-name" .Values.identity.identity }}"
+{{ include "amrc-connectivity-stack.image" .Values.identity.identity | indent 10 }}
           command: ["/bin/sh"]
           {{- if .Values.identity.identity.manualInit }}
           args: [ "-c", "while test ! -f /tmp/KDB-INIT-COMPLETE; do sleep 5; done" ]
@@ -125,7 +125,7 @@ spec:
       containers:
         # The KDC issues tickets to clients.
         - name: kdc
-          image: "{{ include "amrc-connectivity-stack.image-name" .Values.identity.identity }}"
+{{ include "amrc-connectivity-stack.image" .Values.identity.identity | indent 10 }}
           command: ["/usr/sbin/krb5kdc"]
           args: [ "-n" ]
           env:
@@ -144,7 +144,7 @@ spec:
         # Kadmind performs Kerberos database administration, including password
         # changes for users.
         - name: kadmind
-          image: "{{ include "amrc-connectivity-stack.image-name" .Values.identity.identity }}"
+{{ include "amrc-connectivity-stack.image" .Values.identity.identity | indent 10 }}
           command: ["/usr/sbin/kadmind"]
           args: [ "-nofork" ]
           env:

--- a/deploy/templates/manager/cron.yaml
+++ b/deploy/templates/manager/cron.yaml
@@ -22,7 +22,7 @@ spec:
           {{- end }}
           containers:
             - name: cron
-              image: "{{ .Values.manager.image.registry }}/{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}-backend"
+              image: "{{ include "amrc-connectivity-stack.image-name" .Values.manager }}-backend"
               imagePullPolicy: IfNotPresent
               command: [ "php", "artisan", "schedule:run" ]
               env:

--- a/deploy/templates/manager/manager.yaml
+++ b/deploy/templates/manager/manager.yaml
@@ -38,7 +38,7 @@ spec:
         # Do as little work as possible as root... We need to chown the storage
         # as the default permissions will not be correct.
         - name: chown-storage
-          image: "{{ include "amrc-connectivity-stack.image-name" .Values.configdb }}-backend"
+          image: "{{ include "amrc-connectivity-stack.image-name" .Values.manager }}-backend"
           command: [ "/bin/sh", "-c" ]
           args:
             - |
@@ -52,7 +52,7 @@ spec:
             - mountPath: /app/storage/ccache
               name: manager-ccache-storage
         - name: migrate-database
-          image: "{{ include "amrc-connectivity-stack.image-name" .Values.configdb }}-backend"
+          image: "{{ include "amrc-connectivity-stack.image-name" .Values.manager }}-backend"
           imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
           env:
             - name: DB_PASSWORD
@@ -77,7 +77,7 @@ spec:
                 name: manager-secrets
           command: [ 'sh', '-c', 'php artisan migrate --force' ]
         - name: create-admin-user
-          image: "{{ include "amrc-connectivity-stack.image-name" .Values.configdb }}-backend"
+          image: "{{ include "amrc-connectivity-stack.image-name" .Values.manager }}-backend"
           imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
           env:
             - name: DB_PASSWORD
@@ -97,7 +97,7 @@ spec:
               php artisan tinker --execute="if (User::count() === 0) {User::create(['username' => 'admin@{{.Values.identity.realm}}', 'administrator' => 1]);}"
       containers:
         - name: backend
-          image: "{{ include "amrc-connectivity-stack.image-name" .Values.configdb }}-backend"
+          image: "{{ include "amrc-connectivity-stack.image-name" .Values.manager }}-backend"
           imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
           env:
             - name: KRB5_CONFIG
@@ -130,7 +130,7 @@ spec:
             - mountPath: /app/storage/ccache
               name: manager-ccache-storage
         - name: frontend
-          image: "{{ include "amrc-connectivity-stack.image-name" .Values.configdb }}-frontend"
+          image: "{{ include "amrc-connectivity-stack.image-name" .Values.manager }}-frontend"
           imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
 ---
 kind: PersistentVolumeClaim

--- a/deploy/templates/manager/manager.yaml
+++ b/deploy/templates/manager/manager.yaml
@@ -38,7 +38,7 @@ spec:
         # Do as little work as possible as root... We need to chown the storage
         # as the default permissions will not be correct.
         - name: chown-storage
-          image: "{{ .Values.manager.image.registry }}/{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}-backend"
+          image: "{{ include "amrc-connectivity-stack.image-name" .Values.configdb }}-backend"
           command: [ "/bin/sh", "-c" ]
           args:
             - |
@@ -52,7 +52,7 @@ spec:
             - mountPath: /app/storage/ccache
               name: manager-ccache-storage
         - name: migrate-database
-          image: "{{ .Values.manager.image.registry }}/{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}-backend"
+          image: "{{ include "amrc-connectivity-stack.image-name" .Values.configdb }}-backend"
           imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
           env:
             - name: DB_PASSWORD
@@ -77,7 +77,7 @@ spec:
                 name: manager-secrets
           command: [ 'sh', '-c', 'php artisan migrate --force' ]
         - name: create-admin-user
-          image: "{{ .Values.manager.image.registry }}/{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}-backend"
+          image: "{{ include "amrc-connectivity-stack.image-name" .Values.configdb }}-backend"
           imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
           env:
             - name: DB_PASSWORD
@@ -97,7 +97,7 @@ spec:
               php artisan tinker --execute="if (User::count() === 0) {User::create(['username' => 'admin@{{.Values.identity.realm}}', 'administrator' => 1]);}"
       containers:
         - name: backend
-          image: "{{ .Values.manager.image.registry }}/{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}-backend"
+          image: "{{ include "amrc-connectivity-stack.image-name" .Values.configdb }}-backend"
           imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
           env:
             - name: KRB5_CONFIG
@@ -130,7 +130,7 @@ spec:
             - mountPath: /app/storage/ccache
               name: manager-ccache-storage
         - name: frontend
-          image: "{{ .Values.manager.image.registry }}/{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}-frontend"
+          image: "{{ include "amrc-connectivity-stack.image-name" .Values.configdb }}-frontend"
           imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
 ---
 kind: PersistentVolumeClaim

--- a/deploy/templates/manager/queue.yaml
+++ b/deploy/templates/manager/queue.yaml
@@ -27,7 +27,7 @@ spec:
       {{- end }}
       containers:
         - name: queue-default
-          image: "{{ .Values.manager.image.registry }}/{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}-backend"
+          image: "{{ include "amrc-connectivity-stack.image-name" .Values.configdb }}-backend"
           imagePullPolicy: IfNotPresent
           env:
             - name: DB_PASSWORD

--- a/deploy/templates/manager/schema-import-cron.yaml
+++ b/deploy/templates/manager/schema-import-cron.yaml
@@ -29,7 +29,7 @@ spec:
                 name: krb5-conf
           containers:
             - name: cron
-              image: "{{ .Values.manager.image.registry }}/{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}-backend"
+              image: "{{ include "amrc-connectivity-stack.image-name" .Values.configdb }}-backend"
               env:
                 - name: KRB5_CONFIG
                   value: /config/krb5-conf/krb5.conf

--- a/deploy/templates/warehouse/influxdb-ingester.yaml
+++ b/deploy/templates/warehouse/influxdb-ingester.yaml
@@ -34,7 +34,7 @@ spec:
 
       containers:
         - name: influxdb-ingester
-          image: "{{ .Values.warehouse.ingester.image.registry }}/{{ .Values.warehouse.ingester.image.repository }}:{{ .Values.warehouse.ingester.image.tag }}"
+          image: "{{ include "amrc-connectivity-stack.image-name" .Values.warehouse.ingester }}"
           command: [ "/usr/bin/k5start", "-Uf", "/keytabs/client" ]
           args: [ "node", "--es-module-specifier-resolution=node", "bin/ingester.js" ]
           imagePullPolicy: Always

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -10,6 +10,11 @@ acs:
   cacheMaxAge: 300
   # -- Image pull secrets for container images
   imagePullSecrets: []
+  # -- An optional tag that will force images to use this version
+  # regardless of the version in the Helm chart. Each component can
+  # override this value by setting the `tag` property in its own
+  # section.
+  defaultTag: ""
 
 identity:
   # -- Whether or not to enable the Identity component

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -35,8 +35,6 @@ identity:
       registry: ghcr.io/amrc-factoryplus
       # -- The repository of the Identity component
       repository: acs-identity
-      # -- The tag of the Identity component
-      tag: v1.0.0
       # @ignore
       pullPolicy: IfNotPresent
     # If this is set to true, the kdb-init container will not set up the
@@ -54,8 +52,6 @@ identity:
       registry: ghcr.io/amrc-factoryplus
       # -- The repository of the KerberosKey Operator
       repository: acs-krb-keys-operator
-      # -- The tag of the KerberosKey Operator
-      tag: v1.3.1
       # @ignore
       pullPolicy: IfNotPresent
 
@@ -67,8 +63,6 @@ auth:
     registry: ghcr.io/amrc-factoryplus
     # -- The repository of the Authorisation component
     repository: acs-auth
-    # -- The tag of the Authorisation component
-    tag: v1.3.0
     # @ignore
     pullPolicy: IfNotPresent
 
@@ -80,8 +74,6 @@ directory:
     registry: ghcr.io/amrc-factoryplus
     # -- The repository of the Directory component
     repository: acs-directory
-    # -- The tag of the Directory component
-    tag: v1.1.3
     # @ignore
     pullPolicy: IfNotPresent
 
@@ -93,8 +85,6 @@ configdb:
     registry: ghcr.io/amrc-factoryplus
     # -- The repository of the Configuration Store component
     repository: acs-configdb
-    # -- The tag of the Configuration Store component
-    tag: v1.8.2
     # @ignore
     pullPolicy: IfNotPresent
 
@@ -105,7 +95,6 @@ serviceSetup:
   image:
     registry: ghcr.io/amrc-factoryplus
     repository: acs-service-setup
-    tag: v3.0.0-dev.13
     pullPolicy: IfNotPresent
   # This section overrides the classes etc. installed into the ConfigDB
   config:
@@ -140,8 +129,6 @@ mqtt:
     registry: ghcr.io/amrc-factoryplus
     # -- The repository of the MQTT component
     repository: acs-mqtt
-    # -- The tag of the MQTT component
-    tag: v1.1.1
     # @ignore
     pullPolicy: IfNotPresent
   # -- Possible values are either 1 to enable all possible debugging, or a comma-separated list of debug tags (the tags printed before the log lines). No logging is specified as an empty string.
@@ -154,8 +141,6 @@ visualiser:
     registry: ghcr.io/amrc-factoryplus
     # -- The repository of the MQTT component
     repository: acs-visualiser
-    # -- The tag of the MQTT component
-    tag: v1.1.1
     # @ignore
     pullPolicy: IfNotPresent
 
@@ -167,8 +152,6 @@ manager:
     registry: ghcr.io/amrc-factoryplus
     # -- The repository of the Manager component
     repository: acs-manager
-    # -- The tag of the Manager component
-    tag: v2.0.0-dev.25
     # @ignore
     pullPolicy: IfNotPresent
   edge:
@@ -176,8 +159,6 @@ manager:
     registry: ghcr.io/amrc-factoryplus
     # -- The repository of the Edge Agent component
     repository: acs-edge
-    # -- The tag of the Edge Agent component
-    tag: v1.2.2
   meilisearch:
     # -- The key that the manager uses to connect to the Meilisearch search engine
     key: masterKey
@@ -203,8 +184,6 @@ cmdesc:
     registry: ghcr.io/amrc-factoryplus
     # -- The repository of the Commands component
     repository: acs-cmdesc
-    # -- The tag of the Commands component
-    tag: v1.0.2
     # @ignore
     pullPolicy: IfNotPresent
   # -- Possible values are either 1 to enable all possible debugging, or a comma-separated list of debug tags (the tags printed before the log lines). No logging is specified as an empty string.
@@ -225,8 +204,6 @@ warehouse:
       registry: ghcr.io/amrc-factoryplus
       # -- The repository of the Warehouse component
       repository: influxdb-sparkplug-ingester
-      # -- The tag of the ingester component
-      tag: v1.2.1
       # @ignore
       pullPolicy: IfNotPresent
 
@@ -238,8 +215,6 @@ git:
     registry: ghcr.io/amrc-factoryplus
     # -- The repository of the Git component
     repository: acs-git
-    # -- The tag of the Git component
-    tag: v0.0.4-dev.1
     # @ignore
     pullPolicy: IfNotPresent
   # -- Possible values are either 1 to enable all possible debugging, or a comma-separated list of debug tags (the tags printed before the log lines). No logging is specified as an empty string.
@@ -253,8 +228,6 @@ clusterManager:
     registry: ghcr.io/amrc-factoryplus
     # -- The repository of the Clusters component
     repository: acs-cluster-manager
-    # -- The tag of the Clusters component
-    tag: v0.0.4
     # @ignore
     pullPolicy: IfNotPresent
   verbosity: "ALL,!service,!token"

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -12,8 +12,8 @@ acs:
   imagePullSecrets: []
   # -- An optional tag that will force images to use this version
   # regardless of the version in the Helm chart. Each component can
-  # override this value by setting the `tag` property in its own
-  # section.
+  # further override this value by setting the `tag` property in its
+  # own section.
   defaultTag: ""
 
 identity:


### PR DESCRIPTION
Use the helper function to use the chart version for the image tags if not specified in the values file.

- Replaced all remaining static calls to images with the helper functions.