### PR TITLE
Apply CoreDNS patch by default

### DIFF
--- a/deploy/templates/network/coredns-patch.yaml
+++ b/deploy/templates/network/coredns-patch.yaml
@@ -1,0 +1,10 @@
+{{ if .Values.acs.patchCoreDNS }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: acs-rewrite-config
+  namespace: {{ .Release.Namespace }}
+data:
+  rewrite-config: |
+    rewrite stop name regex .*\.{{ .Values.acs.baseUrl | regexReplaceAll "\\." "\\\\." }} {{ .Release.Name }}-traefik.{{ .Release.Namespace }}.svc.cluster.local answer auto
+{{ end }}

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -3,6 +3,10 @@ acs:
   organisation: AMRC
   # -- The base URL that services will be served from
   baseUrl: factoryplus.myorganisation.com
+  # -- Whether or not to create a core-dns patch ConfigMap to redirect
+  # baseUrl requests from inside the cluster to the internal service of
+  # Traefik
+  patchCoreDNS: true
   # -- Whether or not services should be served over HTTPS
   secure: true
   letsEncrypt:

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -3,7 +3,7 @@ acs:
   organisation: AMRC
   # -- The base URL that services will be served from
   baseUrl: factoryplus.myorganisation.com
-  # -- Whether or not to create a core-dns patch ConfigMap to redirect
+  # -- Whether or not to create a coredns patch ConfigMap to redirect
   # baseUrl requests from inside the cluster to the internal service of
   # Traefik
   patchCoreDNS: true


### PR DESCRIPTION
I frequently find myself applying this, especially with air-gap installs. @amrc-benmorrow what do you think and can you see any issues with including this?