### PR TITLE
Allow drivers to access devices on the host

### DIFF
--- a/edge-helm-charts/charts/edge-agent/templates/_helpers.tpl
+++ b/edge-helm-charts/charts/edge-agent/templates/_helpers.tpl
@@ -7,3 +7,6 @@ image: "{{ $spec.registry }}/{{ $spec.repository }}:{{ $spec.tag }}"
 imagePullPolicy: {{ $spec.pullPolicy }}
 {{- end }}
 
+{{- define "edge-agent.k8sname" }}
+{{- .Values.name | lower | replace "_" "-" }}
+{{- end }}

--- a/edge-helm-charts/charts/edge-agent/templates/edge-agent-key.yaml
+++ b/edge-helm-charts/charts/edge-agent/templates/edge-agent-key.yaml
@@ -1,12 +1,13 @@
+{{- $k8sname := include "edge-agent.k8sname" . }}
 apiVersion: factoryplus.app.amrc.co.uk/v1
 kind: KerberosKey
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: edge-agent.{{ .Values.uuid }}
+  name: edge-agent.{{ $k8sname }}
 spec:
   type: Password
   principal: nd1/{{ .Values.cluster }}/{{ .Values.name }}@{{ .Values.realm }}
-  secret: edge-agent-secrets-{{ .Values.uuid }}/keytab
+  secret: edge-agent-secrets.{{ $k8sname }}/keytab
   account:
     uuid: {{ .Values.uuid }}
     groups:

--- a/edge-helm-charts/charts/edge-agent/templates/edge-agent.yaml
+++ b/edge-helm-charts/charts/edge-agent/templates/edge-agent.yaml
@@ -1,11 +1,12 @@
+{{- $k8sname := include "edge-agent.k8sname" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: edge-agent-{{ .Values.uuid }}
+  name: edge-agent-{{ $k8sname }}
   namespace: {{ .Release.Namespace }}
   labels:
     factory-plus.app: edge-agent
-    factory-plus.service: edge-agent-{{ .Values.uuid }}
+    factory-plus.service: edge-agent-{{ $k8sname }}
     factory-plus.nodeUuid: {{ .Values.uuid }}
     factory-plus.name: {{ .Values.name }}
 spec:
@@ -47,7 +48,7 @@ spec:
             - name: SERVICE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: edge-agent-secrets-{{ .Values.uuid }}
+                  name: edge-agent-secrets.{{ $k8sname }}
                   key: keytab
             - name: EDGE_MQTT
 {{- if .Values.externalIPs }}
@@ -82,7 +83,7 @@ spec:
             - name: EDGE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: "driver-passwords-{{ $.Values.uuid }}"
+                  name: "driver-passwords.{{ $k8sname }}"
                   key: "{{ $name }}"
             - name: VERBOSE
               value: "{{ $.Values.verbosity }}"
@@ -104,7 +105,7 @@ spec:
         - name: driver-passwords
           secret:
             optional: true
-            secretName: driver-passwords-{{ .Values.uuid }}
+            secretName: driver-passwords.{{ $k8sname }}
 {{- range $name, $path := coalesce .Values.driverDevices dict }}
         - name: "driver-dev-{{ $name }}"
           hostPath:
@@ -115,7 +116,7 @@ apiVersion: factoryplus.app.amrc.co.uk/v1
 kind: SparkplugNode
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: edge-agent-{{ .Values.uuid }}
+  name: edge-agent.{{ $k8sname }}
 spec:
   uuid: {{ .Values.uuid }}
   edgeAgent: true
@@ -127,9 +128,9 @@ apiVersion: factoryplus.app.amrc.co.uk/v1
 kind: LocalSecret
 metadata:
   namespace: {{ $.Release.Namespace }}
-  name: "driver-passwords-{{ $.Values.uuid }}-{{ $name | lower }}"
+  name: "driver-passwords.{{ $k8sname }}.{{ $name | lower }}"
 spec:
   format: Password
-  secret: "driver-passwords-{{ $.Values.uuid }}"
+  secret: "driver-passwords.{{ $k8sname }}"
   key: "{{ $name }}"
 {{- end }}

--- a/edge-helm-charts/charts/edge-agent/templates/edge-agent.yaml
+++ b/edge-helm-charts/charts/edge-agent/templates/edge-agent.yaml
@@ -71,9 +71,9 @@ spec:
               name: local-config
             - mountPath: /usr/app/driver-passwords
               name: driver-passwords
-{{- range $name, $image := .Values.drivers }}
+{{- range $name, $driver := coalesce .Values.drivers dict }}
         - name: "driver-{{ $name | lower }}"
-{{ list $ $image | include "edge-agent.image" | indent 10 }}
+  {{- list $ $driver.image | include "edge-agent.image" | nindent 10 }}
           env:
             - name: EDGE_MQTT
               value: "mqtt://localhost"
@@ -86,6 +86,13 @@ spec:
                   key: "{{ $name }}"
             - name: VERBOSE
               value: "{{ $.Values.verbosity }}"
+  {{- if $driver.deviceMounts }}
+          volumeMounts:
+    {{- range $name, $path := coalesce $driver.deviceMounts dict }}
+            - mountPath: "{{ $path }}"
+              name: "driver-dev-{{ $name }}"
+    {{- end }}
+  {{- end }}
 {{- end }}
       volumes:
         - name: edge-agent-sensitive-information
@@ -98,6 +105,11 @@ spec:
           secret:
             optional: true
             secretName: driver-passwords-{{ .Values.uuid }}
+{{- range $name, $path := coalesce .Values.driverDevices dict }}
+        - name: "driver-dev-{{ $name }}"
+          hostPath:
+            path: "{{ $path }}"
+{{- end }}
 ---
 apiVersion: factoryplus.app.amrc.co.uk/v1
 kind: SparkplugNode

--- a/edge-helm-charts/charts/edge-agent/templates/service.yaml
+++ b/edge-helm-charts/charts/edge-agent/templates/service.yaml
@@ -1,9 +1,10 @@
+{{- $k8sname := include "edge-agent.k8sname" . }}
 {{- if .Values.externalIPs }}
 apiVersion: v1
 kind: Service
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: edge-agent-{{ .Values.uuid }}
+  name: edge-agent-{{ $k8sname }}
 spec:
   selector:
     factory-plus.app: edge-agent

--- a/edge-helm-charts/charts/edge-agent/values.yaml
+++ b/edge-helm-charts/charts/edge-agent/values.yaml
@@ -12,9 +12,23 @@ image:
   test:
     repository: edge-test
   # Further image names for drivers as needed
-drivers:
-  # An object mapping connection names to images from the list above.
-  #Test: test
+
+# An object mapping connection names to driver configuration. This is
+# for deploying on-cluster drivers.
+drivers: {}
+  #Test:
+    # An image name from the image list above.
+    #image: test
+    # An object mapping mount names from driverDevices to mount points
+    # in the driver container.
+    #deviceMounts:
+      #arduino: /dev/arduino
+
+# Host paths which may be mounted into drivers. This is to make host
+# devices available inside the driver containers.
+#driverDevices:
+  #arduino: /dev/ttyUSB0
+
 # Make the driver interface available externally.
 #externalIPs: []
 debug: false


### PR DESCRIPTION
Some device drivers necessarily need to access devices on the host. Allow the edge agent chart to map host devices into the driver containers.

Rework the edge agent k8s resource naming to use the node name instead of the UUID. The UUIDs are just getting annoying.