### PR TITLE
Create a git repo on auto-pull

### DIFF
--- a/acs-git/Makefile
+++ b/acs-git/Makefile
@@ -2,10 +2,11 @@
 
 -include config.mk
 
-pkgver!=node -e 'console.log(JSON.parse(fs.readFileSync("package.json")).version)'
+release!=git describe --tags --abbrev=0
 
-version?=v${pkgver}
+version?=${release}
 suffix?=
+base_version?=${release}
 registry?=ghcr.io/amrc-factoryplus
 repo?=acs-git
 docker?=docker
@@ -13,13 +14,7 @@ docker?=docker
 tag=${registry}/${repo}:${version}${suffix}
 build_args=
 
-ifdef acs_build
-build_args+=--build-arg acs_build="${acs_build}"
-endif
-
-ifdef acs_run
-build_args+=--build-arg acs_run="${acs_run}"
-endif
+build_args+=--build-arg base_version="${base_version}"
 
 ifdef acs_npm
 build_args+=--build-arg acs_npm="${acs_npm}"

--- a/acs-git/lib/auto-pull.js
+++ b/acs-git/lib/auto-pull.js
@@ -87,6 +87,12 @@ export class AutoPull {
                 : Promise.reject(e))
         const before = await get_ref(spec.branch);
 
+        fs.promises.stat(gitdir)
+            .catch(() => git.init({
+                fs, gitdir,
+                bare:           true,
+                defaultBranch:  "main",
+            }))
         /* There should be noone else trying to create remotes on this
          * repo. However, this update() is not atomic, and if we are
          * killed partway through the remote will not be removed. So,

--- a/acs-git/lib/auto-pull.js
+++ b/acs-git/lib/auto-pull.js
@@ -87,7 +87,7 @@ export class AutoPull {
                 : Promise.reject(e))
         const before = await get_ref(spec.branch);
 
-        fs.promises.stat(gitdir)
+        await fs.promises.stat(gitdir)
             .catch(() => git.init({
                 fs, gitdir,
                 bare:           true,


### PR DESCRIPTION
Auto-pull on a git repo was failing when the repo did not already exist.