### PR TITLE
Use Node names for Monitor devices

### DIFF
--- a/acs-edge-monitor/lib/monitor.js
+++ b/acs-edge-monitor/lib/monitor.js
@@ -77,7 +77,10 @@ export class Monitor {
         return rxx.k8s_watch({
             k8s,
             kubeconfig:     this.kubeconfig,
-            errors:         e => this.log("SP node watch error: %s", e),
+            errors:         e => {
+                if (!(e instanceof rxx.StoppedError))
+                    this.log("SP node watch error: %s", e);
+            },
             apiVersion:     "factoryplus.app.amrc.co.uk/v1",
             kind:           "SparkplugNode",
             namespace:      this.namespace,

--- a/acs-edge-monitor/lib/node.js
+++ b/acs-edge-monitor/lib/node.js
@@ -51,6 +51,10 @@ export class NodeMonitor {
         return this;
     }
 
+    address () {
+        return rx.firstValueFrom(this.device.address);
+    }
+
     checks () {
         const reporter = this.operator.sparkplug;
 

--- a/acs-edge-monitor/lib/sparkplug.js
+++ b/acs-edge-monitor/lib/sparkplug.js
@@ -92,7 +92,7 @@ export class SparkplugNode {
                 ...mk_instance(device, Schema.Alert, name),
                 { name: `${name}/Type`, type: "UUID", value: type },
                 { name: `${name}/Active`, type: "Boolean", value: value },
-                ...mk_link(`${name}/Links/Node`, type, uuid),
+                ...mk_link(`${name}/Links/Node`, Link.DeviceMonitor, uuid),
             ];
         };
 

--- a/acs-edge-monitor/lib/sparkplug.js
+++ b/acs-edge-monitor/lib/sparkplug.js
@@ -59,7 +59,8 @@ class SparkplugDevice {
 
     check_name (typ) {
         if (!this.name) {
-            this.log("Unable to publish %s, I have no name", typ);
+            this.log("Unable to publish %s for %s, I have no name", 
+                typ, this.uuid);
             return false;
         }
         return true;

--- a/mk/acs.k8s.mk
+++ b/mk/acs.k8s.mk
@@ -5,17 +5,29 @@ ifndef .acs.k8s.mk
 
 .PHONY: deploy restart logs
 
+kubectl?=	kubectl
+kubectl_args=	
+_kubectl=	${kubectl} ${kubectl_args}
+
+ifdef k8s.namespace
+kubectl_args+=	-n ${k8s.namespace}
+endif
+
+ifdef k8s.kubeconfig
+kubectl_args+=	--kubeconfig=${k8s.kubeconfig}
+endif
+
 ifdef k8s.deployment
 
 deploy: all restart logs
 
 restart:
-	kubectl rollout restart deploy/"${k8s.deployment}"
-	kubectl rollout status deploy/"${k8s.deployment}"
+	${_kubectl} rollout restart deploy/"${k8s.deployment}"
+	${_kubectl} rollout status deploy/"${k8s.deployment}"
 	sleep 2
 
 logs:
-	kubectl logs -f deploy/"${k8s.deployment}"
+	${_kubectl} logs -f deploy/"${k8s.deployment}"
 
 else
 


### PR DESCRIPTION
Using UUIDs for Sparkplug Device names is convenient, because we always have the UUID available, but it results in some very opaque addresses. Use the Node name instead, which means we can't publish to a Device until we've looked up an address for the monitored Node, but we don't have any useful information until then anyway.

Closes: #239 