### PR TITLE
Update @amrc-factoryplus/service-client version

### DIFF
--- a/acs-activity-monitor/Dockerfile
+++ b/acs-activity-monitor/Dockerfile
@@ -3,7 +3,6 @@ FROM oven/bun:latest as build-stage
 WORKDIR /app
 COPY package*.json ./
 RUN bun install --immutable --immutable-cache --check-cache
-RUN sed -i~ -e'/GSS = await/{N;s/\n//}' /app/node_modules/@amrc-factoryplus/service-client/lib/deps.js
 COPY . /app/
 RUN bun run build
 RUN rm -rf node_modules

--- a/acs-activity-monitor/package.json
+++ b/acs-activity-monitor/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@amrc-factoryplus/service-client": "^1.3.4",
+    "@amrc-factoryplus/service-client": "^1.3.5",
     "@rollup/plugin-inject": "^5.0.5",
     "buffer": "^6.0.3",
     "dayjs": "^1.11.10",

--- a/acs-admin/package.json
+++ b/acs-admin/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@amrc-factoryplus/service-client": "^1.3.4",
+    "@amrc-factoryplus/service-client": "^1.3.5",
     "@amrc-factoryplus/sparkplug-app": "^0.0.5",
     "@preact/signals": "^1.2.2",
     "express": "^4.18.1",

--- a/acs-visualiser/package.json
+++ b/acs-visualiser/package.json
@@ -18,7 +18,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@amrc-factoryplus/service-client": "^1.3.4",
+    "@amrc-factoryplus/service-client": "^1.3.5",
     "express": "^4.18.1",
     "process": "^0.11.10",
     "tailwindcss": "^3.4.1",


### PR DESCRIPTION
The changes involve updating the @amrc-factoryplus/service-client version to ^1.3.5 in both acs-activity-monitor and acs-visualiser. This eliminates the need for the line in the activity monitor Dockerfile as the underlying bug is now fixed upstream.