### PR TITLE
K8s isn't allowing externalTrafficPolicy

### DIFF
--- a/edge-helm-charts/charts/edge-agent/templates/service.yaml
+++ b/edge-helm-charts/charts/edge-agent/templates/service.yaml
@@ -10,7 +10,6 @@ spec:
     factory-plus.app: edge-agent
     factory-plus.nodeUuid: {{ .Values.uuid }}
   internalTrafficPolicy: Local
-  externalTrafficPolicy: Local
   ports:
     - name: mqtt
       port: 1883


### PR DESCRIPTION
It isn't clear from the docs why this is incorrect; this is not a NodePort Service, but it does have external IPs. Perhaps this is because external IPs are never load-balanced.