### PR TITLE
Fix edge agent batching

### DIFF
--- a/acs-edge/lib/device.ts
+++ b/acs-edge/lib/device.ts
@@ -3,28 +3,21 @@
  *  Copyright 2023 AMRC
  */
 
-import {
-    log
-} from "./helpers/log.js";
+import {log} from "./helpers/log.js";
 import * as fs from "fs";
+import {SparkplugNode} from "./sparkplugNode.js";
 import {
-    SparkplugNode
-} from "./sparkplugNode.js";
-import {
-    sparkplugDataType,
-    sparkplugMetric,
     Metrics,
-    sparkplugPayload,
-    sparkplugTemplate,
-    sparkplugValue,
+    parseTimeStampFromPayload,
     parseValueFromPayload,
     serialisationType,
-    parseTimeStampFromPayload
+    sparkplugDataType,
+    sparkplugMetric,
+    sparkplugPayload,
+    sparkplugTemplate,
+    sparkplugValue
 } from "./helpers/typeHandler.js";
-import {
-    EventEmitter
-} from "events";
-import * as util from "util";
+import {EventEmitter} from "events";
 import Long from "long";
 
 /**
@@ -311,7 +304,10 @@ export abstract class Device {
                             );
 
                             // Update the metric value and push it to the array of changed metrics
-                            changedMetrics.push(this._metrics.setValueByAddrPath(addr, path, newVal, timestamp));
+                            changedMetrics.push({...{}, ...(this._metrics.setValueByAddrPath(addr,
+                                    path,
+                                    newVal,
+                                    timestamp))});
                         }
                     }
                 }

--- a/acs-edge/lib/sparkplugNode.ts
+++ b/acs-edge/lib/sparkplugNode.ts
@@ -298,6 +298,10 @@ export class SparkplugNode extends (
             }
             // If polled publishing is enabled, start the loop...
             if (!this.#metrics.getByName("Node Control/Async Publish Mode").value) {
+                // Clear the existing interval if it exists
+                if (this.#pubIntHandle) {
+                    this.#stopPublishInterval();
+                }
                 this.#startPublishInterval();
             }
         } else {


### PR DESCRIPTION
This PR fixes two bugs in the edge agent when `pubInterval` is used.

- **Fixed:** Timestamps and values are no longer the same when metrics are batched
- **Fixed:** Fixed a bug where rebirthing a node would result in duplicate DATA messages being sent