### PR TITLE
Make the ConfigDB body size limit configurable

### DIFF
--- a/acs-configdb/bin/api.js
+++ b/acs-configdb/bin/api.js
@@ -50,6 +50,7 @@ const api = await new WebAPI({
     keytab:     process.env.SERVER_KEYTAB,
     http_port:  process.env.PORT,
     max_age:    process.env.CACHE_MAX_AGE,
+    body_limit: process.env.BODY_LIMIT,
 
     routes: app => {
         /* No fancy query-string parsing */

--- a/acs-configdb/package.json
+++ b/acs-configdb/package.json
@@ -19,7 +19,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@amrc-factoryplus/service-api": "^0.0.1",
+    "@amrc-factoryplus/service-api": "^0.0.2-bmz.9",
     "@amrc-factoryplus/utilities": "2.0.0",
     "ajv": "^8.10.0",
     "ajv-formats": "^2.1.1",

--- a/acs-configdb/package.json
+++ b/acs-configdb/package.json
@@ -19,7 +19,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@amrc-factoryplus/service-api": "^0.0.2-bmz.9",
+    "@amrc-factoryplus/service-api": "^0.0.2",
     "@amrc-factoryplus/utilities": "2.0.0",
     "ajv": "^8.10.0",
     "ajv-formats": "^2.1.1",

--- a/deploy/templates/configdb/configdb.yaml
+++ b/deploy/templates/configdb/configdb.yaml
@@ -132,6 +132,8 @@ spec:
             - name: VERBOSE
               value: "1"
 {{ include "amrc-connectivity-stack.cache-max-age" (list . "configdb") | indent 12 }}
+            - name: BODY_LIMIT
+              value: "{{ .Values.configdb.bodyLimit }}"
             # If this is set it names a principal which overrides all ACLs. This should be turned off in production.
             - name: ROOT_PRINCIPAL
               value: admin@{{ .Values.identity.realm | required "values.identity.realm is required!" }}

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -98,6 +98,7 @@ configdb:
     # -- The repository of the Configuration Store component
     repository: acs-configdb
     pullPolicy: IfNotPresent
+  bodyLimit: 100kb
 
 monitor:
   enabled: true


### PR DESCRIPTION
Accept a Helm value to configure the size of request body accepted by the ConfigDB. We are hitting the limit with some large Edge Agent config files.