### PR TITLE
Tidy up admin account creation

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,0 +1,48 @@
+# Release Notes
+
+This documents important user-visible changes to ACS, in reverse
+chronological order.
+
+## Current development
+
+These changes have not been released yet, but are likely to appear in
+the next release.
+
+### Global admin account changes
+
+The 'Global Administrator Account' user account is now created with a
+UUID specific to this installation of ACS. Once this has been done the
+old account object (`d53f476a-29dd-4d79-b614-5b7fe9bc8acf`) can be
+deleted.
+
+The password for this account has moved from the `krb5-passwords` K8s
+Secret into a dedicated Secret for this purpose, `admin-password`. This
+contains a single key `password` holding the account password.
+
+Note that this account bypasses all ACLs and should not be used for
+normal operation.
+
+### Removed client roles
+
+Previously ACS deployed a Client Role called 'Global Debugger'
+(`4473fe9c-05b0-42cc-ad8c-8e05f6d0ca86`). This was
+a Group of permissions within the Auth service which was granted in the
+`permission` slot of access control entries. It was only useful if
+granted with a wildcard `target`.
+
+This has been replaced by a Group of users called 'MQTT global
+debuggers' (`f76f8445-ce78-41c5-90ec-5964fb0cd431`). Accounts and groups
+which should have global MQTT access should be added to this group; the
+group should not appear in any additional access control entries.
+
+Accounts created by the ACS installation will have been updated to be
+members of the Group, but ACLs referencing the Client Role and the Role
+itself will not have been removed. Any local accounts using the Role
+should be updated to be members of the Group instead, and then any
+access control entries referencing the Role should be removed.
+
+## v3.0.0
+
+This is a major release, with fundamental changes to the architecture.
+[Detailed release notes are available
+here.](./docs/whats-changed-in-v3.md)

--- a/acs-service-setup/dumps/admin.yaml
+++ b/acs-service-setup/dumps/admin.yaml
@@ -11,7 +11,6 @@ objects:
   !u ACS.Class.UserGroup:
     - !u ACS.Group.Administrators
     - !u ACS.Group.GlobalDebuggers
-  !u ACS.Class.ClientRole:
 configs:
   !u UUIDs.App.Info:
     !u ACS.Class.UserAccount:     { name: "User account" }

--- a/acs-service-setup/dumps/admin.yaml
+++ b/acs-service-setup/dumps/admin.yaml
@@ -7,32 +7,23 @@ overwrite: true
 classes:
   - !u ACS.Class.UserAccount
   - !u ACS.Class.UserGroup
-  - !u ACS.Class.ClientRole
 objects:
   !u ACS.Class.UserGroup:
     - !u ACS.Group.Administrators
     - !u ACS.Group.GlobalDebuggers
   !u ACS.Class.ClientRole:
-    # This has been replaced by the user group. It is still deployed for
-    # compatibility with existing installations.
-    - !u ACS.Role.GlobalDebugger
 configs:
   !u UUIDs.App.Info:
     !u ACS.Class.UserAccount:     { name: "User account" }
     !u ACS.Class.UserGroup:       { name: "User group" }
     !u ACS.Group.Administrators:  { name: "Administrators" }
     !u ACS.Group.GlobalDebuggers: { name: "MQTT global debuggers" }
-    !u ACS.Role.GlobalDebugger:   { name: "Role: Global debugger (compat)" }
 ---
 service: !u UUIDs.Service.Authentication
 version: 1
 groups:
   !u ACS.Group.GlobalDebuggers:
     - !u ACS.Group.Administrators
-  # This is for compatability only
-  !u ACS.Role.GlobalDebugger:
-    - !u ACS.Perm.MQTT.ReadWholeNamespace
-    - !u UUIDs.Permission.CmdEsc.Rebirth
 aces:
   - principal: !u ACS.Group.Administrators
     permission: !u ACS.PermGroup.Auth

