### PR TITLE
Wire up driver images to the build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -207,6 +207,8 @@ jobs:
       matrix:
         service:
           - acs-edge
+          - edge-modbus
+          - edge-test
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Unfortunately these really need to be build for ARM, which will make the builds longer.