### PR TITLE
Configure batch publishing from the Manager

### DIFF
--- a/acs-edge/lib/sparkplugNode.ts
+++ b/acs-edge/lib/sparkplugNode.ts
@@ -78,8 +78,6 @@ export class SparkplugNode extends (
     #client: any
     #metrics: Metrics
     isOnline: boolean
-    #metricBuffer: { [index: string]: sparkplugMetric[] }
-    #pubIntHandle: ReturnType<typeof setInterval>
     #aliasCounter: number
     #metricNameIndex: metricIndex
 
@@ -93,12 +91,7 @@ export class SparkplugNode extends (
          * mess everywhere. */
         this.#metrics = new Metrics([]);
         this.#metricNameIndex = {};
-        this.#metricBuffer = {}; // Buffer to hold metrics when periodic publishing enabled
         this.#aliasCounter = 0; // Counter to keep track of metrics aliases for this Edge Node
-        /* XXX This is awful. But it's the only way to get the right
-         * type, and again we really don't want this nullable. */
-        this.#pubIntHandle = setTimeout(() => {
-        }, 1); // Handle for publish interval
 
         this.isOnline = false; // Whether client is online or not
     }
@@ -168,22 +161,10 @@ export class SparkplugNode extends (
                 value: false,
             },
             {
-                // Whether metrics changes should be pushed immediately or buffered and published periodically
-                name: "Node Control/Async Publish Mode",
-                type: sparkplugDataType.boolean,
-                value: this.#conf.nodeControl?.asyncPubMode ?? false,
-            },
-            {
                 // Command to reload the node configuration from the Management App
                 name: "Node Control/Reload Edge Agent Config",
                 type: sparkplugDataType.boolean,
                 value: false
-            },
-            {
-                // If client is to publish periodically then define how often should this be done
-                name: "Node Control/Publish Interval",
-                type: sparkplugDataType.uInt16,
-                value: this.#conf.nodeControl?.pubInterval ?? 0,
             },
             {
                 // Whether payload should be compressed or not
@@ -296,64 +277,11 @@ export class SparkplugNode extends (
             } catch (err) {
                 console.log(err);
             }
-            // If polled publishing is enabled, start the loop...
-            if (!this.#metrics.getByName("Node Control/Async Publish Mode").value) {
-                // Clear the existing interval if it exists
-                if (this.#pubIntHandle) {
-                    this.#stopPublishInterval();
-                }
-                this.#startPublishInterval();
-            }
         } else {
             log(`Skipping DBIRTH for ${deviceId} until we're connected to the Factory+ UNS.`);
         }
     }
 
-    /**
-     * Start periodic publishing
-     */
-    async #startPublishInterval() {
-        // Get required publishing interval
-        const pubInt = this.#metrics.getByName("Node Control/Publish Interval").value as number;
-        // Start periodic publishing of metrics from buffer
-        this.#pubIntHandle = setInterval(() => {
-            this.#publishMetricBuffer();
-        }, pubInt);
-        log(`Started publishing metrics every ${pubInt} ms`);
-    }
-
-    /**
-     * Stop periodic publishing of metrics from buffer
-     */
-    async #stopPublishInterval() {
-        clearInterval(this.#pubIntHandle);
-        this.#publishMetricBuffer(); // Flush any remaining messages
-    }
-
-    /**
-     * If periodic publishing is enabled, publish any queue metrics from the message buffer
-     */
-    async #publishMetricBuffer() {
-        // For all devices we are publsing on behalf of...
-        await Promise.all(
-            Object.keys(this.#metricBuffer).map(async (deviceId) => {
-                const metricsToPublish = this.#metricBuffer[deviceId].length;
-                // If there are metrics waiting to be published and we're online
-                if (metricsToPublish && this.isOnline) {
-                    // Prepare payload and publish metrics
-                    let payload = await this.#preparePayload(
-                        this.#metricBuffer[deviceId].splice(0, metricsToPublish)
-                    );
-                    await this.#client.publishDeviceData(deviceId, payload, {
-                        compress: this.#metrics.getByName("Node Control/Payload Compression").value,
-                    });
-                    log(
-                        `${metricsToPublish} metrics published from buffer for device ${deviceId}.`
-                    );
-                }
-            })
-        );
-    }
 
     /**
      * Publish DDATA on behalf of connected device
@@ -361,29 +289,17 @@ export class SparkplugNode extends (
      * @param {sparkplugMetric[]} metrics Array of metric objects to be published
      */
     async publishDData(deviceId: string, metrics: sparkplugMetric[]) {
-
-        // If metrics are to be published immediately...
-        if (this.#metrics.getByName("Node Control/Async Publish Mode").value) {
-            // Prepare payload and publish metrics now!
-            let payload = await this.#preparePayload(metrics);
-            try {
-                this.#client.publishDeviceData(deviceId, payload, {
-                    compress: this.#metrics.getByName("Node Control/Payload Compression").value,
-                });
-                // console.dir(payload, {depth: null});
-                // console.log(Date.now() - (metrics[2].value as number));
-                log(`Async DDATA published for ${deviceId}.`);
-            } catch (err) {
-                console.log(err);
-            }
-        } else {
-            // Otherwise if metrics are being buffered before publishing
-            // If this device doesn't have an entry in the metric buffer, add one
-            if (!this.#metricBuffer[deviceId]) {
-                this.#metricBuffer[deviceId] = [];
-            }
-            // Then add these metrics to the publish buffer to be published later
-            this.#metricBuffer[deviceId] = this.#metricBuffer[deviceId].concat(metrics);
+        // Prepare payload and publish metrics now!
+        let payload = await this.#preparePayload(metrics);
+        try {
+            this.#client.publishDeviceData(deviceId, payload, {
+                compress: this.#metrics.getByName("Node Control/Payload Compression").value,
+            });
+            // console.dir(payload, {depth: null});
+            // console.log(Date.now() - (metrics[2].value as number));
+            log(`Async DDATA published for ${deviceId}.`);
+        } catch (err) {
+            console.log(err);
         }
     }
 

