### PR TITLE
Also host admin interface at admin.*

### DIFF
--- a/deploy/templates/admin/ingress.yaml
+++ b/deploy/templates/admin/ingress.yaml
@@ -20,4 +20,26 @@ spec:
     domains:
       - main: {{.Values.acs.baseUrl | required "values.acs.baseUrl is required"}}
   {{- end -}}
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: admin-sub-ingressroute
+  namespace: {{ .Release.Namespace }}
+spec:
+  entryPoints:
+    - {{ .Values.acs.secure | ternary "websecure" "web" }}
+  routes:
+    - match: Host(`admin.{{.Values.acs.baseUrl | required "values.acs.baseUrl is required"}}`)
+      kind: Rule
+      services:
+        - name: admin
+          port: 80
+          namespace: {{ .Release.Namespace }}
+  {{- if .Values.acs.secure }}
+  tls:
+    secretName: {{ coalesce .Values.auth.tlsSecretName .Values.acs.tlsSecretName }}
+    domains:
+      - main: admin.{{.Values.acs.baseUrl | required "values.acs.baseUrl is required"}}
+  {{- end -}}
 {{- end -}}


### PR DESCRIPTION
This helps when the TLS certificate for the ACS installation does not include the base domain.