### PR TITLE
Fix vis rendering when a node loses children

### DIFF
--- a/acs-visualiser/public/mqttclient.js
+++ b/acs-visualiser/public/mqttclient.js
@@ -174,12 +174,11 @@ export default class MQTTClient extends EventEmitter {
         if (!node.children) return;
         node.children = node.children.filter(kid => {
             this.check_expiry(now, kid, changed);
-            const ok = !kid.expires || kid.expires > now;
-            if (!ok) {
-                changed[0] = true;
-                this.known.delete(kid.path);
-            }
-            return ok;
+            if (!kid.expires || kid.expires > now)
+                return true;
+            changed[0] = true;
+            this.known.delete(kid.path);
+            return false;
         });
         if (!node.children.length && !node.seen_data)
             node.expires = now;

--- a/acs-visualiser/public/vis.js
+++ b/acs-visualiser/public/vis.js
@@ -63,6 +63,7 @@ export default class Vis {
                 graph.too_many = nodes.length;
             }
             else {
+                graph.too_many = null;
                 graph.leaves = nodes
                     .map(c => c.leaves)
                     .reduce((a, b) => a + b, 0);
@@ -92,15 +93,16 @@ export default class Vis {
         ];
         
         const nodes = graph.children;
-		if (graph.too_many) {
-			const o_cen = [
-            (radius + ring) * Math.cos(myangle) * this.xscale, 
-            (radius + ring) * Math.sin(myangle)];
-			graph.overflow = {
-				parent: graph,
-				centre: o_cen,
-			};
-		}
+        if (graph.too_many) {
+            const o_cen = [
+                (radius + ring) * Math.cos(myangle) * this.xscale, 
+                (radius + ring) * Math.sin(myangle),
+            ];
+            graph.overflow = {
+                parent: graph,
+                centre: o_cen,
+            };
+        }
         if (graph.too_many || !nodes || nodes.length == 0)
              return;
 
@@ -187,6 +189,9 @@ export default class Vis {
 
         const th = TURN / graph.too_many;
         for (let i = 0; i < graph.too_many; i++) {
+            if (!graph.children[i]) {
+                continue;
+            }
             ctx.strokeStyle = graph.children[i].online ? Style.circles : Style.offline;
             ctx.beginPath();
             ctx.arc(x, y, r, th*i, th*(i + 1), true);

--- a/acs-visualiser/public/vis.js
+++ b/acs-visualiser/public/vis.js
@@ -179,22 +179,22 @@ export default class Vis {
         ctx.moveTo(...graph.centre);
         ctx.lineTo(...graph.overflow.centre);
         ctx.strokeStyle = Style.circles;
-        ctx.fillStyle = Style.background;
         ctx.stroke();
         ctx.lineWidth = 3 * this.line_width;
 
         const [x, y] = graph.overflow.centre;
         const r = 0.35*this.root_node;
+        ctx.strokeStyle = Style.background;
+        ctx.fillStyle = Style.background;
         this.circle(x, y, r, null, false);
 
         const th = TURN / graph.too_many;
         for (let i = 0; i < graph.too_many; i++) {
-            if (!graph.children[i]) {
-                continue;
-            }
+            if (!graph.children[i]) continue;
             ctx.strokeStyle = graph.children[i].online ? Style.circles : Style.offline;
+            const [st, en] = [th*i, th*(i + 1)];
             ctx.beginPath();
-            ctx.arc(x, y, r, th*i, th*(i + 1), true);
+            ctx.arc(x, y, r, st, en, false);
             ctx.stroke();
         }
 


### PR DESCRIPTION
There is a bug in the rendering when a node switches from 6 to 5 children and stops being rendered as an overflow node.

This is being triggered more often now as the temporary CMD nodes are included in the overflow count. This is incorrect but harder to fix.