--- a/acs-service-setup/dumps/admin.yaml
+++ b/acs-service-setup/dumps/admin.yaml
@@ -1,0 +1,61 @@
+# Create the Administrator account and group
+# Grant appropriate permissions
+---
+service: !u UUIDs.Service.ConfigDB
+version: 1
+overwrite: true
+classes:
+  - !u ACS.Class.UserAccount
+  - !u ACS.Class.UserGroup
+  - !u ACS.Class.ClientRole
+objects:
+  !u ACS.Class.UserGroup:
+    - !u ACS.Group.Administrators
+    - !u ACS.Group.GlobalDebuggers
+  !u ACS.Class.ClientRole:
+    # This has been replaced by the user group. It is still deployed for
+    # compatibility with existing installations.
+    - !u ACS.Role.GlobalDebugger
+configs:
+  !u UUIDs.App.Info:
+    !u ACS.Class.UserAccount:     { name: "User account" }
+    !u ACS.Class.UserGroup:       { name: "User group" }
+    !u ACS.Group.Administrators:  { name: "Administrators" }
+    !u ACS.Group.GlobalDebuggers: { name: "MQTT global debuggers" }
+    !u ACS.Role.GlobalDebugger:   { name: "Role: Global debugger (compat)" }
+---
+service: !u UUIDs.Service.Authentication
+version: 1
+groups:
+  !u ACS.Group.GlobalDebuggers:
+    - !u ACS.Group.Administrators
+  # This is for compatability only
+  !u ACS.Role.GlobalDebugger:
+    - !u ACS.Perm.MQTT.ReadWholeNamespace
+    - !u UUIDs.Permission.CmdEsc.Rebirth
+aces:
+  - principal: !u ACS.Group.Administrators
+    permission: !u ACS.PermGroup.Auth
+    target: !u UUIDs.Special.Null
+  - principal: !u ACS.Group.Administrators
+    permission: !u ACS.PermGroup.Clusters
+    target: !u UUIDs.Special.Null
+  - principal: !u ACS.Group.Administrators
+    permission: !u ACS.PermGroup.CmdEsc
+    target: !u UUIDs.Special.Null
+  - principal: !u ACS.Group.Administrators
+    permission: !u ACS.PermGroup.ConfigDB
+    target: !u UUIDs.Special.Null
+  - principal: !u ACS.Group.Administrators
+    permission: !u ACS.PermGroup.Directory
+    target: !u UUIDs.Special.Null
+  - principal: !u ACS.Group.Administrators
+    permission: !u ACS.PermGroup.Git
+    target: !u UUIDs.Special.Null
+
+  - principal: !u ACS.Group.GlobalDebuggers
+    permission: !u ACS.Perm.MQTT.ReadWholeNamespace
+    target: !u UUIDs.Special.Null
+  - principal: !u ACS.Group.GlobalDebuggers
+    permission: !u UUIDs.Permission.CmdEsc.Rebirth
+    target: !u UUIDs.Special.Null

