### PR TITLE
New Auth spec

### DIFF
--- a/acs-auth/bin/sexpr.js
+++ b/acs-auth/bin/sexpr.js
@@ -1,0 +1,361 @@
+/* Experiments with expanding s-exprs */
+
+import util from "util";
+
+import imm from "immutable";
+
+export const builtins = new Map();
+export const expanders = new Set();
+export const functions = new Map();
+
+const verbose = process.env.VERBOSE ? console.log : () => {};
+
+/* Might this form expand to a list? */
+function expandable (f, definitions) {
+    if (!Array.isArray(f))
+        return false;
+    if (functions.has(f[0]))
+        return true;
+    if (definitions.has(f[0]))
+        return true;
+    if (expanders.has(f[0]))
+        return true;
+    return false;
+}
+
+export function evaluate (depth, definitions, expr) {
+    verbose("EVAL[%s] %O %O", depth, definitions, expr);
+
+    /* Constants */
+    if (expr == null || typeof expr != "object")
+        return [expr];
+
+    /* Recursion */
+    if (depth > 20)
+        throw "Recursion exceeded";
+    const eve = (x, e) => {
+        const rv = evaluate(depth + 1, e, x);
+        verbose(" -> [%s] %O", depth + 1, rv);
+        return rv;
+    };
+    const ev = x => eve(x, definitions);
+    const sc = x => {
+        const v = ev(x);
+        if (v.length != 1)
+            throw util.format("Expected single element, not %O", v);
+        return v[0];
+    };
+
+    /* Evaluate tuple values */
+    if (!Array.isArray(expr))
+        return [
+            Object.fromEntries(
+                Object.entries(expr)
+                    .map(([k, v]) => [k, sc(v)]))];
+
+    /* Now that we have [get], and given that we don't have lambdas, I'm
+     * not sure this evaluation is needed any more. */
+    const name = sc(expr[0]);
+
+    if (Array.isArray(name))
+        throw "Unexpected list as function name";
+
+    const letbind = (bind, body) => {
+        const entries = new Map(definitions);
+        for (let i = 0; i < bind.length; i += 2)
+            /* This is let* */
+            entries.set(bind[i], eve(bind[i + 1], entries));
+        return body.flatMap(v => eve(v, entries));
+    };
+
+    /* Special forms */
+    switch (name) {
+        case "quote":
+            return expr.slice(1);
+
+        case "list":
+            return expr.slice(1).flatMap(ev);
+
+        case "let": {
+            const [, bind, ...body] = expr;
+            return letbind(bind, body);
+        }
+
+        case "if": {
+            const cond = sc(expr[1]);
+            const listify = l => l.length == 1 ? l[0] : ["list", ...l];
+            if (Array.isArray(cond))
+                return [["if", cond, 
+                    listify(ev(expr[2])),
+                    listify(ev(expr[3]))]];
+            if (cond) return ev(expr[2]);
+            if (expr.length < 3) return [];
+            return ev(expr[3]);
+        }
+
+        case "map": {
+            const [bind, ...body] = expr[1];
+            const list = expr.slice(2).flatMap(ev);
+            if (list.some(v => expandable(v, definitions)))
+                return [["map", 
+                    [bind, ...letbind([bind, ["quote", [bind]]], body)],
+                    ...list]];
+            return list
+                .map(v => ["list", v])
+                .flatMap(e => letbind([bind, e], body));
+        }
+    }
+
+    /* Evaluate arguments */
+    const args = expr.slice(1).flatMap(ev);
+
+    /* Builtins cannot be renamed or overridden */
+    if (builtins.has(name)) {
+        /* Unevaluated arguments mean the whole call must be deferred */
+        if (args.some(Array.isArray))
+            return [[name, ...args]];
+        return builtins.get(name)(...args);
+    }
+
+    if (definitions.has(name))
+        return definitions.get(name);
+
+    if (functions.has(name)) {
+        const [param, ...body] = functions.get(name);
+        const bind = param.flatMap((p, i) => [p, args[i]]);
+        return letbind(bind, body);
+    }
+
+    /* We return a list (everything is flatmapped), so we need to quote
+     * an unevaluated form to return it. */
+    return [[name, ...args]];
+}
+
+/* Forms which may require flatmapping if left unevaluated */
+expanders.add("list");
+expanders.add("let");
+expanders.add("if");
+expanders.add("map");
+expanders.add("lookup");
+expanders.add("members");
+
+builtins.set("get", (tuple, key) => [tuple[key]]);
+builtins.set("has", (tuple, key) => [key in tuple]);
+builtins.set("merge", (...tups) => [Object.assign({}, ...tups)]);
+builtins.set("format", (f, ...a) => [util.format(f, ...a)]);
+
+builtins.set("principal", () => ["ConfigDB-SA"]);
+const ids = new Map();
+ids.set("ConfigDB-SA", { sparkplug: { group: "Core", node: "ConfigDB" } });
+builtins.set("id", (princ, type) => [ids.get(princ)[type]]);
+
+functions.set("Id", [["x"], ["x"]]);
+functions.set("Twice", [["y"], ["y"], ["y"]]);
+
+functions.set("SpTopic", [["type", "addr"],
+    ["if", ["has", ["addr"], "device"],
+        ["format", "spBv1.0/%s/D%s/%s/%s",
+            ["get", ["addr"], "group"], 
+            ["type"], 
+            ["get", ["addr"], "node"], 
+            ["get", ["addr"], "device"]],
+        ["format", "spBv1.0/%s/N%s/%s",
+            ["get", ["addr"], "group"], 
+            ["type"], 
+            ["get", ["addr"], "node"]]]]);
+functions.set("ParticipateAsNode", [[], 
+    ["let", ["node", ["id", ["principal"], "sparkplug"]],
+        ["map", ["addr",
+                ["Publish", ["SpTopic", "BIRTH", ["addr"]]],
+                ["Publish", ["SpTopic", "DATA", ["addr"]]],
+                ["Publish", ["SpTopic", "DEATH", ["addr"]]],
+                ["Subscribe", ["SpTopic", "CMD", ["addr"]]]],
+            ["node"],
+            ["merge", ["node"], { device: "+" }]]]]);
+functions.set("ReadAddress", [["addr"],
+      ["map", ["t", ["Subscribe", ["SpTopic", ["t"], ["addr"]]]],
+        "BIRTH", "DEATH", "DATA"]]);
+
+functions.set("Rebirth", [["addr"],
+      ["SendCmd", {
+        address: ["addr"],
+        name: ["if", ["has", ["addr"], "device"],
+          "Device Control/Rebirth", "Node Control/Rebirth"],
+        type: "Boolean",
+        value: true,
+      }]]);
+
+functions.set("ConsumeNode", [["node"],
+      ["let", ["addr", ["id", ["node"], "sparkplug"]],
+        ["map", ["a", ["ReadAddress", ["a"]], ["Rebirth", ["a"]]],
+          ["addr"], 
+          ["merge", ["addr"], { device: "+" }]]]]);
+functions.set("ConsumeAddress", [["addr"],
+      ["ReadAddress", ["addr"]],
+      ["Rebirth", ["addr"]]]);
+
+functions.set("DeviceAddress", [["device"],
+      ["let", ["info", ["lookup", "DirectorySvc", "v1/device/", ["device"]]],
+        ["if", ["has", ["info"], "device_id"],
+            { group:  ["get", ["info"], "group_id"],
+              node: ["get", ["info"], "node_id"],
+              device: ["get", ["info"], "device_id"],
+            },
+            { group: ["get", ["info"], "group_id"],
+              node: ["get", ["info"], "node_id"],
+            }]]]);
+functions.set("DeviceAddressDirect", [["device"],
+    ["lookup", "DirectorySvc", "v1/device/address/", ["device"]]]);
+functions.set("ConsumeDevice", [["device"],
+      ["ConsumeAddress", ["DeviceAddressDirect", ["device"]]]]);
+functions.set("ConsumeGroup", [["group"],
+    ["map", ["m", ["ConsumeDevice", ["m"]]],
+        ["members", ["group"]]]]);
+
+export const ev = v => evaluate(0, new Map(), v);
+
+const logger = new console.Console({
+    stdout: process.stdout,
+    inspectOptions: {
+        depth: null,
+        compact: 10,
+        breakLength: 90,
+    },
+});
+
+function is (msg, expr, want) {
+    const got = imm.fromJS(ev(expr)).toSet();
+    if (imm.fromJS(want).toSet().equals(got)) {
+        logger.log("ok %s", msg);
+        return;
+    }
+    logger.log("not ok %s\nEvaluated %O\nExpected %O\nGot %O",
+        msg, expr, want, got.toJS());
+    throw "Test failed";
+}
+
+is("number", 1, [1]);
+is("string", "foo", ["foo"]);
+is("tuple", {a: 2}, [{a: 2}]);
+is("get", ["get", {a: 2}, "a"], [2]);
+is("unevaluated", ["Unknown", 2], [["Unknown", 2]]);
+
+is("list", ["list", 1], [1]);
+is("list", ["list", 1, 2, 3], [1, 2, 3]);
+is("list uneval", ["list", ["Uk", 1], ["Uk", 2]], [["Uk", 1], ["Uk", 2]]);
+
+is("if", ["if", true, 1, 2], [1]);
+is("!if", ["if", false, 1, 2], [2]);
+is("merge", ["merge", {a:2}, {b:3}], [{a:2, b:3}]);
+is("has", ["has", {a:2}, "a"], [true]);
+is("!has", ["has", {a:2}, "b"], [false]);
+is("if has", ["if", ["has", {foo:5}, "bar"], "yes", "no"], ["no"]);
+
+is("map constant", ["map", ["a", 1], 2, 3], [1, 1]);
+is("map expand", ["map", ["a", ["a"]], 2, 3], [2, 3]);
+is("map flatmap", ["map", ["a", ["a"], ["Unk", ["a"]]], 2, 3],
+    [2, ["Unk", 2], 3, ["Unk", 3]]);
+is("map unevaluated",
+    ["map", ["a", ["Grant", ["a"]]], ["lookup", "Group"]],
+    [["map", ["a", ["Grant", ["a"]]], ["lookup", "Group"]]]);
+is("map uneval expand bindings",
+    ["let", ["a", 2], ["map", ["b", ["Gr", ["a"], ["b"]]], ["lookup"]]],
+    [["map", ["b", ["Gr", 2, ["b"]]], ["lookup"]]]);
+is("map uneval scope",
+    ["let", ["a", 2], ["map", ["a", ["a"]], ["lookup"]]],
+    [["map", ["a", ["a"]], ["lookup"]]]);
+
+is("call Id", ["Id", 2], [2]);
+is("call Twice", ["Twice", 4], [4, 4]);
+is("nested call", ["Twice", ["Id", 6]], [6, 6]);
+is("let", ["let", ["a", 4], ["a"]], [4]);
+is("nested let", 
+    ["let", ["a", 4], ["let", ["b", 6], ["a"], ["b"]]],
+    [4, 6]);
+is("recursive let",
+    ["let", ["a", 4, "b", ["Ck", ["a"]]], ["b"]],
+    [["Ck", 4]]);
+    
+is("SpTopic node",
+    ["SpTopic", "DATA", { group: "Gr", node: "Nd" }],
+    ["spBv1.0/Gr/NDATA/Nd"]);
+is("SpTopic device",
+    ["SpTopic", "BIRTH", {group: "Gr", node: "Nd", device: "Dv" }],
+    ["spBv1.0/Gr/DBIRTH/Nd/Dv"]);
+is("principal", ["principal"], ["ConfigDB-SA"]);
+is("id sparkplug", 
+    ["id", ["principal"], "sparkplug"],
+    [{group: "Core", node: "ConfigDB"}]);
+is("ParticipateAsNode", ["ParticipateAsNode"],
+    [["Publish", "spBv1.0/Core/NBIRTH/ConfigDB"],
+    ["Publish", "spBv1.0/Core/NDATA/ConfigDB"],
+    ["Publish", "spBv1.0/Core/NDEATH/ConfigDB"],
+    ["Publish", "spBv1.0/Core/DBIRTH/ConfigDB/+"],
+    ["Publish", "spBv1.0/Core/DDATA/ConfigDB/+"],
+    ["Publish", "spBv1.0/Core/DDEATH/ConfigDB/+"],
+    ["Subscribe", "spBv1.0/Core/NCMD/ConfigDB"],
+    ["Subscribe", "spBv1.0/Core/DCMD/ConfigDB/+"]]);
+
+is("ReadAddress node",
+    ["ReadAddress", { group: "Gr", node: "Nd" }],
+    [["Subscribe", "spBv1.0/Gr/NBIRTH/Nd"],
+    ["Subscribe", "spBv1.0/Gr/NDATA/Nd"],
+    ["Subscribe", "spBv1.0/Gr/NDEATH/Nd"]]);
+is("ConsumeAddress node",
+    ["ConsumeAddress", { group: "Gr", node: "Nd" }],
+    [["Subscribe", "spBv1.0/Gr/NBIRTH/Nd"],
+    ["Subscribe", "spBv1.0/Gr/NDATA/Nd"],
+    ["Subscribe", "spBv1.0/Gr/NDEATH/Nd"],
+    ["SendCmd", {
+        address: { group: "Gr", node: "Nd" },
+        name: "Node Control/Rebirth",
+        type: "Boolean",
+        value: true,
+    }]]);
+is("ConsumeAddress device",
+    ["ConsumeAddress", { group: "Gr", node: "Nd", device: "Dv" }],
+    [["Subscribe", "spBv1.0/Gr/DBIRTH/Nd/Dv"],
+    ["Subscribe", "spBv1.0/Gr/DDATA/Nd/Dv"],
+    ["Subscribe", "spBv1.0/Gr/DDEATH/Nd/Dv"],
+    ["SendCmd", {
+        address: { group: "Gr", node: "Nd", device: "Dv" },
+        name: "Device Control/Rebirth",
+        type: "Boolean",
+        value: true,
+    }]]);
+
+{
+    const dev = ["lookup", "DirectorySvc", "v1/device/", "ConfigDB-SA"];
+    is("DeviceAddress expanded", ["DeviceAddress", "ConfigDB-SA"], [
+        ["if", ["has", dev, "device_id"],
+            {   group:  ["get", dev, "group_id"],
+                node:   ["get", dev, "node_id"],
+                device: ["get", dev, "device_id"],
+            },
+            {   group:  ["get", dev, "group_id"],
+                node:   ["get", dev, "node_id"],
+            }],
+    ]);
+}
+{
+    const dev = ["lookup", "DirectorySvc", "v1/device/address/", "ConfigDB-SA"];
+    const ntopic = t => ["format", "spBv1.0/%s/N%s/%s",
+        ["get", dev, "group"], t, ["get", dev, "node"]];
+    const dtopic = t => ["format", "spBv1.0/%s/D%s/%s/%s",
+        ["get", dev, "group"], t, ["get", dev, "node"], ["get", dev, "device"]];
+    const topic = t => ["if", ["has", dev, "device"], dtopic(t), ntopic(t)];
+
+    is("DeviceAddress direct", ["DeviceAddressDirect", "ConfigDB-SA"], [dev]);
+    is("ConsumeDevice", ["ConsumeDevice", "ConfigDB-SA"], [
+        ["Subscribe", topic("BIRTH")],
+        ["Subscribe", topic("DATA")],
+        ["Subscribe", topic("DEATH")],
+        ["SendCmd", {
+            address: dev,
+            name: ["if", ["has", dev, "device"],
+                "Device Control/Rebirth", "Node Control/Rebirth"],
+            type: "Boolean",
+            value: true,
+        }],
+    ]);
+}

