### PR TITLE
Fix deployment-specific values

### DIFF
--- a/acs-edge-sync/lib/deployments.js
+++ b/acs-edge-sync/lib/deployments.js
@@ -153,7 +153,13 @@ export class Deployments {
         const lookup = list => rx.from(list).pipe(
             rx.mergeMap(agent => cdb.get_config(Deployments, agent)
                 .then(spec => ({ uuid: agent, spec }))),
-            rx.mergeMap(deployment => rx.from(deployment.spec.charts).pipe(
+            rx.map(dep => {
+                const { spec } = dep;
+                const charts = 
+                    spec.chart ? rx.of(spec.chart) : rx.from(spec.charts);
+                return [dep, charts];
+            }),
+            rx.mergeMap(([deployment, charts]) => charts.pipe(
                 rx.mergeMap(ch => cdb.get_config(HelmChart, ch)),
                 /* XXX We could cache (against an etag) to avoid
                  * recompiling every time... */

--- a/acs-edge-sync/lib/deployments.js
+++ b/acs-edge-sync/lib/deployments.js
@@ -184,13 +184,13 @@ export class Deployments {
     create_manifests ({ config, deployments }) {
         return imm.List(deployments)
             .map(deployment => {
-                const { uuid } = deployment;
+                const { uuid, config } = deployment;
                 const chart = deployment.chart({
                     uuid,
-                    name:       deployment.config.name,
-                    hostname:   deployment.config.hostname,
+                    name:       config.name,
+                    hostname:   config.hostname,
                 });
-                const values = [this.values, chart.values, deployment.values]
+                const values = [this.values, chart.values, config.values]
                     .map(v => v ?? {}).reduce(jmp.merge);
                 return config.template({
                     uuid, values,

--- a/acs-edge-sync/lib/deployments.js
+++ b/acs-edge-sync/lib/deployments.js
@@ -152,8 +152,8 @@ export class Deployments {
          * deployed. */
         const lookup = list => rx.from(list).pipe(
             rx.mergeMap(agent => cdb.get_config(Deployments, agent)
-                .then(config => ({ uuid: agent, config }))),
-            rx.mergeMap(deployment => rx.from(deployment.config.charts).pipe(
+                .then(spec => ({ uuid: agent, spec }))),
+            rx.mergeMap(deployment => rx.from(deployment.spec.charts).pipe(
                 rx.mergeMap(ch => cdb.get_config(HelmChart, ch)),
                 /* XXX We could cache (against an etag) to avoid
                  * recompiling every time... */
@@ -184,13 +184,13 @@ export class Deployments {
     create_manifests ({ config, deployments }) {
         return imm.List(deployments)
             .map(deployment => {
-                const { uuid, config } = deployment;
+                const { uuid, spec } = deployment;
                 const chart = deployment.chart({
                     uuid,
-                    name:       config.name,
-                    hostname:   config.hostname,
+                    name:       spec.name,
+                    hostname:   spec.hostname,
                 });
-                const values = [this.values, chart.values, config.values]
+                const values = [this.values, chart.values, spec.values]
                     .map(v => v ?? {}).reduce(jmp.merge);
                 return config.template({
                     uuid, values,


### PR DESCRIPTION
It was originally supposed to be possible to specify `values.yaml` overrides in a _Edge deployment_ ConfigDB entry, avoiding the need to create a new _Helm chart template_ for every combination of values. This has never worked correctly; fix it.

Where an _Edge deployment_ deploys more than one chart, this will apply the same values overrides to them all. This is unlikely to be useful. We should consider deprecating multi-chart deployments altogether; they were intended for edge agent driver deployments, which can be handled in the edge-agent chart directly.