--- a/acs-manager/app/Domain/Devices/Actions/UpdateDeviceInformationAction.php
+++ b/acs-manager/app/Domain/Devices/Actions/UpdateDeviceInformationAction.php
@@ -20,7 +20,7 @@ class UpdateDeviceInformationAction
      * - The user must have access to the node that the device is attached to
      */
 
-    public function execute(Device $device, $deviceId)
+    public function execute(Device $device, $deviceId, $pubInterval)
     {
         if (! auth()->user()->administrator && ! auth()->user()->accessibleNodes->contains($device->node)) {
             throw new ActionFailException('You do not have permission to update this device.', 401);
@@ -31,6 +31,7 @@ class UpdateDeviceInformationAction
         // ===================
         $device->update([
             'device_id' => $deviceId,
+            'pub_interval' => $pubInterval,
         ]);
 
         // Create a for all active devices in this node and attach it to the Node

--- a/acs-manager/app/Domain/Devices/Resources/DeviceDetailResource.php
+++ b/acs-manager/app/Domain/Devices/Resources/DeviceDetailResource.php
@@ -40,6 +40,7 @@ class DeviceDetailResource extends JsonResource
                 JSON_THROW_ON_ERROR
             ) : null,
             'device_connection' => $this->deviceConnection,
+            'pub_interval' => $this['pub_interval'],
         ];
     }
 }

--- a/acs-manager/app/Domain/Nodes/Actions/UpdateEdgeAgentConfigurationForNodeAction.php
+++ b/acs-manager/app/Domain/Nodes/Actions/UpdateEdgeAgentConfigurationForNodeAction.php
@@ -178,6 +178,7 @@ class UpdateEdgeAgentConfigurationForNodeAction
                     // We currently copy across the same pollInt and payloadFormat to every device from the deviceConnection. If the need arises we can
                     // natively move these to properties of the device.
                     'pollInt' => $deviceConnectionConfig->pollInt,
+                    'pubInterval' => $device->pub_interval,
                     'payloadFormat' => $deviceConnectionConfig->payloadFormat ?? 'Defined by Protocol',
                 ];
             }

--- a/acs-manager/app/Http/Controllers/DeviceController.php
+++ b/acs-manager/app/Http/Controllers/DeviceController.php
@@ -120,7 +120,8 @@ class DeviceController extends Controller
             );
         }
 
-        (new UpdateDeviceInformationAction)->execute($device, $validated['device_id']);
+        (new UpdateDeviceInformationAction)->execute(
+                $device, $validated['device_id'], $validated['pub_interval']);
     }
 
     public function destroy(DeleteDeviceRequest $request)

--- a/acs-manager/app/Http/Requests/UpdateDeviceInformationRequest.php
+++ b/acs-manager/app/Http/Requests/UpdateDeviceInformationRequest.php
@@ -29,6 +29,7 @@ class UpdateDeviceInformationRequest extends FormRequest
     {
         return [
             'device_id' => ['required', 'string', 'min:3', 'regex:/^\w+$/i'],
+            'pub_interval' => ['required', 'integer', 'min:0'],
         ];
     }
 }

--- a/acs-manager/database/migrations/2024_10_08_144300_add_device_pubinterval.php
+++ b/acs-manager/database/migrations/2024_10_08_144300_add_device_pubinterval.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ *  Factory+ / AMRC Connectivity Stack (ACS) Manager component
+ *  Copyright 2024 AMRC
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table("devices", function (Blueprint $table) {
+            $table->unsignedInteger('pub_interval')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->dropColumn('pub_interval');
+        });
+    }
+};

--- a/acs-manager/resources/js/components/Devices/DeviceEditorInformationTab.vue
+++ b/acs-manager/resources/js/components/Devices/DeviceEditorInformationTab.vue
@@ -6,14 +6,20 @@
 <template>
   <div class="flex flex-col px-10 py-6 items-center flex-grow">
     <div class="flex flex-col items-center gap-6">
