### PR TITLE
Minor Manager changes

### DIFF
--- a/acs-manager/.docker/Dockerfiles/Dockerfile
+++ b/acs-manager/.docker/Dockerfiles/Dockerfile
@@ -5,9 +5,11 @@ ARG base_prefix=ghcr.io/amrc-factoryplus/acs-manager
 
 FROM --platform=linux/amd64 oven/bun:1.1.29 as build-frontend
 WORKDIR /app
-COPY . /app/
 
+COPY package.json bun.lockb .
 RUN bun install --immutable --immutable-cache --check-cache
+
+COPY . .
 RUN bun run build
 RUN rm -rf node_modules
 

--- a/acs-manager/.docker/Dockerfiles/Dockerfile
+++ b/acs-manager/.docker/Dockerfiles/Dockerfile
@@ -3,7 +3,7 @@ ARG base_version
 ARG build_version
 ARG base_prefix=ghcr.io/amrc-factoryplus/acs-manager
 
-FROM --platform=linux/amd64 oven/bun:latest as build-frontend
+FROM --platform=linux/amd64 oven/bun:1.1.29 as build-frontend
 WORKDIR /app
 COPY . /app/
 

--- a/acs-manager/app/Domain/Nodes/Actions/CreateNodeAction.php
+++ b/acs-manager/app/Domain/Nodes/Actions/CreateNodeAction.php
@@ -30,6 +30,7 @@ class CreateNodeAction
      */
 
     public function execute(
+        $infoName,
         $nodeName,
         $destinationCluster,
         $charts,
@@ -70,7 +71,7 @@ class CreateNodeAction
         ]);
 
         $configDB->putConfig(App::Info, $uuid, [
-            "name" => $nodeName,
+            "name" => $infoName,
         ]);
 
         // Split the $charts string (comma-delimited) into an array of UUIDs

