### PR TITLE
Include requesting principal in CMDs

### DIFF
--- a/acs-cmdesc/lib/cmdescd.js
+++ b/acs-cmdesc/lib/cmdescd.js
@@ -169,7 +169,8 @@ export default class CmdEscD {
         }
 
         this.mqtt.publish({
-            topic:      to.topic("CMD"),
+            address:    to,
+            type:       "CMD",
             metrics:    [cmd],
             from:       from instanceof Address 
                 ? `sparkplug:${from}`

--- a/acs-cmdesc/lib/cmdescd.js
+++ b/acs-cmdesc/lib/cmdescd.js
@@ -168,7 +168,13 @@ export default class CmdEscD {
             }
         }
 
-        this.mqtt.publish(to, "CMD", [cmd]);
+        this.mqtt.publish({
+            topic:      to.topic("CMD"),
+            metrics:    [cmd],
+            from:       from instanceof Address 
+                ? `sparkplug:${from}`
+                : `kerberos:${from}`,
+        });
         return log(200);
     }
 }

--- a/acs-cmdesc/lib/mqttcli.js
+++ b/acs-cmdesc/lib/mqttcli.js
@@ -209,8 +209,10 @@ export default class MqttCli {
         }
         if (type == "BIRTH" || type == "CMD")
             payload.uuid = UUIDs.FactoryPlus;
-        if (type == "CMD")
-            payload.body = from ?? `uuid:${this.device_uuid}`;
+        if (type == "CMD") {
+            const sender = from ?? `uuid:${this.device_uuid}`;
+            payload.body = Buffer.from(sender.toString());
+        }
 
         return SpB.encodePayload(payload);
     }


### PR DESCRIPTION
There are situations where it is useful to know the identity of the principal who requested a CMD. Include this information in the CMD packet in the following form:

* The `uuid` field of the CMD is set to the Factory+ UUID.
* The `body` of the CMD is a UTF-8 string starting with a scheme name and a colon.
* The scheme `uuid:` is followed by a principal UUID in canonical string form.
* The scheme `kerberos:` is followed by a Kerberos principal name.
* The schema `sparkplug:` is followed by a Sparkplug address in `Group/Node` form.

(Currently Devices are not permitted to request command escalation, as they aren't security principals and can't be authorised.)

This is a rebase of #269 onto `main`. The previous merge was lost when we changed policy to 'main is always releasable'.