--- a/acs-service-setup/lib/fixups.js
+++ b/acs-service-setup/lib/fixups.js
@@ -15,6 +15,7 @@ export async function fixups (ss) {
 
     await fixup_null(cdb);
     await fixup_sparkplug_nodes(auth);
+    await fixup_admin_account(cdb, auth);
 }
 
 /* Null was originally registered as a Class, which was wrong.
@@ -46,4 +47,14 @@ async function fixup_sparkplug_nodes (auth) {
         await auth.add_to_group(ACS.Group.SparkplugNode, node);
         await auth.delete_ace(node, Fixup.Role.EdgeNode, node);
     }
+}
+
+async function fixup_admin_account (cdb, auth) {
+    const admin = Fixup.User.Administrator;
+
+    await auth.delete_principal(admin);
+    await auth.remove_from_group(ACS.Group.Administrators, admin)
+        .catch(() => null);
+    await cdb.mark_object_deleted(admin)
+        .catch(() => null);
 }

--- a/acs-service-setup/lib/helm.js
+++ b/acs-service-setup/lib/helm.js
@@ -45,34 +45,31 @@ class HelmConfig extends ServiceConfig {
 
 async function setup_perms (auth, group) {
     const { ReadConfig, WriteConfig } = UUIDs.Permission.ConfigDB;
-    const { Rebirth } = UUIDs.Permission.CmdEsc;
     const { ReloadConfig } = Edge.Perm;
-    const { EdgeNodeConsumer, GlobalDebugger } = ACS.Role;
+    const { EdgeNodeConsumer } = ACS.Role;
+
+    /* XXX Until we can resolve the issues with dynamic MQTT ACLs,
+     * just grant the Monitors the very big hammer of full
+     * read/rebirth/reload rights. If we settled on SpGroup ==
+     * Cluster we could reduce this to per-Group rights; this would
+     * involve either a per-monitor explicit ACE or a new reflexive
+     * UUID for group access. */
 
     const members = [
         [ACS.Group.SparkplugNode,       group.agent.uuid],
         [ACS.Group.SparkplugNode,       group.monitor.uuid],
+        [ACS.Group.GlobalDebuggers,     group.monitor.uuid],
     ];
     const aces = [
         [group.agent.uuid,      ReadConfig,     Edge.App.AgentConfig],
-        [group.agent.uuid,      ReadConfig,     UUIDs.App.SparkplugAddress],
         [group.sync.uuid,       ReadConfig,     Clusters.App.HelmRelease],
         [group.sync.uuid,       ReadConfig,     Clusters.App.HelmTemplate],
         [group.sync.uuid,       ReadConfig,     Edge.App.Deployment],
         [group.sync.uuid,       ReadConfig,     Edge.App.ClusterStatus],
         [group.sync.uuid,       WriteConfig,    Edge.App.ClusterStatus],
         [group.sync.uuid,       EdgeNodeConsumer, ACS.Device.ConfigDB],
-        [group.monitor.uuid,    ReadConfig,     UUIDs.App.SparkplugAddress],
         [group.monitor.uuid,    ReadConfig,     Edge.App.AgentConfig],
         [group.monitor.uuid,    EdgeNodeConsumer, ACS.Device.ConfigDB],
-        /* XXX Until we can resolve the issues with dynamic MQTT ACLs,
-         * just grant the Monitors the very big hammer of full
-         * read/rebirth/reload rights. If we settled on SpGroup ==
-         * Cluster we could reduce this to per-Group rights; this would
-         * involve either a per-monitor explicit ACE or a new reflexive
-         * UUID for group access. */
-        [group.monitor.uuid,    GlobalDebugger, UUIDs.Special.Null],
-        [group.monitor.uuid,    Rebirth,        UUIDs.Special.Null],
         [group.monitor.uuid,    ReloadConfig,   UUIDs.Special.Null],
     ];
 

--- a/acs-service-setup/lib/service-setup.js
+++ b/acs-service-setup/lib/service-setup.js
@@ -28,8 +28,6 @@ export class ServiceSetup {
         const { fplus } = this;
 
         await fplus.init();
-        const princ = await fplus.Auth.find_principal();
-        this.email = princ.kerberos;
 
         return this;
     }

