### PR TITLE
Deploy drivers via the edge Helm charts

### DIFF
--- a/edge-helm-charts/charts/edge-agent/templates/_helpers.tpl
+++ b/edge-helm-charts/charts/edge-agent/templates/_helpers.tpl
@@ -1,8 +1,9 @@
-{{/*
-Define the image for a container.
-*/}}
 {{- define "edge-agent.image" -}}
-image: "{{ .registry }}/{{ .repository }}:{{ .tag }}"
-imagePullPolicy: {{ .pullPolicy }}
+{{- $root := index . 0 -}}
+{{- $key := index . 1 -}}
+{{- $image := $root.Values.image -}}
+{{- $spec := merge (get $image $key) $image.default -}}
+image: "{{ $spec.registry }}/{{ $spec.repository }}:{{ $spec.tag }}"
+imagePullPolicy: {{ $spec.pullPolicy }}
 {{- end }}
 

--- a/edge-helm-charts/charts/edge-agent/templates/edge-agent.yaml
+++ b/edge-helm-charts/charts/edge-agent/templates/edge-agent.yaml
@@ -32,7 +32,7 @@ spec:
 {{ end }}
       containers:
         - name: edge-agent
-{{ include "edge-agent.image" .Values.image.edgeAgent | indent 10 }}
+{{ list . "edgeAgent" | include "edge-agent.image" | indent 10 }}
           env:
             - name: DEBUG
               value: {{ .Values.debug | quote }}
@@ -69,7 +69,7 @@ spec:
               name: driver-passwords
 {{- range $name, $image := .Values.drivers }}
         - name: "driver-{{ $name | lower }}"
-          image: "{{ $image }}"
+{{ list $ $image | include "edge-agent.image" | indent 10 }}
           env:
             - name: EDGE_MQTT
               value: "mqtt://localhost"
@@ -80,6 +80,8 @@ spec:
                 secretKeyRef:
                   name: "driver-passwords-{{ $.Values.uuid }}"
                   key: "{{ $name }}"
+            - name: VERBOSE
+              value: "{{ $.Values.verbosity }}"
 {{- end }}
       volumes:
         - name: edge-agent-sensitive-information

--- a/edge-helm-charts/charts/edge-agent/templates/edge-agent.yaml
+++ b/edge-helm-charts/charts/edge-agent/templates/edge-agent.yaml
@@ -49,6 +49,10 @@ spec:
                 secretKeyRef:
                   name: edge-agent-secrets-{{ .Values.uuid }}
                   key: keytab
+            - name: EDGE_MQTT
+              value: "mqtt://0.0.0.0"
+            - name: EDGE_PASSWORDS
+              value: "/usr/app/driver-passwords"
           resources:
             limits:
               memory: {{ .Values.limits.memory | quote }}
@@ -61,6 +65,8 @@ spec:
               readOnly: true
             - mountPath: /home/node/.config
               name: local-config
+            - mountPath: /usr/app/driver-passwords
+              name: driver-passwords
       volumes:
         - name: edge-agent-sensitive-information
           secret:
@@ -68,6 +74,10 @@ spec:
             secretName: edge-agent-sensitive-information-{{ .Values.uuid }}
         - name: local-config
           emptyDir:
+        - name: driver-passwords
+          secret:
+            optional: true
+            secretName: driver-passwords-{{ .Values.uuid }}
 ---
 apiVersion: factoryplus.app.amrc.co.uk/v1
 kind: SparkplugNode

--- a/edge-helm-charts/charts/edge-agent/templates/edge-agent.yaml
+++ b/edge-helm-charts/charts/edge-agent/templates/edge-agent.yaml
@@ -50,7 +50,7 @@ spec:
                   name: edge-agent-secrets-{{ .Values.uuid }}
                   key: keytab
             - name: EDGE_MQTT
-              value: "mqtt://0.0.0.0"
+              value: "mqtt://localhost"
             - name: EDGE_PASSWORDS
               value: "/usr/app/driver-passwords"
           resources:
@@ -67,6 +67,20 @@ spec:
               name: local-config
             - mountPath: /usr/app/driver-passwords
               name: driver-passwords
+{{- range $name, $image := .Values.drivers }}
+        - name: "driver-{{ $name | lower }}"
+          image: "{{ $image }}"
+          env:
+            - name: EDGE_MQTT
+              value: "mqtt://localhost"
+            - name: EDGE_USERNAME
+              value: "{{ $name }}"
+            - name: EDGE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "driver-passwords-{{ $.Values.uuid }}"
+                  key: "{{ $name }}"
+{{- end }}
       volumes:
         - name: edge-agent-sensitive-information
           secret:

--- a/edge-helm-charts/charts/edge-agent/templates/edge-agent.yaml
+++ b/edge-helm-charts/charts/edge-agent/templates/edge-agent.yaml
@@ -105,3 +105,15 @@ spec:
   edgeAgent: true
   secrets:
     - edge-agent-sensitive-information-{{ .Values.uuid }}
+{{ range $name, $image := .Values.drivers }}
+---
+apiVersion: factoryplus.app.amrc.co.uk/v1
+kind: LocalSecret
+metadata:
+  namespace: {{ $.Release.Namespace }}
+  name: "driver-passwords-{{ $.Values.uuid }}-{{ $name | lower }}"
+spec:
+  format: Password
+  secret: "driver-passwords-{{ $.Values.uuid }}"
+  key: "{{ $name }}"
+{{- end }}

