### PR TITLE
Allow node-red chart to map in devices

### DIFF
--- a/edge-helm-charts/charts/node-red/templates/node-red.yaml
+++ b/edge-helm-charts/charts/node-red/templates/node-red.yaml
@@ -36,6 +36,11 @@ spec:
         - name: config
           configMap:
             name: node-red-{{ .Values.uuid }}
+{{- range $ix, $dev := .Values.devices }}
+        - name: device-{{ $ix }}
+          hostPath:
+            path: "{{ $dev }}"
+{{- end }}
       securityContext:
         runAsUser: 1000
       initContainers:
@@ -58,6 +63,10 @@ spec:
           volumeMounts:
             - mountPath: /data
               name: data
+{{- range $ix, $dev := .Values.devices }}
+            - mountPath: "{{ $dev }}"
+              name: device-{{ $ix }}
+{{- end }}
         {{- if .Values.mqttBroker }}
         - name: mqtt-broker
           {{- with .Values.image.mqttBroker }}

--- a/edge-helm-charts/charts/node-red/values.yaml
+++ b/edge-helm-charts/charts/node-red/values.yaml
@@ -13,6 +13,8 @@ image:
 flow: null
 # If this is true we deploy an MQTT broker sidecar
 mqttBroker: false
+# Devices to map in from the host
+devices: []
 # This is required
 # uuid: 12345
 # This deploys to a specific host


### PR DESCRIPTION
Give the node-red chart a list of `hostPath` mounts to grant to node-red. This is intended for mounting devices used to access external hardware. Obviously this needs to be used very carefully.