--- a/acs-service-setup/lib/uuids.js
+++ b/acs-service-setup/lib/uuids.js
@@ -100,6 +100,9 @@ export const Fixup = {
     Role: {
         EdgeNode:           "87e4a5b7-9a89-4796-a216-39666a47b9d2",
     },
+    User: {
+        Administrator:      "d53f476a-29dd-4d79-b614-5b7fe9bc8acf",
+    },
 };
 
 export const Git = {

--- a/acs-service-setup/lib/uuids.js
+++ b/acs-service-setup/lib/uuids.js
@@ -14,13 +14,10 @@ export const ACS = {
     /* XXX These should probably be deployment-specific */
     Group: {
         Administrators:     "10fc06b7-02f5-45f1-b419-a486b6bc13ba",
+        GlobalDebuggers:    "f76f8445-ce78-41c5-90ec-5964fb0cd431",
         SparkplugNode:      "1d3121a0-aade-4376-8fa3-57ba1460ba76",
         EdgeGroups:         "9ba0de4b-056f-4b5e-b966-2d5d85d07767",
         EdgePermissions:    "7594cd71-e5b9-4467-88c0-b11a66d47fec",
-    },
-    /* XXX This should definitely be */
-    User: {
-        Administrator:      "d53f476a-29dd-4d79-b614-5b7fe9bc8acf",
     },
     Perm: {
         MQTT: {
@@ -28,7 +25,17 @@ export const ACS = {
             RepresentDevices:   "e82456b3-a7d9-4971-9d8c-fd0be4545ab4",
             ReadAllStates:      "8790cf3d-b793-423c-b373-8cfcf9f63529",
             ReadNode:           "046d6603-fa62-4208-9400-65d61f8b1ec4",
+            ReadWholeNamespace: "81833dbb-1150-4078-b1db-978c646ba73e",
         },
+    },
+    PermGroup: {
+        Auth:                   "50b727d4-3faa-40dc-b347-01c99a226c58",
+        Clusters:               "9e07fd33-6400-4662-92c4-4dff1f61f990",
+        CmdEsc:                 "9584ee09-a35a-4278-bc13-21a8be1f007c",
+        ConfigDB:               "c43c7157-a50b-4d2a-ac1a-86ff8e8e88c1",
+        Directory:              "58b5da47-d098-44f7-8c1d-6e4bd800e718",
+        Git:                    "c0c55c78-116e-4526-8ff4-e4595251f76c",
+        MQTT:                   "a637134a-d06b-41e7-ad86-4bf62fde914a",
     },
     Service: {
         Manager:                "619eecab-742d-4824-8b97-bcae472e5c04",

--- a/deploy/templates/NOTES.txt
+++ b/deploy/templates/NOTES.txt
@@ -14,7 +14,7 @@ before continuing. This chart installs a full end-to-end deployment of Factory+ 
 
 Get your admin password (you may need to wait until all services are running):
 
-echo $(kubectl get secret krb5-passwords -o jsonpath="{.data.admin}" -n {{.Release.Namespace}} | base64 --decode)
+echo $(kubectl get secret admin-password -o jsonpath="{.data.password}" -n {{.Release.Namespace}} | base64 --decode)
 
 Then view the readme to get started:
 

--- a/deploy/templates/auth/auth.yaml
+++ b/deploy/templates/auth/auth.yaml
@@ -52,8 +52,8 @@ spec:
             - name: PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: krb5-passwords
-                  key: admin
+                  name: admin-password
+                  key: password
           command: [ 'sh', '-c', 'until curl -X PUT -o /dev/null -w "%{http_code}" -u "admin:${PASSWORD}" -H "Content-Type: application/json" --data-raw "{ \"url\": \"http://auth.{{.Release.Namespace}}.svc.cluster.local\" }" http://directory.{{.Release.Namespace}}.svc.cluster.local/v1/service/cab2642a-f7d9-42e5-8845-8f35affe1fd4/advertisment/1e1989ab-14e4-42bd-8171-495230acc406 | grep -E "2[0-9]{2}" > /dev/null; do sleep 10; done' ]
         - name: db-init
 {{ include "amrc-connectivity-stack.image" (list . .Values.auth) | indent 10 }}

--- a/deploy/templates/auth/principals/operators.yaml
+++ b/deploy/templates/auth/principals/operators.yaml
@@ -12,6 +12,12 @@ metadata:
 spec:
     type: Password
     principal: admin@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
+    secret: admin-password/password
+    account:
+      class: 8b3e8f35-78e5-4f93-bf21-7238bcb2ba9d
+      name: Global Administrator Account
+      groups:
+        - 10fc06b7-02f5-45f1-b419-a486b6bc13ba
 
 # Postgres database initialisation account
 ---

--- a/deploy/templates/configdb/configdb.yaml
+++ b/deploy/templates/configdb/configdb.yaml
@@ -51,8 +51,8 @@ spec:
             - name: PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: krb5-passwords
-                  key: admin
+                  name: admin-password
+                  key: password
           command: [ 'sh', '-c', 'until curl -X PUT -o /dev/null -w "%{http_code}" -u "admin:${PASSWORD}" -H "Content-Type: application/json" --data-raw "{ \"url\": \"http://configdb.{{.Release.Namespace}}.svc.cluster.local\" }" http://directory.{{.Release.Namespace}}.svc.cluster.local/v1/service/af15f175-78a0-4e05-97c0-2a0bb82b9f3b/advertisment/36861e8d-9152-40c4-8f08-f51c2d7e3c25 | grep -E "2[0-9]{2}" > /dev/null; do sleep 10; done' ]
         - name: db-init
 {{ include "amrc-connectivity-stack.image" (list . .Values.configdb) | indent 10 }}

--- a/deploy/templates/dumps.yaml
+++ b/deploy/templates/dumps.yaml
@@ -102,11 +102,9 @@
 {{$permissionGroup_git := "c0c55c78-116e-4526-8ff4-e4595251f76c" | quote}}
 {{$permissionGroup_clusterManager := "9e07fd33-6400-4662-92c4-4dff1f61f990" | quote}}
 
-{{$role_administrator := "4c09402f-9923-4c82-a6f2-02bda21aace4" | quote}}
 {{$role_commandEscalation := "dbd0c099-6c59-4bc6-aa92-4ba8a9b543f4" | quote}}
 {{$role_edgeNode := "87e4a5b7-9a89-4796-a216-39666a47b9d2" | quote}}
 {{$role_edgeNodeConsumer := "17a64293-b82d-4db4-af4d-63359bb62934" | quote}}
-{{$role_globalDebugger := "4473fe9c-05b0-42cc-ad8c-8e05f6d0ca86" | quote}}
 {{$role_globalPrimaryApplication := "c0d17bcf-2a90-40e5-b244-07bf631f7417" | quote}}
 {{$role_warehouse := "6958c812-fbe2-4e6c-b997-6f850b89f679" | quote}}
 
@@ -133,9 +131,7 @@
 {{$serviceAccount_krbkeys := "a04b4195-7db4-4480-b3f3-4d22c08b96ea" | quote}}
 {{$serviceAccount_git := "626df296-8156-4c67-8aed-aac70161aa8b" | quote}}
 {{$serviceAccount_clusterManager := "127cde3c-773a-4f61-b0ba-7412a2695253" | quote}}
-{{$userGroup_administrators := "10fc06b7-02f5-45f1-b419-a486b6bc13ba" | quote}}
 {{$userGroup_sparkplugNode := "1d3121a0-aade-4376-8fa3-57ba1460ba76" | quote}}
-{{$user_admin := "d53f476a-29dd-4d79-b614-5b7fe9bc8acf" | quote}}
 
 {{ if .Values.configdb.enabled }}
 apiVersion: v1
@@ -183,19 +179,11 @@ data:
           {{$service_manager}}
         ],
         {{$classDef_clientRole}}: [
-          {{$role_administrator}},
           {{$role_edgeNodeConsumer}},
-          {{$role_globalDebugger}},
           {{$role_edgeNode}},
           {{$role_globalPrimaryApplication}},
           {{$role_commandEscalation}},
           {{$role_warehouse}}
-        ],
-        {{$classDef_userAccount}}: [
-          {{$user_admin}}
-        ],
-        {{$classDef_userGroup}}: [
-          {{$userGroup_administrators}}
         ],
         {{$classDef_permission}}: [
           {{$permission_auth_manageKerberosMappings}},
@@ -273,21 +261,6 @@ data:
           {{$classDef_clientRole}}: {
             "name": "Client Role"
           },
-          {{$classDef_userAccount}}: {
-            "name": "User Account"
-          },
-          {{$classDef_userGroup}}: {
-            "name": "User Group"
-          },
-          {{$role_administrator}}: {
-            "name": "Role: Administrator"
-          },
-          {{$user_admin}}: {
-            "name": "Global Administrator Account"
-          },
-          {{$userGroup_administrators}}: {
-            "name": "Administrators"
-          },
           {{$classDef_permission}}: {
             "name": "Permission"
           },
@@ -341,9 +314,6 @@ data:
           },
           {{$role_edgeNodeConsumer}}: {
             "name": "Role: Edge Node Consumer"
-          },
-          {{$role_globalDebugger}}: {
-            "name": "Role: Global Debugger"
           },
           {{$role_edgeNode}}: {
             "name": "Role: Edge Node"
@@ -901,16 +871,6 @@ data:
       "version": 1,
       "aces": [
         {
-          "principal": {{$userGroup_administrators}},
-          "permission": {{$role_administrator}},
-          "target": {{$special_wildcard}}
-        },
-        {
-          "principal": {{$userGroup_administrators}},
-          "permission": {{$permissionGroup_directory}},
-          "target": {{$special_wildcard}}
-        },
-        {
           "principal": {{$userGroup_sparkplugNode}},
           "permission": {{$permission_mqtt_participateAsNode}},
           "target": {{$special_self}}
@@ -1122,11 +1082,6 @@ data:
         }
       ],
       "groups": {
-        {{$role_administrator}}: [
-          {{$role_globalDebugger}},
-          {{$permissionGroup_authorisation}},
-          {{$permissionGroup_configStore}}
-        ],
         {{$role_edgeNodeConsumer}}: [
           {{$permission_mqtt_subscribeReadNode}},
           {{$permission_ccl_rebirth}}
@@ -1167,9 +1122,6 @@ data:
           {{$permission_auth_manageKerberosMappings}},
           {{$permission_auth_readKerberosMapping}}
         ],
-        {{$role_globalDebugger}}: [
-          {{$permission_mqtt_subscribeReadWholeNamespace}}
-        ],
         {{$permissionGroup_mqtt}}: [
           {{$permission_mqtt_subscribeReadNode}},
           {{$permission_mqtt_subscribeToWholeNamespace}},
@@ -1192,9 +1144,6 @@ data:
           {{$permission_configStore_manageObjects}},
           {{$permission_configStore_deleteObjects}}
         ],
-        {{$userGroup_administrators}}: [
-          {{$user_admin}}
-        ],
         {{$userGroup_sparkplugNode}}: [
           {{$serviceAccount_directory}},
           {{$serviceAccount_configStore}},
@@ -1202,10 +1151,6 @@ data:
         ]
       },
       "principals": [
-        {
-          "uuid": {{$user_admin}},
-          "kerberos": "admin@{{ .Values.identity.realm }}"
-        },
         {
           "uuid": {{$serviceAccount_directory}},
           "kerberos": "sv1directory@{{ .Values.identity.realm }}"
@@ -1290,9 +1235,6 @@ data:
           ],
           {{$userGroup_sparkplugNode}}: [
             {{$serviceAccount_git}}
-          ],
-          {{$role_administrator}}: [
-            {{$permissionGroup_git}}
           ]
       },
       "aces": [
@@ -1455,9 +1397,6 @@ data:
       "groups": {
         {{$serviceRequirement_edgeDeploymentServiceAccount}}: [
           {{$serviceAccount_clusterManager}}
-        ],
-        {{$role_administrator}}: [
-          {{$permissionGroup_clusterManager}}
         ]
       }
     }

--- a/deploy/templates/service-setup.yaml
+++ b/deploy/templates/service-setup.yaml
@@ -27,8 +27,8 @@ spec:
             - name: SERVICE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: krb5-passwords
-                  key: admin
+                  name: admin-password
+                  key: password
             - name: VERBOSE
               value: ALL,!token,!service
             - name: GIT_CHECKOUTS


### PR DESCRIPTION
* Move grants for admin@ into service-setup.
* Allow krbkeys to generate an installation-specific UUID instead of using a fixed one.
* Move the password into a dedicated Secret.
* Replace the Global Debugger role with a Global Debuggers user group.

Start a Release Notes document documenting the user-visible changes.

Closes: #230