### PR TITLE
Fix polling of metrics with no address

### DIFF
--- a/acs-edge/lib/devices/S7.ts
+++ b/acs-edge/lib/devices/S7.ts
@@ -4,7 +4,7 @@
  */
 
 import { Device, deviceOptions, DeviceConnection } from "../device.js";
-import { log } from "../helpers/log.js";
+import { log, logf } from "../helpers/log.js";
 import { SparkplugNode } from "../sparkplugNode.js";
 import { S7Endpoint, S7ItemGroup } from '@st-one-io/nodes7';
 import { Metrics, sparkplugMetric } from '../helpers/typeHandler.js';
@@ -61,6 +61,7 @@ export class S7Connection extends DeviceConnection {
     }
 
     async subscribe (addresses: string[]) {
+        logf("S7 Subscribe: %O", addresses); 
         for (const a of addresses) {
             this.#vars.add(a);
             this.#itemGroup.addItems(a);

--- a/acs-edge/lib/helpers/typeHandler.ts
+++ b/acs-edge/lib/helpers/typeHandler.ts
@@ -250,15 +250,19 @@ export class Metrics {
             const metric = this.#array[i];
             this.#nameIndex[metric.name || ""] = i;
             // this.#aliasIndex[metric.alias as number] = i;
-            if (metric.properties != null && metric.properties.address != null && metric.properties.path != null && (metric.properties.method.value as string).search(
-                /^GET/g) > -1) {
-                const addr = metric.properties.address.value as string;
+            const props = metric.properties;
+            const addr = props?.address?.value;
+            const path = props?.path?.value;
+            const meth = props?.method?.value ?? "";
+            /* XXX bmz: This does not support metrics with addr but no
+             * path. This ought to be a valid combination but I think
+             * has never been supported. */
+            if (addr && path && /GET/.test(meth)) {
                 if (!this.#addrIndex[addr]) {
                     this.#addrIndex[addr] = [];
                 }
                 this.#addrIndex[addr].push(i);
                 this.#addrIndex[addr].push(i);
-                const path = metric.properties.path.value as string;
                 if (!this.#addrPathIndex[addr]) {
                     this.#addrPathIndex[addr] = {};
                 }

--- a/acs-edge/lib/helpers/typeHandler.ts
+++ b/acs-edge/lib/helpers/typeHandler.ts
@@ -253,12 +253,9 @@ export class Metrics {
             const props = metric.properties;
             logf("Processing metric %O", props);
             const addr = props?.address?.value as string|undefined;
-            const path = props?.path?.value as string|undefined;
+            const path = (props?.path?.value ?? "") as string;
             const meth = (props?.method?.value ?? "") as string;
-            /* XXX bmz: This does not support metrics with addr but no
-             * path. This ought to be a valid combination but I think
-             * has never been supported. */
-            if (addr != null && path != null && /GET/.test(meth)) {
+            if (addr != null && /GET/.test(meth)) {
                 if (!this.#addrIndex[addr]) {
                     this.#addrIndex[addr] = [];
                 }

--- a/acs-edge/lib/helpers/typeHandler.ts
+++ b/acs-edge/lib/helpers/typeHandler.ts
@@ -251,7 +251,6 @@ export class Metrics {
             this.#nameIndex[metric.name || ""] = i;
             // this.#aliasIndex[metric.alias as number] = i;
             const props = metric.properties;
-            logf("Processing metric %O", props);
             const addr = props?.address?.value as string|undefined;
             const path = (props?.path?.value ?? "") as string;
             const meth = (props?.method?.value ?? "") as string;
@@ -265,9 +264,6 @@ export class Metrics {
                     this.#addrPathIndex[addr] = {};
                 }
                 this.#addrPathIndex[addr][path] = i;
-            }
-            else {
-                log("Metric skipped, no addr");
             }
         }
     }

--- a/acs-edge/lib/helpers/typeHandler.ts
+++ b/acs-edge/lib/helpers/typeHandler.ts
@@ -251,13 +251,14 @@ export class Metrics {
             this.#nameIndex[metric.name || ""] = i;
             // this.#aliasIndex[metric.alias as number] = i;
             const props = metric.properties;
-            const addr = props?.address?.value;
-            const path = props?.path?.value;
-            const meth = props?.method?.value ?? "";
+            logf("Processing metric %O", props);
+            const addr = props?.address?.value as string|undefined;
+            const path = props?.path?.value as string|undefined;
+            const meth = (props?.method?.value ?? "") as string;
             /* XXX bmz: This does not support metrics with addr but no
              * path. This ought to be a valid combination but I think
              * has never been supported. */
-            if (addr && path && /GET/.test(meth)) {
+            if (addr != null && path != null && /GET/.test(meth)) {
                 if (!this.#addrIndex[addr]) {
                     this.#addrIndex[addr] = [];
                 }
@@ -267,6 +268,9 @@ export class Metrics {
                     this.#addrPathIndex[addr] = {};
                 }
                 this.#addrPathIndex[addr][path] = i;
+            }
+            else {
+                log("Metric skipped, no addr");
             }
         }
     }

--- a/acs-edge/package.json
+++ b/acs-edge/package.json
@@ -45,6 +45,7 @@
     "dotenv": "^10.0.0",
     "jsonpath-plus": "^5.0.7",
     "jsonpointer": "^5.0.1",
+    "long": "4.0.0",
     "node-opcua": "^2.103.0",
     "st-ethernet-ip": "^2.7.1",
     "ts-node-dev": "^1.1.8",


### PR DESCRIPTION
Polling metrics with no defined address was leading to the polling of the address `"undefined"`. Since this is rarely a valid address some of the drivers now have hacks in place to ignore this specific address. Fix the problem at the root instead.