--- a/acs-auth/bin/sexpr.js
+++ b/acs-auth/bin/sexpr.js
@@ -5,24 +5,19 @@ import util from "util";
 import imm from "immutable";
 
 export const builtins = new Map();
-export const lookups = new Map();
 export const permissions = new Set();
 export const functions = new Map();
 
 const verbose = process.env.VERBOSE ? console.log : () => {};
 
-function value (v) {
-    if (Array.isArray(v))
-        throw util.format("Unexpected unevaluated form %O", v);
-    return v;
-}
+function is_scalar (v) { return v == null || typeof v != "object"; }
 
 export function evaluate (expr, ctx) {
     verbose("EVAL[%s] %O %O", ctx.depth,
         Object.fromEntries(ctx.definitions.entries()), expr);
 
     /* Constants */
-    if (expr == null || typeof expr != "object")
+    if (is_scalar(expr))
         return [expr];
 
     /* Recursion */
@@ -38,51 +33,44 @@ export function evaluate (expr, ctx) {
         return rv;
     };
     const ev = x => eve(x, ctx.definitions);
-    const sc = x => {
-        const v = ev(x);
+    const sc = v => {
         if (v.length != 1)
             throw util.format("Expected single element, not %O", v);
-        return value(v[0]);
+        return v[0];
     };
+    const sce = x => sc(ev(x));
 
     /* Evaluate tuple values */
     if (!Array.isArray(expr))
         return [
             Object.fromEntries(
                 Object.entries(expr)
-                    .map(([k, v]) => [k, sc(v)]))];
+                    .map(([k, v]) => [k, sce(v)]))];
 
     /* Now that we have [get], and given that we don't have lambdas, I'm
      * not sure this evaluation is needed any more. */
     //const name = sc(expr[0]);
-    const name = value(expr[0]);
+    const name = expr[0];
 
