### PR TITLE
Allow auth verbosity to be set in values.yaml

### DIFF
--- a/deploy/templates/auth/auth.yaml
+++ b/deploy/templates/auth/auth.yaml
@@ -128,7 +128,7 @@ spec:
             - name: PGDATABASE
               value: auth
             - name: VERBOSE
-              value: "1"
+              value: {{.Values.auth.verbosity | quote | required "values.auth.verbosity is required!"}}
 {{ include "amrc-connectivity-stack.cache-max-age" (list . "auth") | indent 12 }}
             # These are currently only used for the editor. They need to be resolvable by the
             # user's browser, so in-cluster names will not work.

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -69,6 +69,7 @@ auth:
     # -- The repository of the Authorisation component
     repository: acs-auth
     pullPolicy: IfNotPresent
+  verbosity: "ALL,!service,!token,!query"
 
 directory:
   # -- Whether or not to enable the Directory component


### PR DESCRIPTION
Default to not showing `query`, `service` or `token` logs, too.