### PR TITLE
Fix the image tag defaulting to chart version

### DIFF
--- a/deploy/templates/_helpers.tpl
+++ b/deploy/templates/_helpers.tpl
@@ -41,7 +41,8 @@ Define the image for a container.
 {{- define "amrc-connectivity-stack.image-name" -}}
 {{- $top := index . 0 }}
 {{- $context := index . 1 }}
-{{- $defaultTag := coalesce $context.image.tag $top.Values.acs.defaultTag $top.Release.Version }}
+{{- $defaultTag := coalesce 
+    $context.image.tag $top.Values.acs.defaultTag $top.Chart.Version }}
 {{- $context.image.registry }}/{{ $context.image.repository }}:{{ $defaultTag }}
 {{- end }}
 

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -15,7 +15,7 @@ acs:
   # -- An optional tag that will force images to use this version
   # regardless of the version in the Helm chart. Each component can
   # further override this value by setting the `tag` property in its
-  # own section.
+  # own section. Deployments from a Git checkout must set this value.
   #defaultTag: ''
 
 identity:


### PR DESCRIPTION
This will only function correctly for Helm charts published to Github Pages. Installing from a checkout or a git repo will need a `defaultTag` override.