### PR TITLE
Deploy schemas via service-setup

### DIFF
--- a/acs-service-setup/lib/service-setup.js
+++ b/acs-service-setup/lib/service-setup.js
@@ -13,9 +13,9 @@ import { setup_manager }        from "./manager.js";
 
 export class ServiceSetup {
     constructor (opts) {
-        this.config = JSON.parse(opts.env.SS_CONFIG);
+        this.config     = JSON.parse(opts.env.SS_CONFIG);
         this.acs_config = JSON.parse(opts.env.ACS_CONFIG);
-        this.checkouts = opts.env.GIT_CHECKOUTS;
+        this.scratch    = opts.env.SCRATCH_DIR;
 
         this.fplus = new ServiceClient({ env: opts.env });
         this.log = this.fplus.debug.bound("setup");

--- a/deploy/templates/service-setup.yaml
+++ b/deploy/templates/service-setup.yaml
@@ -14,14 +14,16 @@ spec:
     spec:
       restartPolicy: OnFailure
       volumes:
-        - name: git-checkouts
+        - name: scratch
           emptyDir:
       initContainers:
-        - name: service-setup
-{{ include "amrc-connectivity-stack.image" (list . .Values.serviceSetup) | indent 10 }}
+{{- range $name := .Values.serviceSetup.runSteps }}
+  {{- $step := get $.Values.serviceSetup.steps $name }}
+        - name: {{ $name }}
+  {{- include "amrc-connectivity-stack.image" (list $ $step) | nindent 10 }}
           env:
             - name: DIRECTORY_URL
-              value: http://directory.{{ .Release.Namespace }}.svc.cluster.local
+              value: http://directory.{{ $.Release.Namespace }}.svc.cluster.local
             - name: SERVICE_USERNAME
               value: admin
             - name: SERVICE_PASSWORD
@@ -31,39 +33,29 @@ spec:
                   key: password
             - name: VERBOSE
               value: ALL,!token,!service
-            - name: GIT_CHECKOUTS
-              value: /data
-            - name: SS_CONFIG
-              value: {{ .Values.serviceSetup.config | toRawJson | quote }}
+            - name: SCRATCH_DIR
+              value: /scratch
             - name: ACS_CONFIG
               value: {{
                 dict
-                  "organisation"    .Values.acs.organisation
-                  "domain"          .Values.acs.baseUrl
-                  "realm"           .Values.identity.realm
+                  "organisation"    $.Values.acs.organisation
+                  "domain"          $.Values.acs.baseUrl
+                  "realm"           $.Values.identity.realm
                   "directory"
                     (include "amrc-connectivity-stack.external-url" 
-                      (list . "directory"))
+                      (list $ "directory"))
                 | toRawJson | quote }}
+  {{- range $k, $v := coalesce $step.env dict }}
+            - name: {{ $k | quote }}
+              value: {{
+                kindIs "string" $v
+                | ternary $v (toRawJson $v)
+                | quote }}
+  {{- end }}
           volumeMounts:
-            - mountPath: /data
-              name: git-checkouts
-        - name: edge-helm-charts
-{{ include "amrc-connectivity-stack.image" (list . .Values.edgeHelm) | indent 10 }}
-          env:
-            - name: DIRECTORY_URL
-              value: http://directory.{{ .Release.Namespace }}.svc.cluster.local
-            - name: SERVICE_USERNAME
-              value: admin
-            - name: SERVICE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: admin-password
-                  key: password
-            - name: VERBOSE
-              value: ALL,!token,!service
-            - name: GIT_REPO_PATH
-              value: {{ .Values.edgeHelm.repoPath }}
+            - mountPath: /scratch
+              name: scratch
+{{- end }}
       containers:
         # We need a do-nothing container to keep k8s happy
         - name: done

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -115,7 +115,7 @@ serviceSetup:
   # an array it can only be overridden as a whole, so the step
   # definitions are separate so they can be added to rather than
   # replaced.
-  runSteps: [service-setup, edge-helm]
+  runSteps: [service-setup, acs-schemas, edge-helm]
   # This defines what to run for each step.
   steps:
     service-setup:
@@ -123,6 +123,8 @@ serviceSetup:
         registry: ghcr.io/amrc-factoryplus
         repository: acs-service-setup
         pullPolicy: IfNotPresent
+      # Environment variables to pass to this step. Plain strings are
+      # placed in the environment as-is, other values are JSON-encoded.
       env:
         # This section overrides the classes etc. installed into the ConfigDB
         SS_CONFIG:
@@ -138,6 +140,12 @@ serviceSetup:
           helmChart:
             # Chart to deploy an edge cluster
             #cluster: null
+    acs-schemas:
+      image:
+        registry: ghcr.io/amrc-factoryplus
+        repository: acs-schemas
+        tag: v0.0.1
+        pullPolicy: IfNotPresent
     edge-helm:
       image:
         registry: ghcr.io/amrc-factoryplus

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -111,32 +111,40 @@ monitor:
 # the ACS services when the Helm chart is deployed or upgraded.
 serviceSetup:
   enabled: true
-  image:
-    registry: ghcr.io/amrc-factoryplus
-    repository: acs-service-setup
-    pullPolicy: IfNotPresent
-  # This section overrides the classes etc. installed into the ConfigDB
-  config:
-    # Git repos to create in the on-prem server. These may be
-    # automatically mirrored from external repos, or populated by the
-    # service setup job.
-    repoMirror:
-      helm:
-        name: Edge Helm charts
-        pull: {}
-    # Helm charts to deploy to the edge; these default to the charts
-    # created automatically but can be overridden to customise
-    helmChart:
-      # Chart to deploy an edge cluster
-      #cluster: null
-
-edgeHelm:
-  enabled: true
-  image:
-    registry: ghcr.io/amrc-factoryplus
-    repository: edge-helm-charts
-    pullPolicy: IfNotPresent
-  repoPath: shared/helm
+  # This chooses which steps to run, and in which order. Since this is
+  # an array it can only be overridden as a whole, so the step
+  # definitions are separate so they can be added to rather than
+  # replaced.
+  runSteps: [service-setup, edge-helm]
+  # This defines what to run for each step.
+  steps:
+    service-setup:
+      image:
+        registry: ghcr.io/amrc-factoryplus
+        repository: acs-service-setup
+        pullPolicy: IfNotPresent
+      env:
+        # This section overrides the classes etc. installed into the ConfigDB
+        SS_CONFIG:
+          # Git repos to create in the on-prem server. These may be
+          # automatically mirrored from external repos, or populated by the
+          # service setup job.
+          repoMirror:
+            helm:
+              name: Edge Helm charts
+              pull: {}
+          # Helm charts to deploy to the edge; these default to the charts
+          # created automatically but can be overridden to customise
+          helmChart:
+            # Chart to deploy an edge cluster
+            #cluster: null
+    edge-helm:
+      image:
+        registry: ghcr.io/amrc-factoryplus
+        repository: edge-helm-charts
+        pullPolicy: IfNotPresent
+      env:
+        GIT_REPO_PATH: shared/helm
 
 mqtt:
   # -- Whether or not to enable the MQTT component


### PR DESCRIPTION
* Refactor the service-setup Job to allow an arbitrary list of containers to be run under the control of the Helm values file.
* Include a new step to deploy the schemas to the ConfigDB.