-    if (Array.isArray(name))
-        throw "Unexpected list as function name";
-
-    const letbind = (bind, body) => {
-        const entries = new Map(ctx.definitions);
-        for (let i = 0; i < bind.length; i += 2)
-            /* This is let* */
-            entries.set(bind[i], eve(bind[i + 1], entries));
-        return body.flatMap(v => eve(v, entries));
-    };
+    if (typeof name != "string")
+        throw util.format("Unexpected function name: %o", name);
 
     /* Special forms */
     switch (name) {
         case "quote":
             return expr.slice(1);
 
-        case "list":
-            return expr.slice(1).flatMap(ev);
-
         case "let": {
             const [, bind, ...body] = expr;
-            return letbind(bind, body);
+            const entries = new Map(ctx.definitions);
+            for (let i = 0; i < bind.length; i += 2)
+                /* This is let* */
+                entries.set(bind[i], eve(bind[i + 1], entries));
+            return body.flatMap(v => eve(v, entries));
         }
 
         case "if": {
-            const cond = sc(expr[1]);
+            const cond = sce(expr[1]);
             if (cond) return ev(expr[2]);
             if (expr.length < 3) return [];
             return ev(expr[3]);
@@ -93,7 +81,8 @@ export function evaluate (expr, ctx) {
             verbose("MAP: bind %O, body %O, list %O", bind, body, list);
             return list
                 .flatMap(ev)
-                .flatMap(e => letbind([bind, e], body));
+                .map(val => new Map([...ctx.definitions, [bind, [val]]]))
+                .flatMap(env => body.flatMap(x => eve(x, env)));
         }
 
     }
@@ -102,20 +91,28 @@ export function evaluate (expr, ctx) {
     const args = expr.slice(1).flatMap(ev);
 
     /* Builtins cannot be renamed or overridden */
-    if (builtins.has(name)) {
-        /* Unevaluated arguments mean the whole call must be deferred */
-        if (args.some(Array.isArray))
-            return [[name, ...args]];
+    if (builtins.has(name))
         return builtins.get(name)(...args);
-    }
 
-    if (ctx.definitions.has(name))
-        return ctx.definitions.get(name);
+    if (ctx.definitions.has(name)) {
+        let rv = ctx.definitions.get(name);
+        if (!args.length) return rv;
+
+        rv = sc(rv);
+        for (const key of args) {
+            if (typeof rv != "object")
+                throw util.format("Invalid indexing: %o", args);
+            if (rv == null || !(key in rv))
+                return null;
+            rv = rv[key];
+        }
+        return [rv];
+    }
 
     if (functions.has(name)) {
         const [param, ...body] = functions.get(name);
-        const bind = param.flatMap((p, i) => [p, args[i]]);
-        return letbind(bind, body);
+        const env = new Map(param.map((p, i) => [p, [args[i]]]));
+        return body.flatMap(e => eve(e, env));
     }
 
     if (permissions.has(name)) 
@@ -124,22 +121,79 @@ export function evaluate (expr, ctx) {
     throw util.format("Unknown form %s", name);
 }
 
+function preprocess_expr (expr, ctx) {
+    verbose("PREPROCESSING %o", expr);
+    if (is_scalar(expr))
+        return;
+
+    if (!Array.isArray(expr)) {
+        Object.values(expr).forEach(e => preprocess_expr(e, ctx));
+        return;
+    }
+
+    const [name, ...args] = expr;
+    if (name == "lookup") {
+        const [svc, url, item] = args;
+        if (!is_scalar(svc) || !is_scalar(url))
+            throw util.format("Inappropriate args for lookup: %O", args);
+        ctx.lookups.add(`${svc}/${url}`);
+        preprocess_expr(item, ctx);
+    }
+    else {
+        if (permissions.has(name))
+            ctx.perms.add(name);
+        if (functions.has(name))
+            ctx.calls.add(name);
+        args.forEach(e => preprocess_expr(e, ctx));
+    }
+}
+        
+function preprocess ([args, ...definition]) {
+    const ctx = {
+        calls:      new Set(),
+        lookups:    new Set(),
+        perms:      new Set(),
+    };
+    definition.forEach(e => preprocess_expr(e, ctx));
+    return ctx;
+}
+
+function preprocess_all () {
+    const meta = new Map();
+    for (const [name, definition] of functions.entries()) {
+        meta.set(name, preprocess(definition));
+    }
+    return meta;
+}
+
+let principal;
+const ids = new Map();
+const owners = new Map();
+const lookups = new Map();
+
+builtins.set("flat", a => a);
 builtins.set("get", (tuple, key) => [tuple[key]]);
 builtins.set("has", (tuple, key) => [key in tuple]);
 builtins.set("merge", (...tups) => [Object.assign({}, ...tups)]);
 builtins.set("format", (f, ...a) => [util.format(f, ...a)]);
+builtins.set("list", (...a) => [a]);
 builtins.set("lookup", (s, u, a) => {
-    const key = `${s}/${u}${a}`;
+    const key = `${s}/${u}`.replace("%", a);
     const val = lookups.get(key);
     verbose("LOOKUP: %s -> %o", key, val);
     return val ? [val] : [];
 });
-
-builtins.set("principal", () => ["ConfigDB-SA"]);
-const ids = new Map();
-ids.set("ConfigDB-SA", { sparkplug: { group: "Core", node: "ConfigDB" } });
+builtins.set("principal", () => [principal]);
 builtins.set("id", (princ, type) => [ids.get(princ)[type]]);
 
+ids.set("ConfigDB-SA", { sparkplug: { group: "Core", node: "ConfigDB" } });
+ids.set("Directory-SA", { sparkplug: { group: "Core", node: "Directory" } });
+ids.set("Edge-Cl", { sparkplug: { group: "Edge" } });
+
+lookups.set("ConfigDBSvc/v2/group/EdgeGroups/members",
+    ["EdgeAgent", "EdgeSync"]);
+lookups.set("ConfigDBSvc/v2/group/Services/members",
+    ["ConfigDB-SA", "Directory-SA"]);
 lookups.set("DirectorySvc/v1/device/Node",
     { group_id: "Group", node_id: "Node" });
 lookups.set("DirectorySvc/v1/device/address/Node",
@@ -148,11 +202,15 @@ lookups.set("DirectorySvc/v1/device/Device",
     { group_id: "Group", node_id: "Node", device_id: "Device" });
 lookups.set("DirectorySvc/v1/device/address/Device",
     { group: "Group", node: "Node", device: "Device" });
+lookups.set("DirectorySvc/v1/device/address/ConfigDB-SA",
+    { group: "Core", node: "ConfigDB" });
+lookups.set("DirectorySvc/v1/device/address/Directory-SA",
+    { group: "Core", node: "Directory" });
 
-permissions.add("Unknown");
-permissions.add("Publish");
-permissions.add("Subscribe");
-permissions.add("SendCmd");
+["Unknown", "Publish", "Subscribe", "SendCmd",
+    "CreateObject", "ReadConfig", "WriteConfig",
+    "ReadIdentity", "WriteIdentity", "ManageGroup",
+].forEach(p => permissions.add(p));
 
 functions.set("Id", [["x"], ["x"]]);
 functions.set("Twice", [["y"], ["y"], ["y"]]);
@@ -160,14 +218,14 @@ functions.set("Twice", [["y"], ["y"], ["y"]]);
 functions.set("SpTopic", [["type", "addr"],
     ["if", ["has", ["addr"], "device"],
         ["format", "spBv1.0/%s/D%s/%s/%s",
-            ["get", ["addr"], "group"], 
+            ["addr", "group"], 
             ["type"], 
-            ["get", ["addr"], "node"], 
-            ["get", ["addr"], "device"]],
+            ["addr", "node"], 
+            ["addr", "device"]],
         ["format", "spBv1.0/%s/N%s/%s",
-            ["get", ["addr"], "group"], 
+            ["addr", "group"], 
             ["type"], 
-            ["get", ["addr"], "node"]]]]);
+            ["addr", "node"]]]]);
 functions.set("ParticipateAsNode", [[], 
     ["let", ["node", ["id", ["principal"], "sparkplug"]],
         ["map", ["addr",
@@ -200,22 +258,43 @@ functions.set("ConsumeAddress", [["addr"],
       ["Rebirth", ["addr"]]]);
 
 functions.set("DeviceAddress", [["device"],
-      ["let", ["info", ["lookup", "DirectorySvc", "v1/device/", ["device"]]],
+      ["let", ["info", ["lookup", "DirectorySvc", "v1/device/%", ["device"]]],
         ["if", ["has", ["info"], "device_id"],
-            { group:  ["get", ["info"], "group_id"],
-              node: ["get", ["info"], "node_id"],
-              device: ["get", ["info"], "device_id"],
+            { group:  ["info", "group_id"],
+              node: ["info", "node_id"],
+              device: ["info", "device_id"],
             },
-            { group: ["get", ["info"], "group_id"],
-              node: ["get", ["info"], "node_id"],
+            { group: ["info", "group_id"],
+              node: ["info", "node_id"],
             }]]]);
 functions.set("DeviceAddressDirect", [["device"],
-    ["lookup", "DirectorySvc", "v1/device/address/", ["device"]]]);
+    ["lookup", "DirectorySvc", "v1/device/address/%", ["device"]]]);
 functions.set("ConsumeDevice", [["device"],
       ["ConsumeAddress", ["DeviceAddressDirect", ["device"]]]]);
+
+functions.set("Members", [["group"],
+    ["flat", ["lookup", 
+        "ConfigDBSvc", "v2/group/%/members", ["group"]]]]);
+
 functions.set("ConsumeGroup", [["group"],
-    ["map", ["m", ["ConsumeDevice", ["m"]]],
-        ["members", ["group"]]]]);
+    ["map", ["m", ["ConsumeNode", ["m"]]], ["Members", ["group"]]]]);
+
+functions.set("KkForCluster", [["cluster"],
+    ["CreateObject", { class: "EdgeAccount", uuid: false }],
+    ["ReadConfig", { app: "Info", obj: "Mine" }],
+    ["WriteConfig", { app: "Info", obj: "Mine" }],
+    ["ReadIdentity", { uuid: "Mine" }],
+    ["let", ["addr", ["id", ["cluster"], "sparkplug"],
+            "group", ["addr", "group"]],
+        ["WriteIdentity", { uuid: "Mine", sparkplug: { group: ["group"] }}],
+        ["WriteIdentity", { uuid: "Mine", 
+            kerberos: ["format", "*/%s@REALM", ["group"]]}],
+        ["WriteIdentity", { uuid: "Mine",
+            kerberos: ["format", "nd1/%s/*@REALM", ["group"]]}]],
+    ["map", ["g", ["ManageGroup", { group: ["g"], member: "Mine"}]],
+        ["Members", "EdgeGroups"]]]);
+
+const metadata = preprocess_all();
 
 export const ev = v => evaluate(v, { depth: 0, definitions: new Map() });
 
@@ -228,15 +307,22 @@ const logger = new console.Console({
     },
 });
 
-function is (msg, expr, want) {
+let failed = [];
+function is (msg, expr, want_a, test) {
+    const want = imm.fromJS(want_a).toSet();
     const got = imm.fromJS(ev(expr)).toSet();
-    if (imm.fromJS(want).toSet().equals(got)) {
+    if (want.equals(got)) {
         logger.log("ok %s", msg);
         return;
     }
-    logger.log("not ok %s\nEvaluated %O\nExpected %O\nGot %O",
-        msg, expr, want, got.toJS());
-    throw "Test failed";
+    logger.log("not ok %s\n# Evaluated %O", msg, expr);
+    const not_want = got.subtract(want);
+    if (not_want.size > 0)
+        logger.log("# Didn't expect %O", not_want.sort().toJS());
+    const not_got = want.subtract(got);
+    if (not_got.size > 0)
+        logger.log("# Didn't get %O", not_got.sort().toJS());
+    failed.push(msg);
 }
 
 is("number", 1, [1]);
@@ -245,10 +331,14 @@ is("tuple", {a: 2}, [{a: 2}]);
 is("get", ["get", {a: 2}, "a"], [2]);
 is("perm", ["Unknown", 2], [["Unknown", 2]]);
 
-is("list", ["list", 1], [1]);
-is("list", ["list", 1, 2, 3], [1, 2, 3]);
+is("quote 1", ["quote", 1], [1]);
+is("quote list", ["quote", [1]], [[1]]);
+is("quote value", {a: ["quote", [2]]}, [{a: [2]}]);
+
+is("list", ["list", 1], [[1]]);
+is("list", ["list", 1, 2, 3], [[1, 2, 3]]);
 is("list perm", ["list", ["Unknown", 1], ["Unknown", 2]], 
-    [["Unknown", 1], ["Unknown", 2]]);
+    [[["Unknown", 1], ["Unknown", 2]]]);
 
 is("if", ["if", true, 1, 2], [1]);
 is("!if", ["if", false, 1, 2], [2]);
@@ -282,6 +372,8 @@ is("SpTopic node",
 is("SpTopic device",
     ["SpTopic", "BIRTH", {group: "Gr", node: "Nd", device: "Dv" }],
     ["spBv1.0/Gr/DBIRTH/Nd/Dv"]);
+
+principal = "ConfigDB-SA";
 is("principal", ["principal"], ["ConfigDB-SA"]);
 is("id sparkplug", 
     ["id", ["principal"], "sparkplug"],
@@ -355,3 +447,100 @@ is("ConsumeDevice Device", ["ConsumeDevice", "Device"], [
         value: true,
     }],
 ]);
+
+is("ConsumeGroup", ["ConsumeGroup", "Services"], [
+    ["Subscribe", "spBv1.0/Core/NBIRTH/ConfigDB"],
+    ["Subscribe", "spBv1.0/Core/NDATA/ConfigDB"],
+    ["Subscribe", "spBv1.0/Core/NDEATH/ConfigDB"],
+    ["Subscribe", "spBv1.0/Core/DBIRTH/ConfigDB/+"],
+    ["Subscribe", "spBv1.0/Core/DDATA/ConfigDB/+"],
+    ["Subscribe", "spBv1.0/Core/DDEATH/ConfigDB/+"],
+    ["SendCmd", {
+        address: { group: "Core", node: "ConfigDB" },
+        name: "Node Control/Rebirth",
+        type: "Boolean",
+        value: true,
+    }],
+    ["SendCmd", {
+        address: { group: "Core", node: "ConfigDB", device: "+" },
+        name: "Device Control/Rebirth",
+        type: "Boolean",
+        value: true,
+    }],
+    ["Subscribe", "spBv1.0/Core/NBIRTH/Directory"],
+    ["Subscribe", "spBv1.0/Core/NDATA/Directory"],
+    ["Subscribe", "spBv1.0/Core/NDEATH/Directory"],
+    ["Subscribe", "spBv1.0/Core/DBIRTH/Directory/+"],
+    ["Subscribe", "spBv1.0/Core/DDATA/Directory/+"],
+    ["Subscribe", "spBv1.0/Core/DDEATH/Directory/+"],
+    ["SendCmd", {
+        address: { group: "Core", node: "Directory" },
+        name: "Node Control/Rebirth",
+        type: "Boolean",
+        value: true,
+    }],
+    ["SendCmd", {
+        address: { group: "Core", node: "Directory", device: "+" },
+        name: "Device Control/Rebirth",
+        type: "Boolean",
+        value: true,
+    }],
+]);
+
+is("KkForCluster", ["KkForCluster", "Edge-Cl"], [
+  ["CreateObject", { class: "EdgeAccount", uuid: false }],
+  ["ManageGroup", { group: "EdgeAgent", member: "Mine" }],
+  ["ManageGroup", { group: "EdgeSync", member: "Mine" }],
+  ["ReadConfig", { app: "Info", obj: "Mine" }],
+  ["ReadIdentity", { uuid: "Mine" }],
+  ["WriteConfig", { app: "Info", obj: "Mine" }],
+  ["WriteIdentity", { uuid: "Mine", kerberos: "*/Edge@REALM" }],
+  ["WriteIdentity", { uuid: "Mine", kerberos: "nd1/Edge/*@REALM" }],
+  ["WriteIdentity", { uuid: "Mine", sparkplug: { group: "Edge" } }]
+]);
+
+if (failed.length) {
+    console.log("FAILED TESTS: %O", failed);
+    throw util.format("%s tests failed", failed.length);
+}
+
+/*
+logger.log("METADATA: %O", metadata);
+const Analysis = imm.Record({
+    calls:      imm.Set(),
+    lookups:    imm.Set(),
+    perms:      imm.Set(),
+});
+function analyze (name) {
+    const rr = f => {
+        const m = metadata.get(f);
+        const cs = imm.Seq(m.calls);
+        return cs.concat(imm.Seq([f]), cs.flatMap(rr))
+    };
+    const calls = rr(name).toSet();
+    return Analysis({
+        calls:      calls,
+        lookups:    calls.flatMap(f => metadata.get(f).lookups),
+        perms:      calls.flatMap(f => metadata.get(f).perms),
+    });
+}
+logger.log("ANALYZE ConsumeGroup: %O", analyze("ConsumeGroup").toJS());
+const analysis = imm.Seq.Set(functions.keys())
+    .toKeyedSeq()
+    .map(analyze)
+    .toMap();
+logger.log("ANALYSIS: %O", analysis.toJS());
+
+const Requirements = imm.Record({
+    functions:  imm.Set(),
+    lookups:    imm.Set(),
+});
+const requirements = analysis.entrySeq()
+    .flatMap(([f, a]) => a.perms.map(p => [p, f]))
+    .reduce((r, [p, f]) => r.set(p, r.get(p, imm.Set()).add(f)), imm.Map())
+    .map(fs => Requirements({
+        functions:  fs.flatMap(f => analysis.get(f).calls.add(f)),
+        lookups:    fs.flatMap(f => analysis.get(f).lookups),
+    }));
+logger.log("REQUIREMENTS: %O", requirements.toJS());
+*/

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,197 @@
+# Auth service redesign
+
+The Auth service was originally designed to replace the existing MQTT
+ACL and CCL databases. An analysis of these came up with the current
+principal-permission-target-group model. While this is simple and easy
+to understand it is proving not to be flexible enough now that the scope
+has expanded.
+
+Terminology: the _consuming service_ is an F+ service using the Auth
+service to provide ACLs. The consuming service is a client of the Auth
+service. The _requesting client_ is a client of the consuming service
+which is being authorised using the information from the Auth service.
+An _external service_ is a service other than the Auth service which
+provides information used in making authorisation decisions.
+
+## Problems with the current system
+
+### Sparkplug Node address is a security identifier
+
+During the development of the auth service I have realised that a
+Sparkplug Node is a security principal. Node address information should
+live in the Auth service; a Node address is simply an alternative
+identifier for the principal.
+
+### Lack of group quoting
+
+When a group is included into another group no distinction is made
+between 'subset' and 'member-of'. A group is always expanded recursively
+and appears as a subset of the larger group. This means any grant of
+permission to edit groups becomes unrestricted, as the principal can add
+any group (Administrators, say) to a group they can edit and can then
+add themself to that group.
+
+### Groups are becoming difficult to manage
+
+A large number of groups are needed, and they are becoming difficult to
+identify. Any scheme for dynamically creating groups (Devices belonging
+to a Node, for instance) will make this much worse. Classification of
+groups for management purposes (as opposed to amalgamation) is not
+possible due to the lack of quoting.
+
+### Auth information in the ConfigDB
+
+Both MQTT and CCL permissions are dynamic, with the meaning of a
+permission specified in application terms in the ConfigDB. Additionally,
+both ConfigDB entries contain lists, and the MQTT entries are expanded
+with address information from the target. This indicates that the Auth
+data model is not sufficient for the requirements here.
+
+### Targets are inflexible
+
+Some permissions, especially Auth permissions (permissions to change
+permissions), require more parameters than a simple target. This leads
+to either distortion of the permission model or overly broad grants. For
+example:
+
+* Auth: 'Manage ACLs (per permission)' is always an overly broad grant.
+  We should be able to restrict all three parts of the ACE.
+* Auth: 'Manage groups' only restricts the groups managed, not who can
+  be placed in them.
+* Directory: Third-party service advert permissions are convoluted to
+  avoid needing multiple targets.
+* Directory: 'Read alerts of type' and 'Read alerts from device'
+  are separate permissions. Combinations are not possible.
+* ConfigDB: 'Read/Write config' are often too broad. Restriction on
+  object would be useful.
+* Cmdesc: CCL permissions grant a metric and type together. No
+  restriction can be placed on value.
+* Git: Restrictions are only at the repo level. Per-branch restrictions
+  cannot be expressed.
+* The new change-notify system means services need to be able to create
+  Devices under their own Node and grant permissions to them.
+* A reconciliation service will need to create Devices under random
+  Nodes and grant permissions to them.
+
+### No change-notify
+
+The Auth service has no Sparkplug presence and no change-notify
+interface. Trying to create these is likely to open a large can of
+worms; one of the design principles of the Auth service is that it is
+entirely standalone and doesn't depend on any of the other services.
+
+This means that, in general, changes to data in the Auth service will
+not be picked up quickly. This in turn suggests that in a dynamic
+environment the Auth data should be rules for assimilating other data
+sources rather than specific lists of objects that can be accessed.
+
+## Possible solutions
+
+### More ConfigDB-driven permissions
+
+It would be possible to keep pushing most of the information needed to
+grant a permission into custom ConfigDB entries, leaving one piece to be
+`target`. With both `permission` and `target` expanded via the ConfigDB
+this can be quite flexible, if rather ad-hoc. This is effectively how
+the current MQTT permissions work.
+
+### Dynamic groups
+
+It might be possible to define Auth groups with dynamic membership,
+whether based on other groups, ConfigDB entries, or Directory
+information. There is a high risk here of ACL resolution becoming
+unacceptably slow. There is also a risk of information leak where
+consuming services use these dynamic groups to see information they
+shouldn't.
+
+Alternatively groups could be updated by external services. Some of this
+happens already with service-setup and the edge cluster machinery. This
+can be awkward to set up, as the UUIDs of these groups need to be
+recorded somewhere so they can be updated.
+
+A third, and better, option for ACLs dependent on the contents of
+external services is to pass responsibility for querying the external
+services back to the consuming service. This means that the consuming
+service is subject to normal ACLs from the external service, and can
+subscribe to change-notify from the external service on its own account.
+The biggest issue here will be working out how to pass the information
+about which endpoint(s) to use on which service in a sufficiently
+generic way.
+
+### Owners
+
+Can any of these problems be simplified by introducing the general
+concept of an 'owner'? This would need to be registered with the Auth
+service by the ConfigDB at the point where the object was created. This
+might allow a reconciliation service to be owner of a Device rather than
+the Node which is publishing it, for example. More generally it should
+allow restricting the actions of services to objects they have created,
+where this is useful.
+
+### Structured targets
+
+Some of these problems can be solved by allowing the target of an ACE to
+be more than just a UUID. SPO works for RDF, but only because the IRI
+used as object can itself have structure. 
+
+This is obviously equivalent to referencing a ConfigDB application, but
+keeps the relevant information in the Auth service. It also avoids
+creating large numbers of fairly ephemeral ConfigDB objects.
+
+### Permission templates
+
+The MQTT and CCL permissions both expand into lists of the real
+permissions applicable to the service concerned using ConfigDB entries
+as templates. Given an appropriate template language, it would be
+possible for this expansion to happen inside the Auth service. It would
+be necessary to also support structured targets, as the targets for MQTT
+and CCL permissions cannot be reasonably represented as a single UUID.
+
+## Design proposals
+
+All proposals need to meet these conditions:
+
+* Groups distinguish between member-of and subset-of containment.
+
+* The set of members of a group `GROUP` is defined as follows: if
+  `GROUP` is not a group, the result is `GROUP`. Otherwise, the result
+  is all members-of the group `GROUP`, plus `members SUBGROUP` for all
+  subsets-of `GROUP`. Groups are sets, so the result is uniqed.
+
+* Principals always have a UUID, and have at most one each of a Kerberos
+  UPN and a Sparkplug Node address. These additional identifiers are
+  stored in the Auth service and are checked for uniqueness.
+
+* Values which might change need to have change-notify. This includes
+  group membership. It must be acceptable for services not to respond to
+  changes instantly.
+
+* The target of an ACE is a structured value.
+
+* It must be possible to create groups of principals and to grant
+  permissions to all members of the group.
+
+* Factory+ objects can be assigned owners. Creating an object in the
+  ConfigDB grants ownership to the creator. Ownership can be reassigned,
+  subject to permissions.
+
+### Permission templates
+
+[Full proposal](./auth/sexpr.md).
+
+This proposal is intended as a simple way to define a JSON-based
+expression language which can be used to express rich permission
+structures. It also allows the Auth service to reply to an ACL query
+with partially evaluated rules where the final result depends on lookups
+from other services; the final expansion must be performed by the
+consuming service based on change-notify channels.
+
+The result is more complex than I hoped it would be, in particular the
+partial evaluation is difficult to handle correctly. 
+
+### Dynamic groups
+
+[Full proposal](./auth/dyn-groups.md).
+
+This is intended as a simplest-possible proposal while still meeting the
+conditions above.

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -17,7 +17,7 @@ provides information used in making authorisation decisions.
 
 ### Sparkplug Node address is a security identifier
 
-During the development of the auth service I have realised that a
+During the development of the cmdesc service I have realised that a
 Sparkplug Node is a security principal. Node address information should
 live in the Auth service; a Node address is simply an alternative
 identifier for the principal.
@@ -68,22 +68,13 @@ example:
   restriction can be placed on value.
 * Git: Restrictions are only at the repo level. Per-branch restrictions
   cannot be expressed.
-* The new change-notify system means services need to be able to create
-  Devices under their own Node and grant permissions to them.
-* A reconciliation service will need to create Devices under random
-  Nodes and grant permissions to them.
 
 ### No change-notify
 
-The Auth service has no Sparkplug presence and no change-notify
-interface. Trying to create these is likely to open a large can of
-worms; one of the design principles of the Auth service is that it is
-entirely standalone and doesn't depend on any of the other services.
-
-This means that, in general, changes to data in the Auth service will
-not be picked up quickly. This in turn suggests that in a dynamic
-environment the Auth data should be rules for assimilating other data
-sources rather than specific lists of objects that can be accessed.
+The Auth service has no change-notify interface. With the `notify/v2`
+spec which does not rely on Sparkplug it would be possible to create a
+change-notify interface for the Auth service which doesn't cause
+bootstrapping problems.
 
 ## Possible solutions
 
@@ -118,20 +109,10 @@ The biggest issue here will be working out how to pass the information
 about which endpoint(s) to use on which service in a sufficiently
 generic way.
 
-### Owners
-
-Can any of these problems be simplified by introducing the general
-concept of an 'owner'? This would need to be registered with the Auth
-service by the ConfigDB at the point where the object was created. This
-might allow a reconciliation service to be owner of a Device rather than
-the Node which is publishing it, for example. More generally it should
-allow restricting the actions of services to objects they have created,
-where this is useful.
-
 ### Structured targets
 
 Some of these problems can be solved by allowing the target of an ACE to
-be more than just a UUID. SPO works for RDF, but only because the IRI
+be more than just a UUID. Triples work for RDF, but only because the IRI
 used as object can itself have structure. 
 
 This is obviously equivalent to referencing a ConfigDB application, but
@@ -146,6 +127,15 @@ as templates. Given an appropriate template language, it would be
 possible for this expansion to happen inside the Auth service. It would
 be necessary to also support structured targets, as the targets for MQTT
 and CCL permissions cannot be reasonably represented as a single UUID.
+
+This still leaves the question of how to handle data from external
+services: leaving the job to the consuming service potentially requires
+a complex service library implementation and means the consuming service
+needs access to all the data it needs to evaluate the ACL. On the other
+hand providing a complete, dynamic ACL resolution function on the Auth
+service means the Auth service needs to consume notifications from the
+relevant external services, which opens up the bootstrapping problem
+again.
 
 ## Design proposals
 
@@ -170,10 +160,6 @@ All proposals need to meet these conditions:
 
 * It must be possible to create groups of principals and to grant
   permissions to all members of the group.
-
-* Factory+ objects can be assigned owners. Creating an object in the
-  ConfigDB grants ownership to the creator. Ownership can be reassigned,
-  subject to permissions.
 
 ### Permission templates
 

--- a/docs/auth/dyn-groups.md
+++ b/docs/auth/dyn-groups.md
@@ -1,0 +1,212 @@
+# Dynamic groups Auth proposal
+
+This is an Auth service redesign proposal intended not to extend the
+existing systems any further than is needed. The extensions to the
+current data model are:
+
+* Node Sparkplug addresses live in the Auth service as another principal
+  identity. Cluster Sparkplug groups will need to live here too.
+
+* The Auth service will need to provide change-notify.
+
+* Static groups are defined in the Auth database as currently. These
+  groups now distinguish member-of and subset-of.
+
+* ACE targets are extended to be arbitrary JSON objects. The
+  interpretation of the contents is now up to the consuming service, so
+  it isn't possible for group UUIDs in the target to be expanded by the
+  Auth service.
+
+* Objects have ownership, tracked in the Auth service. Permissions here
+  are ClaimObject and ChangeOwner. _Mine_ is a dynamic group containing
+  all objects owned by the requesting client. The existing _Wildcard_ 
+  and _Self_ Special UUIDs are also considered to be dynamic groups,
+  though they will almost certainly be special-cased in any consuming
+  service.
+
+## Examples
+
+The current services will continue to run mostly the same. Clients that
+look up Sparkplug addresses for Nodes will need to contact the Auth
+service; the JS ServiceClient already handles this transparently. If
+these addresses are not proxied through the ConfigDB then the MQTT
+broker would need modifying to contact the Auth service where needed.
+
+Notation:
+
+    ∈       Static group membership
+    ⊂       Static group subgroup
+    G:{}    Dynamic group definition
+    U:<t i> Identity
+    [U P T] ACE
+
+Titlecase strings represent UUIDs. Comments begin with `#`.
+
+### Edge krbkeys
+
+    EdgeAgent ∈ EdgeGroups
+    EdgeSync ∈ EdgeGroups
+
+    Cluster1:<sparkplug { group: "Cluster1" }>
+    Cluster1KK ∈ EdgeKK
+    Cluster1Flux ∈ EdgeFlux
+
+    # These can be granted generically on the groups of operators.
+    [EdgeKK CreateObject { class: EdgeAccount, uuid: false }]
+    [EdgeKK ReadConfig { app: Info, obj: Mine }]
+    [EdgeKK WriteConfig { app: Info, obj: Mine }]
+    [EdgeKK ReadIdentity { uuid: Mine }]
+    [EdgeKK ManageGroup { groups: EdgeGroups, members: Mine }]
+    [EdgeFlux GitPull SharedRepos]
+    
+    # These must be granted specifically per cluster.
+    [Cluster1KK WriteIdentity { uuid: Mine, sparkplug: { group: "Cluster1" } }]
+    [Cluster1KK WriteIdentity { uuid: Mine, kerberos: "*/Cluster1@R" }]
+    [Cluster1KK WriteIdentity { uuid: Mine, kerberos: "nd1/Cluster1/*@R" }]
+    [EdgeFlux GitPull Cluster1Repo]
+
+The list of permissions that must be granted specifically to each edge
+krbkeys operator is very specific. Changing this list would mean
+changing the cluster manager, and unless it was written to reconcile
+permissions, clusters which were already deployed would not be updated
+to the new permission structure. In this particular case this could be
+worked around in the Auth service in at least two different ways:
+
+    # Specify the cluster target explicitly
+    [Cluster1KK WriteClusterIdentity { uuid: Mine, cluster: Cluster1 }]
+
+    # Implicitly grant permission on 'my' cluster. This would mean
+    # krbkeys would need a Sparkplug identity to get the group.
+    [EdgeKK WriteClusterIdentity { uuid: Mine }]
+
+but this embeds assumptions about the V3 edge cluster configuration into
+the Auth service.
+    
+### Dynamic deployment
+
+Because we don't have any form of template expansion it isn't possible
+to implement 'grant permission to Devices under my Node' directly as we
+could with the sexpr proposal. Obviously a specific permission
+implemented in the Auth service would be a possibility but this rather
+destroys the concept of a generic authorisation service.
+
+Applying the 'ownership' concept, and assuming the Directory is set up
+to create objects for new Devices and transfer their ownership to the
+Node, we get something like this:
+
+    EdgeAgents ⊂ SparkplugNodes
+    DynamicNodes ⊂ SparkplugNodes
+
+    EdgeAgent1 ∈ EdgeAgents
+    Directory ∈ DynamicNodes
+    ConfigDB ∈ DynamicNodes
+
+    Directory ∈ SparkplugConsumers
+    ClusterManager ∈ SparkplugConsumers
+
+    [ConfigDB ClaimObject Wildcard]
+    [ConfigDB ChangeOwner { from: ConfigDB, to: Wildcard }]
+    [Directory CreateObject { class: SparkplugDevice, uuid: true }]
+    [Directory ChangeOwner { from: Directory, to: SparkplugNodes }]
+
+    # These are Directory permissions controlling indexing of the
+    # Device. They do not affect MQTT ACLs.
+    [SparkplugNodes PublishDevice Mine]
+    [SparkplugNodes PublishNewDevice]
+
+    # This is an MQTT permission with a ConfigDB definition.
+    ReadDevice ∈ ConsumeDevice
+    # This is the existing CCL with a ConfigDB definition.
+    Rebirth ∈ ConsumeDevice
+
+    ConsumeDevice ∈ DynamicPermissions
+
+    [DynamicNodes ManageACL {
+        principal: SparkplugConsumers,
+        permission: DynamicPermissions,
+        target: Mine,
+    }]
+    
+The ownership tracking is quite complicated due to the different
+services interacting:
+
+* When EdgeAgent1 publishes a new Device the Directory picks this up and
+  attempts to register the Device UUID with the ConfigDB.
+
+* The Directory has `CreateObject`, a ConfigDB permission. In this case
+  this allows the Directory to register a pre-existing UUID with the
+  ConfigDB (rather than the ConfigDB generating and returning the UUID).
+
+* The ConfigDB has `ClaimObject`. This is an Auth permission allowing
+  the ConfigDB to create a new ownership record with itself as owner.
+
+* The ConfigDB then reassigns ownership to the Directory, as permitted
+  by its `ChangeOwner` grant.
+
+* Once the ConfigDB has returned success, the Directory reassigns
+  ownership again to EdgeAgent1.
+
+The MQTT ReadDevice permission will need to look up via the Directory
+rather than via the Auth service; this will probably mean a change in
+detail to the ConfigDB permission template format. The plugin will also
+need to track changes, including keeping track of which changes we care
+about and which clients they will affect. An alternative would be to
+proxy both data sources through the ConfigDB, but then: how do we do
+change-notify, how do we handle etags, and what do we do if both
+services give different answers?.
+
+I am here assuming the ManageACL permission accepts a group for each
+property and allows grants to any combinations of the members of those
+groups. Since we want to allow a grant of `ConsumeDevice` only, not a
+grant of the individual components, this means we need
+`DynamicPermissions` to provide a layer of quoting.
+
+### Initial object creation
+
+The chain of actions taking place when a new Device is registered only
+involves the ConfigDB as the central UUID registry. Given that the
+Device UUID doesn't have anything recorded against it (yet), maybe the
+master list of known UUIDs moves into the Auth service and the Directory
+creates the object directly there. 
+
+In this case I think the Auth groups should be considered to subsume and
+replace the ConfigDB classes. This has the disadvantage of losing the
+ability to display a 'primary classification' to users. Maybe that moves
+into General Info, as user-visible rather than machine-usable
+information?
+
+    # This is group quoting as before.
+    SparkplugDevices ∈ DirectoryManagedGroups
+
+    # The boolean here indicates whether arbitrary (nonexistent) UUIDs
+    # can be claimed. 
+    [Directory ClaimObject true]
+    [Directory ManageGroup { groups: DirectoryManagedGroups, members: Mine }]
+    [Directory ChangeOwner { from: Self, to: SparkplugNodes }]    
+
+In this situation the Directory's ownership has a purpose, as it allows
+the Directory to set the SparkplugDevice group membership. The ConfigDB
+is not involved.
+
+Of course, normally Edge Agents have their Device UUIDs assigned by the
+Manager. This is similar to the use case requirement here for dynamic
+devices created by a reconciliation service. This now looks more like
+
+    EdgeAgents ⊂ SparkplugNodes
+    DynamicNodes ⊂ SparkplugNodes
+
+    # Users can (where permitted) deploy Devices on their own account.
+    me1xxx ∈ DeploymentUsers
+    SparkplugDevices ∈ DeploymentGroups
+
+    # The Manager can generate new UUIDs, but can't choose what they
+    # are. It must use the UUIDs it's given.
+    [DeploymentUsers ClaimObject false]
+    [DeploymentUsers ManageGroup { groups: DeploymentGroups, members: Mine }]
+    [DeploymentUsers ManageACL {
+        principal: EdgeAgents,
+        permission: PublishDevice,
+        target: Mine
+    }]
+
+    [DynamicNodes PublishNewDevice]

--- a/docs/auth/sexpr.md
+++ b/docs/auth/sexpr.md
@@ -1,0 +1,377 @@
+# S-expression based permission templates
+
+This is a proposal for an Auth service redesign based on s-expressions
+expressed as JSON arrays.
+
+* Groups can only be used for principals or targets (nouns). Groups of
+  permissions are no longer expanded.
+
+* The function `members` expands the members of a group. Expanding a
+  UUID which does not represent a group returns a singleton list.
+
+* The principal of an ACE is always a UUID and is always expanded with
+  `members`. The ACE is granted to any identifier belonging to a UUID on
+  the resulting list. Principal UUIDs should not normally be used as
+  group UUIDs.
+
+* The target of an ACE is a JSON value, which must be either an object,
+  a string or `null`. Arrays are reserved to represent template calls.
+  In some cases this will be a string representing a UUID but this is up
+  to the service to interpret. Wildcards and group expansion are also up
+  to the service.
+
+* A permission is always a UUID. There are two categories of permission:
+  base permissions which are returned to the requesting service, and
+  permission templates. Templates are defined in the Auth service and
+  permissions defined as templates will never be returned to a service.
+
+## Permission templates
+
+A permission template is a function which accepts the principal UUID and
+the target value and returns a list of ACEs. When ACLs are looked up all
+permission templates are expanded recursively and the result included in
+the list of ACEs returned. Some form of recursion control will obviously
+be necessary.
+
+A template definition is represented in JSON as an s-expression built
+from arrays and strings.
+
+* A 'base value' is `null`, a string, or an object whose values are all
+  base values.
+
+* An array represents a function call. The first member of the array
+  names the function to call. This must be a string and it names a
+  builtin, a `let` binding, or a permission UUID.
+
+* Certain strings name builtins. These are: `list`, `let`, `merge`,
+  `if`, `get`, `has`, `equal`, `map`, `join`, `format`, `members`,
+  `principal`, `id`, `lookup`.
+
+* Let bindings are created with the `let` builtin and are only available
+  over the scope of the call to `let`. Function arguments are available
+  as though they were `let` bindings. Let bindings must be called as
+  though they were functions with no arguments to avoid an ambiguity
+  with a literal string (we have no symbols in JSON).
+
+* Functions which are UUIDs without a template definition represent base
+  permission grants. These should be called with one argument, the
+  target of the permission, which should be a base value.
+
+* The top-level of a function definition is an array. The first element
+  is another array naming the parameters. Subsequent elements are the
+  result list. Where the result of evaluating a result list element is
+  itself a list, this is flattened into the function result.
+
+## Examples
+
+Notation:
+
+    ∈           Group membership
+    ⊂           Group subset
+    →           Permission template definition
+    u:[]        Permission grant
+    u:<t i>     Identity
+    ⇒           Permission expansion
+
+Titlecase strings represent UUIDs. Lowercase strings represent JSON
+strings. JSON arrays are represented without commas. JSON objects allow
+trailing commas. For example, this
+
+    [ReadConfig {app: Address, obj: ConfigDB}]
+
+represents this JSON
+
+    [
+      "4a339562-cd57-408d-9d1a-6529a383ea4b",
+      {   
+        "app": "8e32801b-f35a-4cbf-a5c3-2af64d3debd7",
+        "obj": "36861e8d-9152-40c4-8f08-f51c2d7e3c25"
+      }
+    ]
+
+Each example builds on the others. Comments start with `#`. Object
+contents are abbreviated where there is a lot of repetition.
+
+### Sparkplug Node publishing
+
+    # Template definitions
+    ReadOwnConfig → [[app]
+      [ReadConfig: { app: [app], obj: [principal] }]]
+
+    SpTopic → [[type addr]
+      [if [has [addr] device] 
+        [format "spBv1.0/%s/N%s/%s" 
+          [get [addr] group] [type] [get [addr] node]]
+        [format "spBv1.0/%s/D%s/%s" 
+          [get [addr] group] [type] [get [addr] node] [get [addr] device]]]]
+    ParticipateAsNode → [[]
+      [let [node [id [principal] sparkplug]]
+        [map [addr
+            [Publish [SpTopic "BIRTH" [addr]]]
+            [Publish [SpTopic "DATA" [addr]]]
+            [Publish [SpTopic "DEATH" [addr]]]
+            [Subscribe [SpTopic "CMD" [addr]]]]
+          [node]
+          [merge [node] { device: "+" }]]]]
+
+    # Groups and identities
+    ConfigDB ∈ SparkplugNode
+    EdgeAgent ⊂ SparkplugNode
+    Node ∈ EdgeAgent
+    Node:<sparkplug { group: "Group", node: "Node" }>
+
+    # ACEs and their eventual expansion
+
+    # This is just an example. This ACE would not be needed as Sparkplug
+    # identity is now in the Auth service. A principal can always read
+    # their own identities.
+
+    SparkplugNode:[ReadOwnConfig Address]
+    ⇒ ConfigDB:[ReadOwnConfig Address]
+      Node:[ReadOwnConfig Address]
+
+      # These are 'base permission' entries
+    ⇒ ConfigDB:[ReadConfig {app: Address, obj: ConfigDB}]
+      Node:[ReadConfig { app: Address, obj: Node }]
+
+    Node:[ParticipateAsNode]
+    ⇒ [map [addr
+          [Publish [SpTopic "BIRTH" [addr]]]
+          [Publish [SpTopic "DATA" [addr]]]
+          [Publish [SpTopic "DEATH" [addr]]]
+          [Subscribe [SpTopic "CMD" [addr]]]]
+        { group: "Group", node: "Node" }
+        [merge { group: "Group", node: "Node" } { device: "+" }]]
+
+    ⇒ [map [addr
+          [Publish [SpTopic "BIRTH" [addr]]]
+          [Publish [SpTopic "DATA" [addr]]]
+          [Publish [SpTopic "DEATH" [addr]]]
+          [Subscribe [SpTopic "CMD" [addr]]]]
+        { group: "Group", node: "Node" }
+        { group: "Group", node: "Node", device: "+" }]
+
+    ⇒ [Publish [SpTopic "BIRTH" {g: n:}]]
+      [Publish [SpTopic "DATA" {g: n:}]]
+      [Publish [SpTopic "DEATH" {g: n:}]]
+      [Subscribe [SpTopic "CMD" {g: n:}]]
+      [Publish [SpTopic "BIRTH" {g: n: d: +}]]
+      [Publish [SpTopic "DATA" {g: n: d: +}]]
+      [Publish [SpTopic "DEATH" {g: n: d: +}]]
+      [Subscribe [SpTopic "CMD" {g: n: d: +}]]
+
+      # Under this system we can expand all the way out to the topic
+      # ACLs the MQTT broker actually wants.
+    ⇒ [Publish "spBv1.0/Group/NBIRTH/Node"]
+      [Publish "spBv1.0/Group/NDEATH/Node"]
+      [Publish "spBv1.0/Group/NDATA/Node"]
+      [Subscribe "spBv1.0/Group/NCMD/Node"]
+      [Publish "spBv1.0/Group/DBIRTH/Node/+"]
+      [Publish "spBv1.0/Group/DDEATH/Node/+"]
+      [Publish "spBv1.0/Group/DDATA/Node/+"]
+      [Subscribe "spBv1.0/Group/DCMD/Node/+"]
+
+### Consuming Sparkplug data
+
+    ReadAddress → [[addr]
+      [map [t
+          [Subscribe [SpTopic [merge [addr] { type: [t] }]]]]
+        "BIRTH" "DEATH" "DATA"]]
+
+    # We can be more specific with CCL ACEs
+    Rebirth → [[addr]
+      [SendCmd {
+        address: [addr],
+        name: [if [has [addr] device]
+          "Device Control/Rebirth" "Node Control/Rebirth],
+        type: "Boolean",
+        value: true,
+      }]]
+
+    ConsumeNode → [[node]
+      [let [addr [id [node] sparkplug]]
+        [map [a [ReadAddress [a]] [Rebirth [a]]]
+          [addr]
+          [merge [addr] { device: "+" }]]]]
+    ConsumeAddress → [[addr]
+      [ReadAddress [a]]
+      [Rebirth [a]]]
+
+    ConfigDB:<sparkplug { group: "Core", node: "ConfigDB" }>
+
+    # A permission template expanding to permissions for more than one
+    # service.
+    ClusterManager:[ConsumeNode ConfigDB]
+    ⇒ [map [a [ReadAddress [a]] [Rebirth [a]]]
+        { g: n: }
+        [merge {g: n:} {device: "+"}]]
+
+    ⇒ [ReadAddress {g: n:}]
+      [Rebirth {g: n:}]
+      [ReadAddress {g: n: d:+}]
+      [Rebirth {g: n: d:+}]
+
+    ⇒ [Subscribe "spBv1.0/Core/NBIRTH/ConfigDB"]
+      [Subscribe "spBv1.0/Core/NDEATH/ConfigDB"]
+      [Subscribe "spBv1.0/Core/NDATA/ConfigDB"]
+      [SendCmd { address: {g: n:}, name: "NC/R", t: v: }]
+      [Subscribe "spBv1.0/Core/DBIRTH/ConfigDB/+"]
+      [Subscribe "spBv1.0/Core/DDEATH/ConfigDB/+"]
+      [Subscribe "spBv1.0/Core/DDATA/ConfigDB/+"]
+      [SendCmd { address: {g: n: d:+}, name: "DC/R", t: v: }]
+
+    # The administrator permissions would need reexamining; blindly
+    # applying whole permission groups to wildcard is unlikely to work.
+    # This example assumes cmdesc treats missing keys in the target as
+    # indicating wildcards, and accepts MQTT wildcards in the address.
+    Administrators:[SendCmd { address: {g:+ n:+ d:#} }]
+    Administrators ⊂ GlobalDebuggers
+    GlobalDebuggers:[Subscribe "spBv1.0/#"]
+      :[Rebirth {g:+ n:+}]
+      :[Rebirth {g:+ n:+ d:+}]
+
+### Improvements for Auth ACLs
+
+This assumes that we create Sparkplug identities for edge clusters in
+the Auth service. This doesn't quite add up as clusters are not
+principals, but this is definitely auth information. 
+
+This also assumes the Auth service can optionally store an 'owner' for
+each object, and that the ConfigDB sets the owner to the creator when an
+object is created. ACEs concerning ownership must be explicitly
+implemented by the consuming service. Expanding an explicit list of
+objects into an ACL returned from the Auth service and cached would
+quickly become stale.
+
+A Special UUID, `Mine`, matches any object owned by the requesting
+principal. This is treated as a group, so here the base permissions must
+be expecting groups, and expecting to expand them.
+
+    KkForCluster → [[cluster]
+      [CreateObject { class: EdgeAccount, uuid: false }]
+      [ReadConfig { app: Info, obj: Mine }]
+      [WriteConfig { app: Info, obj: Mine }]
+      [ReadIdentity { uuid: Mine }]
+      [let [group [get [id [cluster] sparkplug] group]]
+        [WriteIdentity { uuid: Mine, sparkplug: {group: [group]} }]
+        [WriteIdentity { uuid: Mine, kerberos: [format "*/%s@REALM", [group]] }]
+        [WriteIdentity { uuid: Mine,
+          kerberos: [format "nd1/%s/*@REALM" [group]] }]]
+      [map [g [ManageGroup {group: [g], member: Mine}]]
+        [members EdgeGroups]]
+    ]
+
+    # Note: this is not ⊂ as at present.
+    EdgeAgent ∈ EdgeGroups
+    EdgeSync ∈ EdgeGroups
+
+    Cluster1:<sparkplug { group: "Cluster1" }>
+    
+    Cluster1KK:[KkForCluster Cluster1]
+      # Some ACEs omitted
+    ⇒ [WriteIdentity {uuid: Mine, sparkplug: {group: "Cluster1"}}]
+      [WriteIdentity {uuid: Mine, kerberos: "*/Cluster1@REALM"}]
+      [WriteIdentity {uuid: Mine, kerberos: "nd1/Cluster1/*@REALM"}]
+      [ManageGroup {group: EdgeAgent, member: Mine}]
+      [ManageGroup {group: EdgeSync, member: Mine}]
+
+As opposed to the current system, this both correctly identifies the
+groups which can be managed by the edge krbkeys and also limits the
+members which can be placed in them. The identity restrictions also
+avoid making a root-equivalent grant.
+
+The groups changes mean it isn't any longer possible to simply grant a
+permission on a group and have the grant distribute over the group
+members. An explicit `map` is required, and if this is to be granted in
+an ACE a template definition needs to be created to contain the `map`.
+In this case a template would have been required anyway, as the
+`ManageGroup` base permission now required a structured target.
+
+### Change-notify Devices
+
+A simple scheme for allowing certain Nodes to grant read access to their
+Devices might look like this. This is limited to direct grants to a Node
+to manage its own Devices.
+
+This also relies on a ManageACL permission which puts limits on the
+contents of the target rather than simply requiring the target to be in
+a group; given the general nature of targets under this design it's not
+clear how this would work in general. One possibility might be: perform
+a JSON merge patch of the template onto the proposed target; if the
+result changes then the test fails.
+
+    DynamicNodes ⊂ SparkplugNodes
+
+    DynamicNodes:[ManageACL {
+      permission: ConsumeAddress,
+      target: {
+        group:  [get [id [principal] sparkplug] group],
+        node: [get [id [principal] sparkplug] node]
+      }]
+
+### Dynamic deployment
+
+A more general scheme for allowing dynamic ACLs on Devices relies on
+ownership. In general an 'ordinary' Device published by a Node will need
+to be created in the services by the Directory. This means the Directory
+will need to be able to chown the Device to the Node which originally
+published it. It also means there will be a delay before the Node is
+authorised to set permissions on a new Device.
+
+This scheme unavoidably depends on Directory lookups to make
+authorisation decisions. In this case the Directory lookup will need to
+be performed by the MQTT broker, and the broker will need to use
+change-notify to track changes to the Device address. One important
+disadvantage here is that if a Device changes address there will be a
+delay before the ACLs change. 
+
+    GiveToGroup → [[group]
+      [map [m [ChangeOwner { from: [principal], to: [m] }]]
+        [members [group]]]]
+
+    DeviceAddress → [[device]
+      [let [info [lookup DirectorySvc "v1/device/" [device]]]
+        [if [has [info] "device_id"]
+          { group:  [get [info] "group_id"],
+            node:   [get [info] "node_id"],
+            device: [get [info] "device_id"],
+          }
+          { group:  [get [info] "group_id"],
+            node:   [get [info] "node_id"],
+          }]]
+    ConsumeDevice → [[device]
+      [ConsumeAddress [DeviceAddress [device]]]]
+
+    SparkplugNodes:[PublishDevice Mine]
+    SparkplugNodes:[PublishNewDevice]
+    Directory:[GiveToGroup SparkplugNodes]
+    
+    DynamicNodes ⊂ SparkplugNodes
+    DynamicNodes:[ManageACL {
+      principal: SparkplugConsumers,
+      permission: ConsumeDevice,
+      target: Mine }]
+
+This version of ManageACL expects a group for each of principal,
+permission, target. As usual the permission entry `ConsumeDevice`, which
+is not a group, is expanded by `members` as a singleton group.
+
+Here `lookup` is a new builtin which performs a Factory+ Service API
+call. It takes three parameters: a service function UUID, a path, and
+(optionally) an object ID relative to that path. The form with separate
+object ID should only be used for services supporting
+[../acs-rendezvous/docs/notify-v1.md](the new notify-v1 interface) and
+which allow the base path to be used as a channel URL.
+
+This definition of `DeviceAddress` results in a lot of deferred
+evaluation, as the `[if]` depends on the result from the Directory. If
+we adjust the Directory API to return what we need directly we can use a
+direct call:
+
+    DeviceAddress → [[device]
+      [lookup DirectorySvc "v1/device/address/" [device]]]
+
+which does not result in so much work being deferred to the consuming
+service.
+
+vi:set sts=2 sw=2:


### PR DESCRIPTION
Specify the data model used for the new Auth service. This defines ACLs in terms of templates, allowing a single grant to expand to multiple related grants on different services. The template language is able to look up information from other services allowing support for dynamically-defined ACLs.