--- a/acs-manager/app/Http/Controllers/NodeController.php
+++ b/acs-manager/app/Http/Controllers/NodeController.php
@@ -27,6 +27,7 @@ class NodeController extends Controller
 
         return process_action(
             (new CreateNodeAction)->execute(
+                infoName: $validated['info_name'],
                 nodeName: $validated['node_name'],
                 destinationCluster: $validated['destination_cluster'],
                 charts: $validated['charts'],

--- a/acs-manager/app/Http/Requests/CreateNodeRequest.php
+++ b/acs-manager/app/Http/Requests/CreateNodeRequest.php
@@ -48,7 +48,7 @@ class CreateNodeRequest extends FormRequest
     public function rules()
     {
         return [
-            'node_name' => ['required', 'string', 'min:5', 'regex:/^\w+$/i'],
+            'node_name' => ['required', 'string', 'min:5', 'regex:/^[-\w]+$/i'],
             'charts' => ['required', 'string'],
             'destination_cluster' => ['required', 'string'],
             'destination_node' => ['string', 'nullable'],

--- a/acs-manager/app/Http/Requests/CreateNodeRequest.php
+++ b/acs-manager/app/Http/Requests/CreateNodeRequest.php
@@ -48,6 +48,7 @@ class CreateNodeRequest extends FormRequest
     public function rules()
     {
         return [
+            'info_name' => ['required', 'string', 'min:5'],
             'node_name' => ['required', 'string', 'min:5', 'regex:/^[-\w]+$/i'],
             'charts' => ['required', 'string'],
             'destination_cluster' => ['required', 'string'],

--- a/acs-manager/resources/js/components/General/DeviceConnectionForm.vue
+++ b/acs-manager/resources/js/components/General/DeviceConnectionForm.vue
@@ -417,9 +417,6 @@ export default {
                 return this.model.connType === 'Driver' || false
               },
               validations: {
-                requiredIf: requiredIf(() => {
-                  return this.model.connType === 'Driver' || false
-                }),
               },
               description: 'Driver-specific connection details.',
               title: 'DriverDetails',

--- a/acs-manager/resources/js/components/Nodes/NewNodeOverlay.vue
+++ b/acs-manager/resources/js/components/Nodes/NewNodeOverlay.vue
@@ -159,6 +159,11 @@ export default {
           type: 'post',
           url: 'replaced',
           parameters: {
+            info_name: {
+              dataType: "collected",
+              dataSource: ["nodeSelection", "controls", "info_name", "value"],
+              data: null,
+            },
             node_name: {
               dataType: 'collected',
               dataSource: ['nodeSelection', 'controls', 'node_name', 'value'],
@@ -182,14 +187,27 @@ export default {
         nodeSelection: {
           tagline: 'Choose the edge cluster and node on which to deploy the new node',
           controls: {
+            info_name: {
+              name: "Name",
+              description: "This is a short human-readable name for this Node",
+              prefix: "",
+              placeholder: "e.g. Assembly Cell",
+              type: "input",
+              validations: {
+                required: helpers.withMessage('Please enter a name for this Node', required),
+                minLength: minLength(5),
+              },
+              initialValue: "",
+              value: "",
+            },
             node_name: {
-              name: 'Node Name',
+              name: 'Sparkplug Name',
               description: 'Node names use underscores for spaces and hyphens for structure',
               prefix: '',
               placeholder: 'e.g. Assembly_Cell',
               type: 'input',
               validations: {
-                required: helpers.withMessage('Please enter a Node name', required),
+                required: helpers.withMessage('Please enter a Sparkplug name', required),
                 minLength: minLength(5),
                 valid: helpers.withMessage('This Node name does not conform to the naming convention',
                     helpers.regex(/^[-\w]+$/)),

--- a/acs-manager/resources/js/components/Nodes/NewNodeOverlay.vue
+++ b/acs-manager/resources/js/components/Nodes/NewNodeOverlay.vue
@@ -184,7 +184,7 @@ export default {
           controls: {
             node_name: {
               name: 'Node Name',
-              description: 'Node names must use underscores for spaces',
+              description: 'Node names use underscores for spaces and hyphens for structure',
               prefix: '',
               placeholder: 'e.g. Assembly_Cell',
               type: 'input',
@@ -192,7 +192,7 @@ export default {
                 required: helpers.withMessage('Please enter a Node name', required),
                 minLength: minLength(5),
                 valid: helpers.withMessage('This Node name does not conform to the naming convention',
-                    helpers.regex(/^[\w_]+$/i)),
+                    helpers.regex(/^[-\w]+$/)),
               },
               initialValue: '',
               value: ''

--- a/acs-manager/vite.config.js
+++ b/acs-manager/vite.config.js
@@ -48,6 +48,8 @@ export default defineConfig({
 
   // This allows us to get values out of the tailwind file
   build: {
+    target: "esnext",
+    minify: false,
     assetsInlineLimit: 0,
     commonjsOptions: {
       include: ['/tailwind.config.js', 'node_modules/**'],

--- a/acs-visualiser/public/mqttclient.js
+++ b/acs-visualiser/public/mqttclient.js
@@ -57,7 +57,7 @@ export default class MQTTClient extends EventEmitter {
         const { address, type: kind } = topic;
         const { group, node, device } = address;
 
-        const parts = [...group.split("-"), node];
+        const parts = [...group.split("-"), ...node.split("-")];
         if (device != undefined) parts.push(device);
         
         const graph = this.add_to_graph(parts);


### PR DESCRIPTION
* Allow Node names to include hyphens. With the identification of clusters and Groups it will be useful to have structure within a Node name.
* Adapt the visualiser to understand structured Node names.
* Request and record a human-readable name for a Node, to go in the ConfigDB Info entry. Currently this cannot be edited via the Manager.
* Remove the validation from DriverDetails, it is refusing to allow an empty object. This is a valid config for the edge-test driver.
* Pin oven/bin version in the Dockerfile; 1.1.30 is causing build problems.
* Make the build a little more usable.