### PR TITLE
Give the central monitors global debugger

### DIFF
--- a/acs-service-setup/dumps/edge.yaml
+++ b/acs-service-setup/dumps/edge.yaml
@@ -29,6 +29,8 @@ version: 1
 groups:
   !u ACS.Group.SparkplugNode:
     - !u ACS.Group.CentralMonitor
+  !u ACS.Group.GlobalDebuggers:
+    - !u ACS.Group.CentralMonitor
 aces:
   - principal: !u ACS.Group.CentralMonitor
     permission: !u ACS.Role.EdgeNodeConsumer

--- a/acs-service-setup/lib/helm.js
+++ b/acs-service-setup/lib/helm.js
@@ -71,7 +71,6 @@ async function setup_perms (auth, group) {
         [group.monitor.uuid,    ReadConfig,     Edge.App.AgentConfig],
         [group.monitor.uuid,    EdgeNodeConsumer, ACS.Device.ConfigDB],
         [group.monitor.uuid,    ReloadConfig,   UUIDs.Special.Null],
-        [ACS.Group.CentralMonitor, EdgeNodeConsumer, group.monitor.uuid],
     ];
 
     for (const m of members) {


### PR DESCRIPTION
We don't yet have a system for granting dynamic MQTT permissions which actually works. For now just grant the monitor global debugger rights.