### PR TITLE
Tidy up a bit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea/
+config.mk
+*/config.mk

--- a/acs-auth/Makefile
+++ b/acs-auth/Makefile
@@ -1,48 +1,7 @@
-# On Windows try https://frippery.org/busybox/
+top=..
+include ${top}/mk/acs.init.mk
 
--include config.mk
-
-pkgver!=node -e 'console.log(JSON.parse(fs.readFileSync("package.json")).version)'
-
-version?=v${pkgver}
-suffix?=
-registry?=ghcr.io/amrc-factoryplus
 repo?=acs-auth
+k8s.deployment?=auth
 
-tag=${registry}/${repo}:${version}${suffix}
-
-all: build push
-
-.PHONY: all build push check-committed
-
-check-committed:
-	[ -z "$$(git status --porcelain)" ] || (git status; exit 1)
-
-build: check-committed
-	docker build -t "${tag}" .
-
-push:
-	docker push "${tag}"
-
-ifdef deployment
-
-.PHONY: deploy restart logs
-
-kdeploy=	deploy/"${deployment}"
-
-deploy: all restart logs
-
-restart:
-	kubectl rollout restart ${kdeploy}
-	kubectl rollout status ${kdeploy}
-	sleep 2
-
-logs:
-	kubectl logs -f ${kdeploy}
-
-else
-
-deploy:
-	: Set $${deployment} for automatic k8s deployment
-
-endif
+include ${mk}/acs.js.mk