-      <form-control-input :key="'deviceId'" :control="deviceIdControl" :valid="v$" :value="deviceId"
-                          @valueUpdated="deviceIdUpdated"
-                          @keyUpEnter="updateDeviceId"/>
+      <form-control-input :key="'deviceId'" :control="deviceIdControl"
+        :valid="v$.deviceId" :value="deviceId" @valueUpdated="deviceIdUpdated"/>
+      <div class="w-full">
+        <form-control-input :key="'pubInterval'" :control="pubIntervalControl"
+          :valid="v$.pubInterval" :value="pubInterval"
+          @valueUpdated="pubIntervalUpdated"/>
+      </div>
       <div class="w-full">
         <form-control-input :key="'deviceUUID'" :control="deviceUUIDControl" :valid="{}" :value="device?.instance_uuid"/>
       </div>
     </div>
-    <button @mouseup="updateDeviceId" :disabled="loading || (v$ && (!v$.$dirty || v$.$invalid))" class="fpl-button-brand h-10 ml-auto w-32 mt-6">
+    <button @mouseup="updateDeviceInfo" 
+      :disabled="loading || (v$ && (!v$.$anyDirty || v$.$invalid))"
+      class="fpl-button-brand h-10 ml-auto w-32 mt-6">
       <div v-if="loading === false" class="text-base mr-3 ml-10 flex items-center justify-center">
         Save
         <i class="fa-sharp fa-solid fa-save ml-2"></i>
@@ -49,6 +55,9 @@ export default {
       handler (val) {
         this.deviceIdControl.value = val.device_id;
         this.deviceId = val.device_id;
+        const pubInt = val.pub_interval.toString();
+        this.pubIntervalControl.value = pubInt;
+        this.pubInterval = pubInt;
       }, deep: true,
     },
   },
@@ -58,14 +67,20 @@ export default {
       this.deviceId = val;
       this.v$.deviceId.$touch();
     },
+    pubIntervalUpdated (val) {
+      this.pubInterval = val;
+      this.v$.pubInterval.$touch();
+    },
 
-    updateDeviceId() {
+    updateDeviceInfo() {
       if (this.loading) {
         return;
       }
       this.loading = true;
       axios.patch(`/api/devices/${this.device.id}`, {
         'device_id': this.deviceId,
+        /* The vuelidation should not allow this to fail */
+        'pub_interval': Number.parseInt(this.pubInterval),
       }).then(() => {
         this.loading = false;
         this.requestDataReloadFor('device');
@@ -92,6 +107,11 @@ export default {
         minLength: minLength(3),
         deviceNameValid: helpers.withMessage('The device name does not conform to the Factory+ specification.', helpers.regex(/^\w+?$/i)),
       },
+      pubInterval: {
+        required,
+        unsignedInt: helpers.withMessage(
+          "An integer is required", helpers.regex(/^[0-9]+$/)),
+      },
     };
   },
 
@@ -100,12 +120,21 @@ export default {
       loading: false,
       deviceId: this.device ? this.device.device_id : 'Device',
       deviceUUID: this.device ? this.device.instance_uuid : 'Not yet assigned',
+      pubInterval: this.device?.pub_interval?.toString() ?? "0",
       deviceIdControl: {
         name: 'Device Name',
         description: 'Device names must comply with the naming convention outlined in the Factory+ specification.',
         placeholder: 'e.g. KUKA_KR360_5345243',
         infoLink: 'https://factoryplus.app.amrc.co.uk/core-framework/framework/messages-payload/framework-protocol#topic-structure',
         infoTooltip: 'Read naming convention',
+        type: 'input',
+        validations: {},
+        initialValue: '',
+        value: '',
+      },
+      pubIntervalControl: {
+        name: 'Publish interval',
+        description: 'Set to 0 to publish all received data immediately.',
         type: 'input',
         validations: {},
         initialValue: '',

--- a/acs-manager/resources/js/components/FormControls/Input.vue
+++ b/acs-manager/resources/js/components/FormControls/Input.vue
@@ -97,7 +97,7 @@ export default {
 
     localValue (val) {
 
-      if (val.length === 0) {
+      if (val == null || val.length === 0) {
         val = null
       } else if (this.type === 'number') {
         val = Number(val)


### PR DESCRIPTION
Allow configuration of batch publishing from the Manager.

* Deprecate the `asyncPubMode`/`pubInterval` properties on the Node configuration. The Manager has no interface to configure the Node and it doesn't really make sense for this to be a whole-node option.
* Create UI to configure a new per-Device `pubInterval` property.
* Change the Edge Agent to honour this new configuration. Remove the `asyncPubMode` implementation, it wasn't usable in practice without Manager support.
* Stop publishing the Node metrics related to `asyncPubMode`. Publish a `Publish Interval` metric on the Device.
* Make the poll/publish interval metrics read-only. We have no way to persist config changes any more.