### PR TITLE
Create local secrets with krbkeys

### DIFF
--- a/acs-krb-keys-operator/crd/local-secret.yaml
+++ b/acs-krb-keys-operator/crd/local-secret.yaml
@@ -1,0 +1,51 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: localsecrets.factoryplus.app.amrc.co.uk
+spec:
+  group: factoryplus.app.amrc.co.uk
+  names:
+    kind: LocalSecret
+    plural: localsecrets
+    categories:
+      - all
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Secret
+          jsonPath: ".spec.secret"
+          type: string
+        - name: Key
+          jsonPath: ".spec.key"
+          type: string
+        - name: Format
+          jsonPath: ".spec.format"
+          type: string
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [secret, key, format]
+              properties:
+                secret:
+                  description: The name of the Secret to edit.
+                  type: string
+                key:
+                  description: The key to create within the Secret.
+                  type: string
+                format:
+                  description: >
+                    The format of the secret value. Currently must be Password.
+                  type: string
+                  enum: [Password]
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}

--- a/acs-krb-keys-operator/lib/amrc/factoryplus/krbkeys/util.py
+++ b/acs-krb-keys-operator/lib/amrc/factoryplus/krbkeys/util.py
@@ -17,14 +17,16 @@ class Identifiers:
     DOMAIN = "factoryplus.app.amrc.co.uk"
     APP = "krbkeys"
     APPID = f"{APP}.{DOMAIN}"
-    CRD_PLURAL = "kerberos-keys"
-    CRD_VERSION = "v1"
 
     FORCE_REKEY = f"{APPID}/force-rekey"
     HAS_OLD_KEYS = f"{APPID}/has-old-keys"
     ACCOUNT_UUID = f"{APPID}/account-uuid"
 
     MANAGED_BY = "app.kubernetes.io/managed-by"
+
+class CRD:
+    krbkey = (Identifiers.DOMAIN, "v1", "kerberos-keys")
+    local = (Identifiers.DOMAIN, "v1", "localsecrets")
 
 def dslice (dct, *args):
     if dct is None:


### PR DESCRIPTION
Give the krbkeys operator the ability to create secrets which only exist on an edge cluster, not connected to a Kerberos principal. These can be used to authenticate edge drivers to the edge agent.

Request these secrets using a new LocalSecret CRD.