### PR TITLE
Allow privileged containers

### DIFF
--- a/edge-helm-charts/charts/edge-agent/templates/edge-agent.yaml
+++ b/edge-helm-charts/charts/edge-agent/templates/edge-agent.yaml
@@ -75,6 +75,10 @@ spec:
 {{- range $name, $driver := coalesce .Values.drivers dict }}
         - name: "driver-{{ $name | lower }}"
   {{- list $ $driver.image | include "edge-agent.image" | nindent 10 }}
+  {{- if $driver.privileged }}
+          securityContext:
+            privileged: true
+  {{- end }}
           env:
             - name: EDGE_MQTT
               value: "mqtt://localhost"

--- a/edge-helm-charts/charts/edge-agent/values.yaml
+++ b/edge-helm-charts/charts/edge-agent/values.yaml
@@ -19,6 +19,9 @@ drivers: {}
   #Test:
     # An image name from the image list above.
     #image: test
+    # Run this driver as a privileged container. This removes a k8s
+    # security feature but is necessary to allow access to hardware.
+    #privileged: true
     # An object mapping mount names from driverDevices to mount points
     # in the driver container.
     #deviceMounts:

--- a/edge-helm-charts/charts/node-red/templates/node-red.yaml
+++ b/edge-helm-charts/charts/node-red/templates/node-red.yaml
@@ -60,6 +60,10 @@ spec:
           image: "{{ .registry }}/{{ .repository }}:{{ .tag }}"
           imagePullPolicy: {{ .pullPolicy }}
           {{- end }}
+{{- if .Values.privileged }}
+          securityContext:
+            privileged: true
+{{- end }}
           volumeMounts:
             - mountPath: /data
               name: data

--- a/edge-helm-charts/charts/node-red/values.yaml
+++ b/edge-helm-charts/charts/node-red/values.yaml
@@ -15,6 +15,8 @@ flow: null
 mqttBroker: false
 # Devices to map in from the host
 devices: []
+# Does Node-RED require access to host devices?
+privileged: false
 # This is required
 # uuid: 12345
 # This deploys to a specific host


### PR DESCRIPTION
Containers that need to access host devices, e.g. serial ports, need to be run with privilege. Otherwise k8s forbids access. This is obviously a big hammer and should only be used with care.