--- a/edge-helm-charts/charts/edge-agent/templates/edge-agent.yaml
+++ b/edge-helm-charts/charts/edge-agent/templates/edge-agent.yaml
@@ -50,7 +50,11 @@ spec:
                   name: edge-agent-secrets-{{ .Values.uuid }}
                   key: keytab
             - name: EDGE_MQTT
+{{- if .Values.externalIPs }}
+              value: "mqtt://0.0.0.0"
+{{- else }}
               value: "mqtt://localhost"
+{{- end }}
             - name: EDGE_PASSWORDS
               value: "/usr/app/driver-passwords"
           resources:

--- a/edge-helm-charts/charts/edge-agent/templates/service.yaml
+++ b/edge-helm-charts/charts/edge-agent/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: edge-agent-{{ .Values.uuid }}
+spec:
+  selector:
+    factory-plus.service: edge-mqtt-{{ .Values.uuid }}
+  internalTrafficPolicy: Local
+  ports:
+    - name: mqtt
+      port: 1883
+{{- if .Values.externalIPs }}
+  externalIPs: {{ .Values.externalIPs }}
+{{- end }}

--- a/edge-helm-charts/charts/edge-agent/templates/service.yaml
+++ b/edge-helm-charts/charts/edge-agent/templates/service.yaml
@@ -5,7 +5,8 @@ metadata:
   name: edge-agent-{{ .Values.uuid }}
 spec:
   selector:
-    factory-plus.service: edge-mqtt-{{ .Values.uuid }}
+    factory-plus.app: edge-agent
+    factory-plus.nodeUuid: {{ .Values.uuid }}
   internalTrafficPolicy: Local
   ports:
     - name: mqtt

--- a/edge-helm-charts/charts/edge-agent/templates/service.yaml
+++ b/edge-helm-charts/charts/edge-agent/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.externalIPs }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -8,9 +9,9 @@ spec:
     factory-plus.app: edge-agent
     factory-plus.nodeUuid: {{ .Values.uuid }}
   internalTrafficPolicy: Local
+  externalTrafficPolicy: Local
   ports:
     - name: mqtt
       port: 1883
-{{- if .Values.externalIPs }}
   externalIPs: {{ .Values.externalIPs }}
 {{- end }}

--- a/edge-helm-charts/charts/edge-agent/values.yaml
+++ b/edge-helm-charts/charts/edge-agent/values.yaml
@@ -1,10 +1,20 @@
 image:
-  # Parameters for the Edge Agent image to pull
-  edgeAgent:
+  # Default image parameters. These can be overidden per-image.
+  default:
     registry: ghcr.io/amrc-factoryplus
-    repository: acs-edge
     tag: v3.1.2
     pullPolicy: IfNotPresent
+  # Edge Agent image to pull
+  edgeAgent:
+    repository: acs-edge
+  modbus:
+    repository: edge-modbus
+  test:
+    repository: edge-test
+  # Further image names for drivers as needed
+drivers:
+  # An object mapping connection names to images from the list above.
+  #Test: test
 debug: false
 verbosity: ALL,!token,!service,!sparkplug
 poll_int: 10

--- a/edge-helm-charts/charts/edge-agent/values.yaml
+++ b/edge-helm-charts/charts/edge-agent/values.yaml
@@ -15,6 +15,8 @@ image:
 drivers:
   # An object mapping connection names to images from the list above.
   #Test: test
+# Make the driver interface available externally.
+#externalIPs: []
 debug: false
 verbosity: ALL,!token,!service,!sparkplug
 poll_int: 10

--- a/edge-helm-charts/charts/edge-cluster/crds/local-secret.yaml
+++ b/edge-helm-charts/charts/edge-cluster/crds/local-secret.yaml
@@ -1,0 +1,51 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: localsecrets.factoryplus.app.amrc.co.uk
+spec:
+  group: factoryplus.app.amrc.co.uk
+  names:
+    kind: LocalSecret
+    plural: localsecrets
+    categories:
+      - all
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Secret
+          jsonPath: ".spec.secret"
+          type: string
+        - name: Key
+          jsonPath: ".spec.key"
+          type: string
+        - name: Format
+          jsonPath: ".spec.format"
+          type: string
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [secret, key, format]
+              properties:
+                secret:
+                  description: The name of the Secret to edit.
+                  type: string
+                key:
+                  description: The key to create within the Secret.
+                  type: string
+                format:
+                  description: >
+                    The format of the secret value. Currently must be Password.
+                  type: string
+                  enum: [Password]
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}

--- a/edge-helm-charts/charts/edge-cluster/templates/krb-keys.yaml
+++ b/edge-helm-charts/charts/edge-cluster/templates/krb-keys.yaml
@@ -108,10 +108,10 @@ metadata:
   name: krb-keys
 rules:
   -   apiGroups: [factoryplus.app.amrc.co.uk]
-      resources: [kerberos-keys]
+      resources: [kerberos-keys, localsecrets]
       verbs: [list, get, watch, patch]
   -   apiGroups: [factoryplus.app.amrc.co.uk]
-      resources: [kerberos-keys/status]
+      resources: [kerberos-keys/status, localsecrets/status]
       verbs: [list, get, create, update, delete, watch, patch]
   -   apiGroups: [""]
       resources: [secrets]


### PR DESCRIPTION
Deploy Edge Agent drivers from within the edge-agent chart. There is no need for a separate chart as drivers all deploy identically.

At the moment the drivers deploy as containers on the edge agent pod. This keeps things simple and a bit more secure and means on-cluster drivers can contact the edge agent on `localhost` without needing to go through a Service.

If `externalIPs` is included in the values then the driver interface will be available externally to support off-cluster drivers. Authentication for such drivers will need to be handled through SealedSecrets and may need a little more work.