### PR TITLE
Change Makefiles to use docker buildx

### DIFF
--- a/acs-edge/Makefile
+++ b/acs-edge/Makefile
@@ -4,6 +4,8 @@ include ${top}/mk/acs.init.mk
 repo?=acs-edge
 # Don't set k8s.deployment, the deployment doesn't have a fixed name.
 
+platform?=	linux/amd64,linux/arm64
+
 include ${mk}/acs.js.mk
 
 local.build:

--- a/mk/README.md
+++ b/mk/README.md
@@ -20,9 +20,15 @@ the commands to be run without running them.
 * `all`: This is the default target if you just run `make`. This will
   build and push an image for subdirs that build an image.
 
-* `build`: Just build an image.
+* `build`: Build and push an image. You will need to have overridden the
+  default registry for this to succeed.
 
-* `push`: Just push an image (which must be already built).
+* `pull`: Pull a built image. Since Docker has required use of `buildx`
+  to build images are not normally transferred via the local Docker
+  image cache.
+
+* `run`: Run a shell inside the built image. This will not build but
+  will pull.
 
 * `deploy`: For those subdirs which support this, this will attempt to
   restart a k8s deployment and show the logs. This requires `KUBECONFIG`

--- a/mk/acs.docker.mk
+++ b/mk/acs.docker.mk
@@ -10,6 +10,8 @@ suffix?=
 tag=${version}${suffix}
 image=${registry}/${repo}:${tag}
 
+platform?=	linux/amd64
+
 build_args+=	--build-arg revision="${git.tag} (${git.sha})"
 build_args+=	--build-arg tag="${tag}"
 
@@ -19,17 +21,17 @@ build_args+=	--build-arg tag="${tag}"
 # has changed, or even to retag an existing image from the same
 # source...
 
-.PHONY: build push run
+.PHONY: build pull run
 
-all: build push
+all: build
 
 build: git.prepare
-	docker build -t "${image}" ${build_args} .
+	docker buildx build --push --platform "${platform}" -t "${image}" ${build_args} .
 
-push:
-	docker push "${image}"
+pull:
+	docker pull "${image}"
 
-run:
+run: pull
 	docker run -ti --rm "${image}" /bin/sh
 
 include ${mk}/acs.git.mk


### PR DESCRIPTION
Use of buildx appears to be mandatory now. Even an explicit `docker builder build` seems to invoke buildx. Adjust the Makefile to suit; this means the `build` target now performs `push`, and we need `pull` target for cases where we want an up-to-date local image.

Support multi-platform builds, now we can.