### PR TITLE
Lock down @types/readable-stream

### DIFF
--- a/acs-edge/package-lock.json
+++ b/acs-edge/package-lock.json
@@ -13,6 +13,7 @@
         "@st-one-io/nodes7": "^1.0.1",
         "@types/dotenv": "^8.2.0",
         "@types/node": "^16.10.1",
+        "@types/readable-stream": "^4.0.11",
         "@types/ws": "^8.2.0",
         "@types/xmldom": "^0.1.31",
         "@xmldom/xmldom": "^0.8.6",

--- a/acs-edge/package.json
+++ b/acs-edge/package.json
@@ -33,6 +33,7 @@
     "@st-one-io/nodes7": "^1.0.1",
     "@types/dotenv": "^8.2.0",
     "@types/node": "^16.10.1",
+    "@types/readable-stream": "^4.0.11",
     "@types/ws": "^8.2.0",
     "@types/xmldom": "^0.1.31",
     "@xmldom/xmldom": "^0.8.6",


### PR DESCRIPTION
Upstream version 4.0.14 appears to have a bug.