### PR TITLE
Fix the build in the monorepo

### DIFF
--- a/acs-manager/app/Domain/Schemas/Actions/GetDeviceSchemasAction.php
+++ b/acs-manager/app/Domain/Schemas/Actions/GetDeviceSchemasAction.php
@@ -18,7 +18,7 @@ class GetDeviceSchemasAction
     {
         $cdb = resolve(ServiceClient::class)->getConfigDB();
 
-        $keys = ["name", "version", "created", "modified"];
+        $keys = ["name", "version"];
 
         /* This endpoint isn't wrapped in php-service-client yet. Using
          * search for this is a bit of a hack; properly we should call

--- a/acs-manager/resources/js/components/Schemas/SchemaBrowser.vue
+++ b/acs-manager/resources/js/components/Schemas/SchemaBrowser.vue
@@ -48,15 +48,6 @@
             {{
               item.version
             }}</a>
-          <a href="#"
-             class="text-gray-400">Created
-            {{
-              moment.unix(item.created).fromNow()
-            }},
-            Updated
-            {{
-              moment.unix(item.modified).fromNow()
-            }}</a>
         </div>
       </template>
     </ColumnList>

--- a/acs-schemas/deploy/bin/find-schemas.js
+++ b/acs-schemas/deploy/bin/find-schemas.js
@@ -3,7 +3,6 @@ import $fs from "fs/promises";
 import $path from "path";
 
 import Walk from "@root/walk";
-import git from "isomorphic-git";
 import YAML from "yaml";
 
 const schemas = "../schemas";
@@ -41,17 +40,9 @@ for (const [path, meta] of yamls.entries()) {
         throw `Schema_UUID mismatch for ${path}`;
     console.log("Found Schema_UUID %s", uuid);
 
-    const changes = (await git.log({
-        fs, 
-        dir:        "..", 
-        filepath:   $path.posix.relative("..", path),
-    })).map(l => l.commit.author.timestamp);
-
     configs[uuid] = {
         metadata: {
             ...meta,
-            created:    changes.at(-1),
-            modified:   changes.at(0),
         },
         schema,
     };

--- a/acs-schemas/deploy/package.json
+++ b/acs-schemas/deploy/package.json
@@ -13,6 +13,6 @@
   "dependencies": {
     "@amrc-factoryplus/service-client": "^1.3.6",
     "@root/walk": "^1.1.0",
-    "isomorphic-git": "^1.27.1"
+    "yaml": "^2.6.0"
   }
 }


### PR DESCRIPTION
We can't retrieve Git timestamps in the monorepo as we don't have the Git history in the Docker context.