--- a/acs-auth/bin/authn.js
+++ b/acs-auth/bin/authn.js
@@ -21,7 +21,7 @@ const authn = await new AuthN({ }).init();
 const authz = await new AuthZ({
     acl_cache:          process.env.ACL_CACHE ?? 5,
     root_principal:     process.env.ROOT_PRINCIPAL,
-    verbose:            !!process.env.VERBOSE,
+    verbose:            process.env.VERBOSE,
 }).init();
 
 const editor = await new Editor({
@@ -41,6 +41,7 @@ const api = await new WebAPI({
             revision:       GIT_VERSION,
         },
     },
+    verbose:    process.env.VERBOSE,
     realm:      process.env.REALM,
     hostname:   process.env.HOSTNAME,
     keytab:     process.env.SERVER_KEYTAB,

--- a/acs-auth/bin/load-dump.js
+++ b/acs-auth/bin/load-dump.js
@@ -39,7 +39,7 @@ const dumps = process.argv.slice(2)
     .map(f => [f, loadJSONobj(f)])
     .filter(([f, d]) => d.service == UUIDs.Service.Authentication);
 
-const model = await new Model({ verbose: !!process.env.VERBOSE }).init();
+const model = await new Model({ verbose: process.env.VERBOSE }).init();
 
 for (const [file, dump] of dumps) {
     console.log(`Loading dump ${file}...`);

--- a/acs-auth/lib/authz.js
+++ b/acs-auth/lib/authz.js
@@ -14,7 +14,6 @@ import {Perm} from "./uuids.js";
 const UUID_rx = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 const KRB_rx = /^[a-zA-Z0-9_./-]+@[A-Z0-9-.]+$/;
 
-const debug = new Debug();
 const booleans = {
     undefined: false,
     "true": true, "false": false,
@@ -26,20 +25,21 @@ const booleans = {
 function valid_uuid(uuid) {
     if (UUID_rx.test(uuid))
         return true;
-    debug.log("debug", `Ignoring invalid UUID [${uuid}]`);
+    //debug.log("debug", `Ignoring invalid UUID [${uuid}]`);
     return false;
 }
 
 function valid_krb(krb) {
     if (KRB_rx.test(krb))
         return true;
-    debug.log("debug", `Ignoring invalid principal [${krb}]`);
+    //debug.log("debug", `Ignoring invalid principal [${krb}]`);
     return false;
 }
 
 export default class AuthZ {
     constructor(opts) {
-        this.model = new Model(opts);
+        this.debug  = new Debug(opts);
+        this.model  = new Model(opts);
         this.routes = express.Router();
     }
 
@@ -268,7 +268,7 @@ export default class AuthZ {
         const dump = req.body;
 
         if (!this.model.dump_validate(dump)) {
-            debug.log("dump", "Dump failed initial validation");
+            this.debug.log("dump", "Dump failed initial validation");
             return res.status(400).end();
         }
 
@@ -282,7 +282,7 @@ export default class AuthZ {
                 const ok = await this.model.check_acl(
                     req.auth, perm, UUIDs.Null, false);
                 if (!ok) {
-                    debug.log("dump", "Refusing dump: %s needs permission to set %s",
+                    this.debug.log("dump", "Refusing dump: %s needs permission to set %s",
                         req.auth, key);
                     return res.status(403).end();
                 }

--- a/acs-auth/lib/model.js
+++ b/acs-auth/lib/model.js
@@ -9,16 +9,15 @@ import {DB, Debug, UUIDs} from "@amrc-factoryplus/utilities";
 import Queries from "./queries.js";
 import {Perm} from "./uuids.js";
 
-const debug = new Debug();
-
 export default class Model extends Queries {
     constructor(opts) {
         const db = new DB({
             version: Queries.DBVersion,
-            verbose: opts.verbose,
         });
 
         super(db.query.bind(db))
+
+        this.debug = new Debug(opts);
 
         this.db = db;
         this.acl_cache_age = opts.acl_cache * 1000;
@@ -47,7 +46,7 @@ export default class Model extends Queries {
         const now = Date.now();
         const cached = cache.get(key);
         if (cached) {
-            debug.log("acl", `Cached result ${cached.expiry} (${cached.expiry - now})`);
+            this.debug.log("acl", `Cached result ${cached.expiry} (${cached.expiry - now})`);
             if (cached.expiry > now)
                 return cached.result;
             cache.delete(key);

--- a/acs-auth/package.json
+++ b/acs-auth/package.json
@@ -21,7 +21,7 @@
   "author": "AMRC",
   "license": "MIT",
   "dependencies": {
-    "@amrc-factoryplus/utilities": "^1.0.8",
+    "@amrc-factoryplus/utilities": "^2.0.0",
     "express": "^4.18.1",
     "express-basic-auth": "^1.2.1",
     "http-errors": "^2.0.0",

--- a/acs-base-images/Dockerfile.pg-build
+++ b/acs-base-images/Dockerfile.pg-build
@@ -5,8 +5,9 @@
 # support.
 
 ARG version
+ARG base=ghcr.io/amrc-factoryplus/acs-base
 
-FROM ghcr.io/amrc-factoryplus/acs-base-js-build:${version}
+FROM ${base}-js-build:${version}
 
 # This must be here to show up in RUN
 ARG pg_version=16.1

--- a/acs-base-images/Dockerfile.pg-run
+++ b/acs-base-images/Dockerfile.pg-run
@@ -5,10 +5,11 @@
 # support.
 
 ARG version
+ARG base=ghcr.io/amrc-factoryplus/acs-base
 
-FROM ghcr.io/amrc-factoryplus/acs-base-pg-build:${version} AS build
+FROM ${base}-pg-build:${version} AS build
 
-FROM ghcr.io/amrc-factoryplus/acs-base-js-run:${version}
+FROM ${base}-js-run:${version}
 
 # Install system packages we need for runtime.
 RUN <<'SHELL'

--- a/acs-base-images/Makefile
+++ b/acs-base-images/Makefile
@@ -1,42 +1,35 @@
-# On Windows try https://frippery.org/busybox/
+top=..
+include ${top}/mk/acs.init.mk
 
--include config.mk
-
-version?=v0.0.1
-suffix?=
+# We aren't using acs.docker.mk, so these all need to be here too
+version?=${git.tag}
 registry?=ghcr.io/amrc-factoryplus
-base?=acs-base
-docker?=docker
+repo?=acs-base
+suffix?=
 
-images=	js-build js-run pg-build pg-run
+images=		js-build js-run pg-build pg-run
+tag.base=	${registry}/${repo}
+tag.version=	${version}${suffix}
 
-tag_start=${registry}/${base}-
-tag_end=:${version}${suffix}
-build_args=	--build-arg base=${registry}/${base} \
-		--build-arg version=${version}${suffix}
+build_args+=	--build-arg base=${tag.base}
+build_args+= 	--build-arg version=${tag.version}
 
-ifdef acs_npm
-build_args+=--build-arg acs_npm="${acs_npm}"
-endif
+include ${mk}/acs.git.mk
+
+.PHONY: build push
 
 all: build push
 
-.PHONY: all build push check-committed amend
-
-check-committed:
-	[ -z "$$(git status --porcelain)" ] || (git status; exit 1)
-
-amend:
-	git commit -a -C HEAD --amend
-
-build: check-committed
+# Yuck. This is where I miss BSD make...
+build: git.prepare
 	for i in ${images}; do \
-	    ${docker} build -t ${tag_start}$${i}${tag_end} \
-	        -f Dockerfile.$${i} ${build_args} .; \
+	    t="${tag.base}-$$i:${tag.version}"; \
+	    docker build -t $$t -f Dockerfile.$$i ${build_args} .; \
 	done
 
 push:
 	for i in ${images}; do \
-	    ${docker} push ${tag_start}$${i}${tag_end}; \
+	    t="${tag.base}-$$i:${tag.version}"; \
+	    docker push $$t; \
 	done
 

--- a/acs-cluster-manager/Makefile
+++ b/acs-cluster-manager/Makefile
@@ -1,58 +1,7 @@
-# On Windows try https://frippery.org/busybox/
+top=..
+include ${top}/mk/acs.init.mk
 
--include config.mk
-
-release!=git describe --tags --abbrev=0
-
-version?=${release}
-suffix?=
-base_version?=${release}
-registry?=ghcr.io/amrc-factoryplus
 repo?=acs-cluster-manager
-docker?=docker
+k8s.deployment?=cluster-manager
 
-tag=${registry}/${repo}:${version}${suffix}
-build_args=
-
-build_args+=--build-arg base_version="${base_version}"
-
-ifdef acs_npm
-build_args+=--build-arg acs_npm="${acs_npm}"
-endif
-
-all: build push
-
-.PHONY: all build push check-committed
-
-check-committed:
-	[ -z "$$(git status --porcelain)" ] || (git status; exit 1)
-
-build: check-committed
-	docker build -t "${tag}" ${build_args} .
-
-push:
-	docker push "${tag}"
-
-run:
-	docker run -ti --rm "${tag}" /bin/sh
-
-.PHONY: deploy restart logs
-
-ifdef deployment
-
-deploy: all restart logs
-
-restart:
-	kubectl rollout restart deploy/"${deployment}"
-	kubectl rollout status deploy/"${deployment}"
-	sleep 2
-
-logs:
-	kubectl logs ${logs_opts} -f deploy/"${deployment}"
-
-else
-
-deploy restart logs:
-	: Set $${deployment} for automatic k8s deployment
-
-endif
+include ${mk}/acs.js.mk

--- a/acs-cmdesc/Dockerfile
+++ b/acs-cmdesc/Dockerfile
@@ -2,6 +2,7 @@ ARG base_version
 ARG base_prefix=ghcr.io/amrc-factoryplus/acs-base
 
 FROM ${base_prefix}-js-build:${base_version} AS build
+ARG acs_npm=NO
 
 # Install the node application on the build container where we can
 # compile the native modules.
@@ -9,8 +10,19 @@ RUN install -d -o node -g node /home/node/app
 WORKDIR /home/node/app
 USER node
 COPY package*.json ./
-RUN npm install --save=false
-COPY . .
+RUN <<'SHELL'
+    touch /home/node/.npmrc
+    if [ "${acs_npm}" != NO ]
+    then
+        npm config set @amrc-factoryplus:registry "${acs_npm}"
+    fi
+
+    npm install --save=false
+SHELL
+COPY --chown=node . .
+RUN <<'SHELL'
+    echo "export const GIT_VERSION=\"$revision\";" > ./lib/git-version.js
+SHELL
 
 FROM ${base_prefix}-js-run:${base_version}
 

--- a/acs-cmdesc/Makefile
+++ b/acs-cmdesc/Makefile
@@ -1,58 +1,7 @@
-# On Windows try https://frippery.org/busybox/
+top=..
+include ${top}/mk/acs.init.mk
 
--include config.mk
-
-pkgver!=node -e 'console.log(JSON.parse(fs.readFileSync("package.json")).version)'
-
-version?=v${pkgver}
-suffix?=
-registry?=ghcr.io/amrc-factoryplus
 repo?=acs-cmdesc
+k8s.deployment?=cmdescd
 
-tag=${registry}/${repo}:${version}${suffix}
-build_args=
-
-ifdef acs_base
-build_args+=--build-arg acs_base="${acs_base}"
-endif
-
-ifdef acs_npm
-build_args+=--build-arg acs_npm="${acs_npm}"
-endif
-
-all: build push
-
-.PHONY: all build push check-committed
-
-check-committed:
-	[ -z "$$(git status --porcelain)" ] || (git status; exit 1)
-
-build: check-committed
-	docker build -t "${tag}" ${build_args} .
-
-push:
-	docker push "${tag}"
-
-run:
-	docker run -ti --rm "${tag}" /bin/sh
-
-.PHONY: deploy restart logs
-
-ifdef deployment
-
-deploy: all restart logs
-
-restart:
-	kubectl rollout restart deploy/"${deployment}"
-	kubectl rollout status deploy/"${deployment}"
-	sleep 2
-
-logs:
-	kubectl logs -f deploy/"${deployment}"
-
-else
-
-deploy restart logs:
-	: Set $${deployment} for automatic k8s deployment
-
-endif
+include ${mk}/acs.js.mk

--- a/acs-cmdesc/bin/cmdescd.js
+++ b/acs-cmdesc/bin/cmdescd.js
@@ -4,21 +4,21 @@
  * Copyright 2022 AMRC
  */
 
-import { ServiceClient, WebAPI, pkgVersion } from "@amrc-factoryplus/utilities";
+import { ServiceClient }    from "@amrc-factoryplus/service-client";
+import { WebAPI }           from "@amrc-factoryplus/utilities";
 
+import { GIT_VERSION } from "../lib/git-version.js";
 import ApiV1 from "../lib/api_v1.js";
 import CmdEscD from "../lib/cmdescd.js";
 import MqttCli from "../lib/mqttcli.js";
 
 const Service_Cmdesc = "78ea7071-24ac-4916-8351-aa3e549d8ccd";
+/* This is the service spec version, not the implementation version */
+const Version = "1.0.2";
 
-const Version = pkgVersion(import.meta);
 const Device_UUID = process.env.DEVICE_UUID;
 
-const fplus = await new ServiceClient({
-    root_principal:     process.env.ROOT_PRINCIPAL,
-    directory_url:      process.env.DIRECTORY_URL,
-}).init();
+const fplus = await new ServiceClient({ env: process.env }).init();
 
 const cmdesc = await new CmdEscD({
     fplus,
@@ -41,7 +41,13 @@ const web = await new WebAPI({
         version:    Version,
         service:    Service_Cmdesc,
         device:     Device_UUID,
+        software: {
+            vendor:         "AMRC",
+            application:    "acs-cmdesc",
+            revision:       GIT_VERSION,
+        },
     },
+    verbose:    process.env.VERBOSE,
     realm:      process.env.REALM,
     hostname:   process.env.HOSTNAME,
     keytab:     process.env.SERVER_KEYTAB,

--- a/acs-cmdesc/lib/cmdescd.js
+++ b/acs-cmdesc/lib/cmdescd.js
@@ -9,12 +9,11 @@ import {Address, Debug, UUIDs,} from "@amrc-factoryplus/utilities";
 const CCL_Perms = "9584ee09-a35a-4278-bc13-21a8be1f007c";
 const CCL_Template = "60e99f28-67fe-4344-a6ab-b1edb8b8e810";
 
-const debug = new Debug();
-
 export default class CmdEscD {
     constructor(opts) {
         this.fplus = opts.fplus;
         this.root = this.fplus.Auth.root_principal;
+        this.log = this.fplus.debug.log.bind(this.fplus.debug);
     }
 
     async init() {
@@ -27,7 +26,7 @@ export default class CmdEscD {
 
     async find_principal_for_address(from) {
         if (from.isDevice()) {
-            debug.log("cmdesc", "Cannot authorise request from a Device");
+            this.log("cmdesc", "Cannot authorise request from a Device");
             return;
         }
 
@@ -40,23 +39,23 @@ export default class CmdEscD {
             },
         });
         if (!res.ok) {
-            debug.log("cmdesc", `Failed to look up address ${from}: ${res.status}`);
+            this.log("cmdesc", `Failed to look up address ${from}: ${res.status}`);
             return;
         }
         const json = await res.json();
 
         switch (json.length) {
             case 0:
-                debug.log("cmdesc", `No UUID found for address ${from}`);
+                this.log("cmdesc", `No UUID found for address ${from}`);
                 return;
             case 1:
                 break;
             default:
-                debug.log("cmdesc", `More than one UUID found for address ${from}`);
+                this.log("cmdesc", `More than one UUID found for address ${from}`);
                 return;
         }
 
-        debug.log("cmdesc", `Request from ${from} = ${json[0]}`);
+        this.log("cmdesc", `Request from ${from} = ${json[0]}`);
         return json[0];
     }
 
@@ -71,7 +70,7 @@ export default class CmdEscD {
             },
         });
         if (!res.ok) {
-            debug.log("acl", `Can't get ACL for ${princ}: ${res.status}`);
+            this.log("acl", `Can't get ACL for ${princ}: ${res.status}`);
             return [];
         }
 
@@ -132,7 +131,7 @@ export default class CmdEscD {
      */
     async execute_command(from, to, cmd) {
         const log = stat => {
-            debug.log("cmdesc", `${stat}: ${from} -> ${to}[${cmd.name} = ${cmd.value}]`);
+            this.log("cmdesc", `${stat}: ${from} -> ${to}[${cmd.name} = ${cmd.value}]`);
             return stat;
         };
 
@@ -145,11 +144,11 @@ export default class CmdEscD {
             from == this.root;
 
         if (is_root) {
-            debug.log("acl", `Granting root rights to ${from}`);
+            this.log("acl", `Granting root rights to ${from}`);
         }
         else {
             const acl = await this.expand_acl(from);
-            debug.log("acl", "ACL for %s: %o", from, acl);
+            this.log("acl", "ACL for %s: %o", from, acl);
 
             const type_ok = cmd.type == undefined
                 ? t => true

--- a/acs-cmdesc/package.json
+++ b/acs-cmdesc/package.json
@@ -22,7 +22,7 @@
     "start": "node bin/cmdescd.js"
   },
   "dependencies": {
-    "@amrc-factoryplus/utilities": "^1.3.1",
+    "@amrc-factoryplus/utilities": "2.0.0",
     "@isaacs/ttlcache": "^1.2.0",
     "express": "^4.18.1",
     "express-basic-auth": "^1.2.1",

--- a/acs-configdb/Makefile
+++ b/acs-configdb/Makefile
@@ -1,58 +1,7 @@
-# On Windows try https://frippery.org/busybox/
+top=..
+include ${top}/mk/acs.init.mk
 
--include config.mk
-
-pkgver!=node -e 'console.log(JSON.parse(fs.readFileSync("package.json")).version)'
-
-version?=v${pkgver}
-suffix?=
-registry?=ghcr.io/amrc-factoryplus
 repo?=acs-configdb
+k8s.deployment?=configdb
 
-tag=${registry}/${repo}:${version}${suffix}
-build_args=
-
-ifdef acs_base
-build_args+=--build-arg acs_base="${acs_base}"
-endif
-
-ifdef acs_npm
-build_args+=--build-arg acs_npm="${acs_npm}"
-endif
-
-all: build push
-
-.PHONY: all build push check-committed
-
-check-committed:
-	[ -z "$$(git status --porcelain)" ] || (git status; exit 1)
-
-build: check-committed
-	docker build -t "${tag}" ${build_args} .
-
-push:
-	docker push "${tag}"
-
-run:
-	docker run -ti --rm "${tag}" /bin/sh
-
-.PHONY: deploy restart logs
-
-ifdef deployment
-
-deploy: all restart logs
-
-restart:
-	kubectl rollout restart deploy/"${deployment}"
-	kubectl rollout status deploy/"${deployment}"
-	sleep 2
-
-logs:
-	kubectl logs -f deploy/"${deployment}"
-
-else
-
-deploy restart logs:
-	: Set $${deployment} for automatic k8s deployment
-
-endif
+include ${mk}/acs.js.mk

--- a/acs-configdb/lib/api-v1/controller.js
+++ b/acs-configdb/lib/api-v1/controller.js
@@ -6,7 +6,7 @@
 import content_type from "content-type";
 import express from "express";
 
-import {Debug, UUIDs} from "@amrc-factoryplus/utilities";
+import { UUIDs } from "@amrc-factoryplus/service-client";
 
 import * as etags from "../etags.js";
 
@@ -21,8 +21,6 @@ const Perm = {
     Delete_Obj: "6957174b-7b08-45ca-ac5c-c03ab6928a6e",
     Manage_App: "95c7cbcb-ce60-49ed-aa81-2fe3eec4559d",
 };
-
-const debug = new Debug();
 
 function compat(dest) {
     const pieces = dest.split("/");
@@ -56,8 +54,13 @@ function json_value(str) {
 export default class API {
     constructor(opts) {
         this.fplus = opts.fplus_client;
-        this.model = new Model(opts);
+
+        this.log = this.fplus.debug.log.bind(this.fplus.debug);
+
         this.routes = express.Router();
+        this.model = new Model({
+            log:    this.log,
+        });
     }
 
     async init() {
@@ -407,7 +410,7 @@ export default class API {
                 const ok = await this._check_acl(
                     req.auth, perm, UUIDs.Null, false);
                 if (!ok) {
-                    debug.log("dump", "Refusing dump (%s)", key);
+                    this.log("dump", "Refusing dump (%s)", key);
                     return res.status(403).end();
                 }
             }

--- a/acs-configdb/package.json
+++ b/acs-configdb/package.json
@@ -19,11 +19,9 @@
   },
   "type": "module",
   "dependencies": {
-    "@amrc-factoryplus/utilities": "^1.3.1",
+    "@amrc-factoryplus/utilities": "2.0.0",
     "ajv": "^8.10.0",
     "ajv-formats": "^2.1.1",
-    "content-type": "^1.0.5",
-    "express": "^4.18.1",
     "express-openapi-validator": "^4.13.2",
     "json-merge-patch": "^1.0.2"
   }

--- a/acs-directory/Makefile
+++ b/acs-directory/Makefile
@@ -2,19 +2,18 @@
 
 -include config.mk
 
-pkgver!=node -e 'console.log(JSON.parse(fs.readFileSync("package.json")).version)'
+release!=git describe --tags --abbrev=0
 
-version?=v${pkgver}
+version?=${release}
 suffix?=
+base_version?=${release}
 registry?=ghcr.io/amrc-factoryplus
 repo?=acs-directory
 
 tag=${registry}/${repo}:${version}${suffix}
-build_args=
 
-ifdef acs_base
-build_args+=--build-arg acs_base="${acs_base}"
-endif
+build_args=
+build_args+=--build-arg base_version="${base_version}"
 
 ifdef acs_npm
 build_args+=--build-arg acs_npm="${acs_npm}"

--- a/acs-directory/Makefile
+++ b/acs-directory/Makefile
@@ -1,57 +1,9 @@
-# On Windows try https://frippery.org/busybox/
+top=..
+include ${top}/mk/acs.init.mk
 
--include config.mk
-
-release!=git describe --tags --abbrev=0
-
-version?=${release}
-suffix?=
-base_version?=${release}
-registry?=ghcr.io/amrc-factoryplus
 repo?=acs-directory
 
-tag=${registry}/${repo}:${version}${suffix}
+# Let's go with the web API as default.
+k8s.deployment?=directory-webapi
 
-build_args=
-build_args+=--build-arg base_version="${base_version}"
-
-ifdef acs_npm
-build_args+=--build-arg acs_npm="${acs_npm}"
-endif
-
-all: build push
-
-.PHONY: all build push check-committed
-
-check-committed:
-	[ -z "$$(git status --porcelain)" ] || (git status; exit 1)
-
-build: check-committed
-	docker build -t "${tag}" ${build_args} .
-
-push:
-	docker push "${tag}"
-
-run:
-	docker run -ti --rm "${tag}" /bin/sh
-
-.PHONY: deploy restart logs
-
-ifdef deployment
-
-deploy: all restart logs
-
-restart:
-	kubectl rollout restart deploy/"${deployment}"
-	kubectl rollout status deploy/"${deployment}"
-	sleep 2
-
-logs:
-	kubectl logs -f deploy/"${deployment}"
-
-else
-
-deploy restart logs:
-	: Set $${deployment} for automatic k8s deployment
-
-endif
+include ${mk}/acs.js.mk

--- a/acs-directory/bin/directory-mqtt.js
+++ b/acs-directory/bin/directory-mqtt.js
@@ -6,7 +6,7 @@
  * Copyright 2021 AMRC.
  */
 
-import { ServiceClient } from "@amrc-factoryplus/utilities";
+import { ServiceClient } from "@amrc-factoryplus/service-client";
 
 import MQTTCli from "../lib/mqttcli.js";
 import Model from "../lib/model.js";
@@ -17,7 +17,7 @@ const model = await new Model({
     verbose: true,
 }).init();
 
-const fplus = new ServiceClient({});
+const fplus = new ServiceClient({ env: process.env });
 fplus.set_service_discovery(model.find_service_url.bind(model));
 
 const app = await new MQTTCli({

--- a/acs-directory/bin/directory-webapi.js
+++ b/acs-directory/bin/directory-webapi.js
@@ -6,7 +6,8 @@
  * Copyright 2021 AMRC.
  */
 
-import { ServiceClient, WebAPI, UUIDs } from "@amrc-factoryplus/utilities";
+import { ServiceClient, UUIDs } from "@amrc-factoryplus/service-client";
+import { WebAPI }               from "@amrc-factoryplus/utilities";
 
 import Model from "../lib/model.js";
 import APIv1 from "../lib/api_v1.js";
@@ -22,7 +23,7 @@ const model = await new Model({
 }).init();
 
 const fplus = new ServiceClient({
-    root_principal:     process.env.ROOT_PRINCIPAL,
+    env:    process.env,
     permission_group:   Perm.All,
 });
 fplus.set_service_discovery(model.find_service_url.bind(model));
@@ -44,6 +45,7 @@ const app = await new WebAPI({
             revision:       GIT_VERSION,
         },
     },
+    verbose:    process.env.VERBOSE,
     keytab:     process.env.SERVER_KEYTAB,
     http_port:  process.env.PORT,
     max_age:    process.env.CACHE_MAX_AGE,

--- a/acs-directory/package.json
+++ b/acs-directory/package.json
@@ -19,7 +19,7 @@
     "webapi": "node bin/directory-webapi"
   },
   "dependencies": {
-    "@amrc-factoryplus/utilities": "^1.3.1",
+    "@amrc-factoryplus/utilities": "2.0.0-bmz2",
     "async": "^3.2.4",
     "express": "^4.17.1",
     "express-openapi-validator": "^4.13.2"

--- a/acs-directory/package.json
+++ b/acs-directory/package.json
@@ -19,7 +19,7 @@
     "webapi": "node bin/directory-webapi"
   },
   "dependencies": {
-    "@amrc-factoryplus/utilities": "2.0.0-bmz2",
+    "@amrc-factoryplus/utilities": "2.0.0",
     "async": "^3.2.4",
     "express": "^4.17.1",
     "express-openapi-validator": "^4.13.2"

--- a/acs-edge-monitor/Makefile
+++ b/acs-edge-monitor/Makefile
@@ -1,71 +1,9 @@
-# On Windows try https://frippery.org/busybox/
+top=..
+include ${top}/mk/acs.init.mk
 
--include config.mk
-
-pkgver!=node -e 'console.log(JSON.parse(fs.readFileSync("package.json")).version)'
-
-version?=v${pkgver}
-suffix?=
-registry?=ghcr.io/amrc-factoryplus
 repo?=acs-edge-monitor
+k8s.deployment?=edge-monitor
 
-kubectl?= kubectl
+eslint=	bin lib
 
-tag=${registry}/${repo}:${version}${suffix}
-build_args=
-
-ifdef acs_build
-build_args+=--build-arg acs_build="${acs_build}"
-endif
-
-ifdef acs_run
-build_args+=--build-arg acs_run="${acs_run}"
-endif
-
-ifdef acs_npm
-build_args+=--build-arg acs_npm="${acs_npm}"
-endif
-
-
-all: build push
-
-.PHONY: all build push check-committed lint amend
-
-check-committed:
-	[ -z "$$(git status --porcelain)" ] || (git status; exit 1)
-
-lint:
-	npx eslint bin lib
-
-amend:
-	git commit -a -C HEAD --amend
-
-build: check-committed lint
-	docker build -t "${tag}" ${build_args} .
-
-push:
-	docker push "${tag}"
-
-run:
-	docker run -ti --rm "${tag}" /bin/sh
-
-.PHONY: deploy restart logs
-
-ifdef deployment
-
-deploy: all restart logs
-
-restart:
-	${kubectl} rollout restart deploy/"${deployment}"
-	${kubectl} rollout status deploy/"${deployment}"
-	sleep 2
-
-logs:
-	${kubectl} logs -f deploy/"${deployment}"
-
-else
-
-deploy restart logs:
-	: Set $${deployment} for automatic k8s deployment
-
-endif
+include ${mk}/acs.js.mk

--- a/acs-edge-sync/Makefile
+++ b/acs-edge-sync/Makefile
@@ -1,68 +1,7 @@
-# On Windows try https://frippery.org/busybox/
+top=..
+include ${top}/mk/acs.init.mk
 
--include config.mk
-
-pkgver!=node -e 'console.log(JSON.parse(fs.readFileSync("package.json")).version)'
-
-version?=v${pkgver}
-suffix?=
-registry?=ghcr.io/amrc-factoryplus
 repo?=acs-edge-sync
+k8s.deployment?=edge-sync
 
-kubectl?= kubectl
-
-tag=${registry}/${repo}:${version}${suffix}
-build_args=
-
-ifdef acs_build
-build_args+=--build-arg acs_build="${acs_build}"
-endif
-
-ifdef acs_run
-build_args+=--build-arg acs_run="${acs_run}"
-endif
-
-ifdef acs_npm
-build_args+=--build-arg acs_npm="${acs_npm}"
-endif
-
-
-all: build push
-
-.PHONY: all build push check-committed amend
-
-check-committed:
-	[ -z "$$(git status --porcelain)" ] || (git status; exit 1)
-
-amend:
-	git commit -a -C HEAD --amend
-
-build: check-committed
-	docker build -t "${tag}" ${build_args} .
-
-push:
-	docker push "${tag}"
-
-run:
-	docker run -ti --rm "${tag}" /bin/sh
-
-.PHONY: deploy restart logs
-
-ifdef deployment
-
-deploy: all restart logs
-
-restart:
-	${kubectl} rollout restart deploy/"${deployment}"
-	${kubectl} rollout status deploy/"${deployment}"
-	sleep 2
-
-logs:
-	${kubectl} logs -f deploy/"${deployment}"
-
-else
-
-deploy restart logs:
-	: Set $${deployment} for automatic k8s deployment
-
-endif
+include ${mk}/acs.js.mk

--- a/acs-edge/Makefile
+++ b/acs-edge/Makefile
@@ -1,60 +1,7 @@
-# On Windows try https://frippery.org/busybox/
+top=..
+include ${top}/mk/acs.init.mk
 
--include config.mk
-
-pkgver!=node -e 'console.log(JSON.parse(fs.readFileSync("package.json")).version)'
-
-version?=v${pkgver}
-suffix?=
-registry?=ghcr.io/amrc-factoryplus
 repo?=acs-edge
+# Don't set k8s.deployment, the deployment doesn't have a fixed name.
 
-tag=${registry}/${repo}:${version}${suffix}
-build_args=
-
-ifdef acs_build
-build_args+=--build-arg acs_build="${acs_build}"
-endif
-
-ifdef acs_run
-build_args+=--build-arg acs_run="${acs_run}"
-endif
-
-ifdef acs_npm
-build_args+=--build-arg acs_npm="${acs_npm}"
-endif
-
-all: build push
-
-.PHONY: all build push
-
-build:
-	[ -z "$$(git status --porcelain)" ] || (git status; exit 1)
-	docker build -t "${tag}" ${build_args} .
-
-push:
-	docker push "${tag}"
-
-run:
-	docker run -ti --rm "${tag}" /bin/sh
-
-.PHONY: deploy restart logs
-
-ifdef deployment
-
-deploy: all restart logs
-
-restart:
-	kubectl rollout restart deploy/"${deployment}"
-	kubectl rollout status deploy/"${deployment}"
-	sleep 2
-
-logs:
-	kubectl logs -f deploy/"${deployment}"
-
-else
-
-deploy restart logs:
-	: Set $${deployment} for automatic k8s deployment
-
-endif
+include ${mk}/acs.js.mk

--- a/acs-edge/lib/sparkplugNode.ts
+++ b/acs-edge/lib/sparkplugNode.ts
@@ -92,7 +92,7 @@ export class SparkplugNode extends (
             + (Math.random() * 1e17).toString(36);
 
         // conf.keepalive = 10;
-        this.#client = fplus.MQTT.basic_sparkplug_node({
+        this.#client = await fplus.MQTT.basic_sparkplug_node({
             address,
             clientId,
             publishDeath:   true,

--- a/acs-git/Makefile
+++ b/acs-git/Makefile
@@ -1,64 +1,9 @@
-# On Windows try https://frippery.org/busybox/
+top=..
+include ${top}/mk/acs.init.mk
 
--include config.mk
-
-release!=git describe --tags --abbrev=0
-
-version?=${release}
-suffix?=
-base_version?=${release}
-registry?=ghcr.io/amrc-factoryplus
 repo?=acs-git
-docker?=docker
+k8s.deployment?=git
 
-tag=${registry}/${repo}:${version}${suffix}
-build_args=
+eslint=	bin lib
 
-build_args+=--build-arg base_version="${base_version}"
-
-ifdef acs_npm
-build_args+=--build-arg acs_npm="${acs_npm}"
-endif
-
-all: build push
-
-.PHONY: all build push check-committed lint amend
-
-check-committed:
-	[ -z "$$(git status --porcelain)" ] || (git status; exit 1)
-
-lint:
-	npx eslint bin lib
-
-amend:
-	git commit -a -C HEAD --amend
-
-build: check-committed lint
-	${docker} build -t "${tag}" ${build_args} .
-
-push:
-	${docker} push "${tag}"
-
-run:
-	${docker} run -ti --rm "${tag}" /bin/sh
-
-.PHONY: deploy restart logs
-
-ifdef deployment
-
-deploy: all restart logs
-
-restart:
-	kubectl rollout restart deploy/"${deployment}"
-	kubectl rollout status deploy/"${deployment}"
-	sleep 2
-
-logs:
-	kubectl logs -f deploy/"${deployment}"
-
-else
-
-deploy restart logs:
-	: Set $${deployment} for automatic k8s deployment
-
-endif
+include ${mk}/acs.js.mk

--- a/acs-git/lib/sparkplug.js
+++ b/acs-git/lib/sparkplug.js
@@ -61,7 +61,7 @@ export class SparkplugNode {
     connect_sparkplug () {
         const { ids, fplus } = this;
 
-        const cli = fplus.MQTT.basic_sparkplug_node({
+        const cli = await fplus.MQTT.basic_sparkplug_node({
             address:        ids.sparkplug,
             clientId:       ids.uuid,
             publishDeath:   true,

--- a/acs-identity/Makefile
+++ b/acs-identity/Makefile
@@ -1,0 +1,7 @@
+top=..
+include ${top}/mk/acs.init.mk
+
+repo?=acs-identity
+k8s.deployment?=kdc
+
+include ${mk}/acs.docker.mk

--- a/acs-krb-keys-operator/Makefile
+++ b/acs-krb-keys-operator/Makefile
@@ -1,48 +1,9 @@
-# On Windows try https://frippery.org/busybox/
+top=..
+include ${top}/mk/acs.init.mk
 
--include config.mk
+repo?=acs-krb-keys-operator
 
-version?=v1.3.1
-suffix?=
-registry?=ghcr.io/amrc-factoryplus
-repo?=acs-kerberos-keys
+# Edge krbkeys are called `krb-keys` instead
+k8s.deployment?=krb-keys-operator
 
-kubectl?=kubectl
-
-tag=${registry}/${repo}:${version}${suffix}
-
-all: build push
-
-.PHONY: all build push run
-
-build:
-	[ -z "$$(git status --porcelain)" ] || (git status; exit 1)
-	docker build -t "${tag}" .
-
-push:
-	docker push "${tag}"
-
-run:
-	docker run -ti --rm -v "$$(pwd)":/local "${tag}" /bin/sh
-
-
-ifdef deployment
-
-.PHONY: deploy restart logs
-
-deploy: all restart logs
-
-restart:
-	${kubectl} rollout restart deploy/"${deployment}"
-	${kubectl} rollout status deploy/"${deployment}"
-	sleep 2
-
-logs:
-	${kubectl} logs -f deploy/"${deployment}" -c operator
-
-else
-
-deploy:
-	: Set $${deployment} for automatic k8s deployment
-
-endif
+include ${mk}/acs.docker.mk

--- a/acs-krb-utils/Makefile
+++ b/acs-krb-utils/Makefile
@@ -1,0 +1,6 @@
+top=..
+include ${top}/mk/acs.init.mk
+
+repo?=acs-krb-utils
+
+include ${mk}/acs.docker.mk

--- a/acs-mqtt/Makefile
+++ b/acs-mqtt/Makefile
@@ -1,30 +1,27 @@
--include config.mk
+top=..
+include ${top}/mk/acs.init.mk
 
-registry?=	ghcr.io/amrc-factoryplus
-repository?=	acs-mqtt
-version?= 	v1.1.1
-suffix?=
+repo?=acs-mqtt
+k8s.deployment?=mqtt
 
-image=	${registry}/${repository}:${version}${suffix}
 env= 	JAVA_HOME='${JAVA_HOME}' M2_HOME='${M2_HOME}' M2='${M2_HOME}/bin'
-mvn=	'${M2_HOME}'/bin/mvn
+mvn?=	'${M2_HOME}'/bin/mvn
 
-pluginver!=	cd hivemq-krb && \
+src=	../hivemq-krb
+
+pluginver!=	cd ${src} && \
 	${env} ${mvn} -q help:evaluate -Dexpression=project.version -DforceStdout
+
 zip=hivemq-auth-krb-${pluginver}-distribution.zip
 
+build_args+=	krb_zipfile=${zip}
 
-.PHONY: all build-plugin build-image update
+include ${mk}/acs.docker.mk
 
-all:	build-plugin build-image
+.PHONY: build-plugin
 
-update:
-	git submodule update --remote
+build: build-plugin
 
-build-plugin:
-	cd hivemq-krb && ${env} ${mvn} -B package
-	cp hivemq-krb/target/${zip} .
-
-build-image:
-	docker build -t ${image} --build-arg krb_zipfile=${zip} .
-	docker push ${image}
+build-plugin: git.prepare
+	cd ${src} && ${env} ${mvn} -B package
+	cp ${src}/target/${zip} .

--- a/acs-service-setup/Makefile
+++ b/acs-service-setup/Makefile
@@ -1,70 +1,13 @@
-# On Windows try https://frippery.org/busybox/
+top=..
+include ${top}/mk/acs.init.mk
 
--include config.mk
-
-pkgver!=node -e 'console.log(JSON.parse(fs.readFileSync("package.json")).version)'
-
-version?=v${pkgver}
-suffix?=
-registry?=ghcr.io/amrc-factoryplus
 repo?=acs-service-setup
-docker?=docker
-kubectl?=kubectl
 
-tag=${registry}/${repo}:${version}${suffix}
+eslint=	bin lib
 
-build_args=
+include ${mk}/acs.js.mk
 
-ifdef acs_base
-build_args+=--build-arg acs_base="${acs_base}"
-endif
+lint: check-yaml
 
-ifdef acs_npm
-build_args+=--build-arg acs_npm="${acs_npm}"
-endif
-
-all: build push
-
-.PHONY: all build push check-committed pull
-
-check-committed:
-	[ -z "$$(git status --porcelain)" ] || (git status; exit 1)
-
-pull:
-	git pull --ff-only
-
-lint:
-	npx eslint bin lib
+check-yaml:
 	node bin/check-yaml.js
-
-ifdef pull
-build: check-committed pull lint
-else
-build: check-committed lint
-endif
-	${docker} build -t "${tag}" ${build_args} .
-
-push:
-	${docker} push "${tag}"
-
-run:
-	${docker} run -ti --rm "${tag}" /bin/sh
-
-.PHONY: deploy run-job logs
-
-ifdef job_name
-
-deploy: all run-job logs
-
-run-job:
-	kubectl create -f service-setup.yaml
-
-logs:
-	kubectl logs -f job/"${job_name}"
-
-else
-
-deploy run-job logs:
-	: Set $${job_name} for automatic k8s deployment
-
-endif

--- a/acs-visualiser/Makefile
+++ b/acs-visualiser/Makefile
@@ -1,0 +1,7 @@
+top=..
+include ${top}/mk/acs.init.mk
+
+repo?=acs-visualiser
+k8s.deployment?=visualiser
+
+include ${mk}/acs.docker.mk

--- a/influxdb-sparkplug-ingester/Dockerfile
+++ b/influxdb-sparkplug-ingester/Dockerfile
@@ -1,8 +1,11 @@
 # syntax=docker/dockerfile:1
 # The line above must be the first line in the file!
 
-ARG acs_build=ghcr.io/amrc-factoryplus/utilities-build:v1.0.8
-ARG acs_run=ghcr.io/amrc-factoryplus/utilities-run:v1.0.8
+ARG base_version
+ARG base_prefix=ghcr.io/amrc-factoryplus/acs-base
+
+ARG acs_build=${base_prefix}-js-build:${base_version}
+ARG acs_run=${base_prefix}-js-run:${base_version}
 
 FROM ${acs_build} as ts-compiler
 # This ARG must go here, in the image that uses it, or it isn't

--- a/influxdb-sparkplug-ingester/Makefile
+++ b/influxdb-sparkplug-ingester/Makefile
@@ -1,0 +1,7 @@
+top=..
+include ${top}/mk/acs.init.mk
+
+repo?=influxdb-sparkplug-ingester
+k8s.deployment?=influxdb-ingester
+
+include ${mk}/acs.js.mk

--- a/mk/README.md
+++ b/mk/README.md
@@ -1,0 +1,77 @@
+# ACS Makefiles
+
+This is a set of Makefile fragments used for building ACS images for
+local development. Currently they are not used for building ACS
+releases, that is handled by the Github Actions. Consquently there is no
+overall 'build everything' target as that wouldn't be useful at this
+point.
+
+The Makefiles are 'almost POSIX'; please keep them that way. In
+particular please make sure they remain compatible with [GNU
+ake](https://www.gnu.org/software/make/manual/make.html) and [PDP
+Make](https://frippery.org/make/).
+
+## Useful targets
+
+These can be invoked with `make TARGET` from within the relevant
+subdir, or `make -C SUBDIR TARGET` from elsewhere. Adding `-n` will show
+the commands to be run without running them.
+
+* `all`: This is the default target if you just run `make`. This will
+  build and push an image for subdirs that build an image.
+
+* `build`: Just build an image.
+
+* `push`: Just push an image (which must be already built).
+
+* `deploy`: For those subdirs which support this, this will attempt to
+  restart a k8s deployment and show the logs. This requires `KUBECONFIG`
+  to be set properly in the environment.
+
+* `amend`: Amend the last git commit.
+
+## Configuration
+
+The Makefiles all read `config.mk` at the top-level and in their own
+subdir. This can set variables to change the behaviour of the targets.
+Some useful variables are:
+
+* `registry`: The Docker registry to build images under.
+
+* `version`: By default the version number comes from the most recent
+  tag. This will override it.
+
+* `suffix`: This will be appended to the version on the image tag.
+
+* `acs_npm`: An alternative NPM registry to use for `@amrc-factoryplus`.
+
+* `git.allow_dirty`: Set (to anything) to disable the check for a clean
+  working directory.
+
+* `git.pull`: Set (to anything) to run `git pull` before building.
+
+## Writing a Makefile
+
+Every Makefile using this set of Make fragments should follow this
+structure (this is `acs-auth`):
+
+    top=..
+    include ${top}/mk/acs.init.mk
+
+    repo?=acs-auth
+    k8s.deployment?=auth
+
+    include ${mk}/acs.js.mk
+
+The initial two lines should always come first; `top` needs to be set to
+a relative path to the top of the source tree. Including `acs.init.mk`
+sets `mk` to a path to the Makefiles and reads the `config.mk` files.
+
+Then we set variables configuring this build. In this case: `repo` sets
+the repository part of a Docker image name, and `k8s.deployment`
+configures `make deploy`.
+
+Then we include Makefiles to perform a build. `acs.js.mk` is for Docker
+images which include a Javascript service; it pulls in `acs.docker.mk`
+which builds a Docker image. See the Makefiles themselves for more
+details.

--- a/mk/acs.docker.mk
+++ b/mk/acs.docker.mk
@@ -1,0 +1,36 @@
+# Make rules for building Docker images
+
+ifndef .acs.docker.mk
+.acs.docker.mk=1
+
+version?=${git.tag}
+registry?=ghcr.io/amrc-factoryplus
+suffix?=
+
+tag=${registry}/${repo}:${version}${suffix}
+
+build_args+=	--build-arg revision="${git.tag} (${git.sha})"
+
+# `git rev-parse HEAD:directory` gives a SHA for the contents of that
+# directory. In particular, it changes only when changes are made to
+# that directory. This might be usable to only rebuild when the source
+# has changed, or even to retag an existing image from the same
+# source...
+
+.PHONY: build push run
+
+all: build push
+
+build: git.prepare
+	docker build -t "${tag}" ${build_args} .
+
+push:
+	docker push "${tag}"
+
+run:
+	docker run -ti --rm "${tag}" /bin/sh
+
+include ${mk}/acs.git.mk
+include ${mk}/acs.k8s.mk
+
+endif

--- a/mk/acs.git.mk
+++ b/mk/acs.git.mk
@@ -1,0 +1,31 @@
+# Makefile rules for git operations
+
+ifndef .acs.git.mk
+.acs.git.mk=1
+
+git.tag!=git describe --tags --abbrev=0
+git.sha!=git rev-parse --verify HEAD
+
+.PHONY: git.prepare git.check-committed git.pull amend
+
+git.prepare:
+	@:
+
+ifndef git.allow_dirty
+git.prepare: git.check-committed
+endif
+
+ifdef git.pull
+git.prepare: git.pull
+endif
+
+git.check-committed:
+	[ -z "$$(git status --porcelain)" ] || (git status; exit 1)
+
+git.pull:
+	git pull --ff-only
+
+amend:
+	git commit --amend -C HEAD -a
+
+endif

--- a/mk/acs.init.mk
+++ b/mk/acs.init.mk
@@ -1,0 +1,17 @@
+# Set up initial variables for all Makefiles
+
+ifndef .acs.init.mk
+.acs.init.mk=
+
+mk=${top}/mk
+
+-include ${top}/config.mk
+-include config.mk
+
+.PHONY: all
+
+# This is defined here so it becomes the default target.
+# Make sure it stays first.
+all:
+
+endif

--- a/mk/acs.js.mk
+++ b/mk/acs.js.mk
@@ -1,0 +1,30 @@
+# Include this Makefile for JS services
+
+ifndef .acs.js.mk
+.acs.js.mk=1
+
+base_version?=${git.tag}
+
+build_args+=	--build-arg base_version="${base_version}"
+
+ifdef acs_npm
+build_args+=	--build-arg acs_npm="${acs_npm}"
+endif
+
+.PHONY: lint
+
+build: lint
+
+lint:
+	@:
+
+ifdef eslint
+lint: js.eslint
+
+js.eslint:
+	npx eslint ${eslint}
+endif
+
+include ${mk}/acs.docker.mk
+
+endif

--- a/mk/acs.k8s.mk
+++ b/mk/acs.k8s.mk
@@ -1,0 +1,32 @@
+# Makefile rules for automatic K8s deployment
+
+ifndef .acs.k8s.mk
+.acs.k8s.mk=1
+
+.PHONY: deploy restart logs
+
+ifdef k8s.deployment
+
+deploy: all restart logs
+
+restart:
+	kubectl rollout restart deploy/"${k8s.deployment}"
+	kubectl rollout status deploy/"${k8s.deployment}"
+	sleep 2
+
+logs:
+	kubectl logs -f deploy/"${k8s.deployment}"
+
+else
+
+deploy:
+	@: Set k8s.deployment for automatic deployment
+	exit 1
+
+endif
+
+# The Makefile for service-setup had logic to run a Job. However it
+# required a manifest to create the Job; there isn't any sort of 'job
+# template' that can be pushed to k8s and then poked as needed.
+
+endif


### PR DESCRIPTION
This is just housekeeping after the reorganisations we've just done.

* Rework the Makefiles for the monorepo. Now they can be factored out properly rather than being all copy/paste and not up to date with each other.
* Start updating the services to use the broken-out JS libraries. 
* The new `utilities` module no longer reads directly from the environment. Carry this fix through everywhere.