### PR TITLE
Fix addr parsing handling 'undefined'

### DIFF
--- a/edge-bacnet/lib/bacnet.js
+++ b/edge-bacnet/lib/bacnet.js
@@ -39,6 +39,8 @@ export class BacnetHandler {
 
   parseAddr (spec) {
 
+    // XXX - This is a hack and shouldn't need to handle this at all.
+    // This originates from an upstream edge agent bug.
     if (spec === 'undefined') {
       return {
         type: null,
@@ -71,6 +73,8 @@ export class BacnetHandler {
 
     const { client } = this
 
+    // XXX - This is a hack and shouldn't need to handle this at all.
+    // This originates from an upstream edge agent bug.
     if (addr.type === null) {
       return;
     }

--- a/edge-bacnet/lib/bacnet.js
+++ b/edge-bacnet/lib/bacnet.js
@@ -39,6 +39,14 @@ export class BacnetHandler {
 
   parseAddr (spec) {
 
+    if (spec === 'undefined') {
+      return {
+        type: null,
+        instance: null,
+        propertyId: null,
+      }
+    }
+
     const parts = spec.split(',')
 
     // If there are three parts, then the last one is the propertyID. If
@@ -60,7 +68,12 @@ export class BacnetHandler {
   }
 
   async poll (addr) {
+
     const { client } = this
+
+    if (addr.type === null) {
+      return;
+    }
 
     return new Promise((resolve, reject) => {
 


### PR DESCRIPTION
This is a hack until we can fix the upstream edge agent bug sending 'undefined'.