### PR TITLE
Bump and pin node-opcua to version 2.133.0 in `acs-edge`

### DIFF
--- a/acs-edge/package-lock.json
+++ b/acs-edge/package-lock.json
@@ -25,7 +25,8 @@
         "dotenv": "^10.0.0",
         "jsonpath-plus": "^5.0.7",
         "jsonpointer": "^5.0.1",
-        "node-opcua": "^2.103.0",
+        "long": "4.0.0",
+        "node-opcua": "2.133.0",
         "st-ethernet-ip": "^2.7.1",
         "ts-node-dev": "^1.1.8",
         "uuid": "^9.0.0",
@@ -1094,100 +1095,100 @@
       "license": "MIT"
     },
     "node_modules/@peculiar/asn1-cms": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.3.8.tgz",
-      "integrity": "sha512-Wtk9R7yQxGaIaawHorWKP2OOOm/RZzamOmSWwaqGphIuU6TcKYih0slL6asZlSSZtVoYTrBfrddSOD/jTu9vuQ==",
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.3.13.tgz",
+      "integrity": "sha512-joqu8A7KR2G85oLPq+vB+NFr2ro7Ls4ol13Zcse/giPSzUNN0n2k3v8kMpf6QdGUhI13e5SzQYN8AKP8sJ8v4w==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.8",
-        "@peculiar/asn1-x509": "^2.3.8",
-        "@peculiar/asn1-x509-attr": "^2.3.8",
+        "@peculiar/asn1-schema": "^2.3.13",
+        "@peculiar/asn1-x509": "^2.3.13",
+        "@peculiar/asn1-x509-attr": "^2.3.13",
         "asn1js": "^3.0.5",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@peculiar/asn1-csr": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.3.8.tgz",
-      "integrity": "sha512-ZmAaP2hfzgIGdMLcot8gHTykzoI+X/S53x1xoGbTmratETIaAbSWMiPGvZmXRA0SNEIydpMkzYtq4fQBxN1u1w==",
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.3.13.tgz",
+      "integrity": "sha512-+JtFsOUWCw4zDpxp1LbeTYBnZLlGVOWmHHEhoFdjM5yn4wCn+JiYQ8mghOi36M2f6TPQ17PmhNL6/JfNh7/jCA==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.8",
-        "@peculiar/asn1-x509": "^2.3.8",
+        "@peculiar/asn1-schema": "^2.3.13",
+        "@peculiar/asn1-x509": "^2.3.13",
         "asn1js": "^3.0.5",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@peculiar/asn1-ecc": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.3.8.tgz",
-      "integrity": "sha512-Ah/Q15y3A/CtxbPibiLM/LKcMbnLTdUdLHUgdpB5f60sSvGkXzxJCu5ezGTFHogZXWNX3KSmYqilCrfdmBc6pQ==",
+      "version": "2.3.14",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.3.14.tgz",
+      "integrity": "sha512-zWPyI7QZto6rnLv6zPniTqbGaLh6zBpJyI46r1yS/bVHJXT2amdMHCRRnbV5yst2H8+ppXG6uXu/M6lKakiQ8w==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.8",
-        "@peculiar/asn1-x509": "^2.3.8",
+        "@peculiar/asn1-schema": "^2.3.13",
+        "@peculiar/asn1-x509": "^2.3.13",
         "asn1js": "^3.0.5",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@peculiar/asn1-pfx": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.3.8.tgz",
-      "integrity": "sha512-XhdnCVznMmSmgy68B9pVxiZ1XkKoE1BjO4Hv+eUGiY1pM14msLsFZ3N7K46SoITIVZLq92kKkXpGiTfRjlNLyg==",
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.3.13.tgz",
+      "integrity": "sha512-fypYxjn16BW+5XbFoY11Rm8LhZf6euqX/C7BTYpqVvLem1GvRl7A+Ro1bO/UPwJL0z+1mbvXEnkG0YOwbwz2LA==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-cms": "^2.3.8",
-        "@peculiar/asn1-pkcs8": "^2.3.8",
-        "@peculiar/asn1-rsa": "^2.3.8",
-        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/asn1-cms": "^2.3.13",
+        "@peculiar/asn1-pkcs8": "^2.3.13",
+        "@peculiar/asn1-rsa": "^2.3.13",
+        "@peculiar/asn1-schema": "^2.3.13",
         "asn1js": "^3.0.5",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@peculiar/asn1-pkcs8": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.3.8.tgz",
-      "integrity": "sha512-rL8k2x59v8lZiwLRqdMMmOJ30GHt6yuHISFIuuWivWjAJjnxzZBVzMTQ72sknX5MeTSSvGwPmEFk2/N8+UztFQ==",
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.3.13.tgz",
+      "integrity": "sha512-VP3PQzbeSSjPjKET5K37pxyf2qCdM0dz3DJ56ZCsol3FqAXGekb4sDcpoL9uTLGxAh975WcdvUms9UcdZTuGyQ==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.8",
-        "@peculiar/asn1-x509": "^2.3.8",
+        "@peculiar/asn1-schema": "^2.3.13",
+        "@peculiar/asn1-x509": "^2.3.13",
         "asn1js": "^3.0.5",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@peculiar/asn1-pkcs9": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.3.8.tgz",
-      "integrity": "sha512-+nONq5tcK7vm3qdY7ZKoSQGQjhJYMJbwJGbXLFOhmqsFIxEWyQPHyV99+wshOjpOjg0wUSSkEEzX2hx5P6EKeQ==",
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.3.13.tgz",
+      "integrity": "sha512-rIwQXmHpTo/dgPiWqUgby8Fnq6p1xTJbRMxCiMCk833kQCeZrC5lbSKg6NDnJTnX2kC6IbXBB9yCS2C73U2gJg==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-cms": "^2.3.8",
-        "@peculiar/asn1-pfx": "^2.3.8",
-        "@peculiar/asn1-pkcs8": "^2.3.8",
-        "@peculiar/asn1-schema": "^2.3.8",
-        "@peculiar/asn1-x509": "^2.3.8",
-        "@peculiar/asn1-x509-attr": "^2.3.8",
+        "@peculiar/asn1-cms": "^2.3.13",
+        "@peculiar/asn1-pfx": "^2.3.13",
+        "@peculiar/asn1-pkcs8": "^2.3.13",
+        "@peculiar/asn1-schema": "^2.3.13",
+        "@peculiar/asn1-x509": "^2.3.13",
+        "@peculiar/asn1-x509-attr": "^2.3.13",
         "asn1js": "^3.0.5",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@peculiar/asn1-rsa": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.3.8.tgz",
-      "integrity": "sha512-ES/RVEHu8VMYXgrg3gjb1m/XG0KJWnV4qyZZ7mAg7rrF3VTmRbLxO8mk+uy0Hme7geSMebp+Wvi2U6RLLEs12Q==",
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.3.13.tgz",
+      "integrity": "sha512-wBNQqCyRtmqvXkGkL4DR3WxZhHy8fDiYtOjTeCd7SFE5F6GBeafw3EJ94PX/V0OJJrjQ40SkRY2IZu3ZSyBqcg==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.8",
-        "@peculiar/asn1-x509": "^2.3.8",
+        "@peculiar/asn1-schema": "^2.3.13",
+        "@peculiar/asn1-x509": "^2.3.13",
         "asn1js": "^3.0.5",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@peculiar/asn1-schema": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.8.tgz",
-      "integrity": "sha512-ULB1XqHKx1WBU/tTFIA+uARuRoBVZ4pNdOA878RDrRbBfBGcSzi5HBkdScC6ZbHn8z7L8gmKCgPC1LHRrP46tA==",
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.13.tgz",
+      "integrity": "sha512-3Xq3a01WkHRZL8X04Zsfg//mGaA21xlL4tlVn4v2xGT0JStiztATRkMwa5b+f/HXmY2smsiLXYK46Gwgzvfg3g==",
       "license": "MIT",
       "dependencies": {
         "asn1js": "^3.0.5",
@@ -1196,12 +1197,12 @@
       }
     },
     "node_modules/@peculiar/asn1-x509": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.3.8.tgz",
-      "integrity": "sha512-voKxGfDU1c6r9mKiN5ZUsZWh3Dy1BABvTM3cimf0tztNwyMJPhiXY94eRTgsMQe6ViLfT6EoXxkWVzcm3mFAFw==",
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.3.13.tgz",
+      "integrity": "sha512-PfeLQl2skXmxX2/AFFCVaWU8U6FKW1Db43mgBhShCOFS1bVxqtvusq1hVjfuEcuSQGedrLdCSvTgabluwN/M9A==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/asn1-schema": "^2.3.13",
         "asn1js": "^3.0.5",
         "ipaddr.js": "^2.1.0",
         "pvtsutils": "^1.3.5",
@@ -1209,13 +1210,13 @@
       }
     },
     "node_modules/@peculiar/asn1-x509-attr": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.3.8.tgz",
-      "integrity": "sha512-4Z8mSN95MOuX04Aku9BUyMdsMKtVQUqWnr627IheiWnwFoheUhX3R4Y2zh23M7m80r4/WG8MOAckRKc77IRv6g==",
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.3.13.tgz",
+      "integrity": "sha512-WpEos6CcnUzJ6o2Qb68Z7Dz5rSjRGv/DtXITCNBtjZIRWRV12yFVci76SVfOX8sisL61QWMhpLKQibrG8pi2Pw==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.8",
-        "@peculiar/asn1-x509": "^2.3.8",
+        "@peculiar/asn1-schema": "^2.3.13",
+        "@peculiar/asn1-x509": "^2.3.13",
         "asn1js": "^3.0.5",
         "tslib": "^2.6.2"
       }
@@ -1249,21 +1250,21 @@
       }
     },
     "node_modules/@peculiar/x509": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.11.0.tgz",
-      "integrity": "sha512-8rdxE//tsWLb2Yo2TYO2P8gieStbrHK/huFMV5PPfwX8I5HmtOus+Ox6nTKrPA9o+WOPaa5xKenee+QdmHBd5g==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.12.3.tgz",
+      "integrity": "sha512-+Mzq+W7cNEKfkNZzyLl6A6ffqc3r21HGZUezgfKxpZrkORfOqgRXnS80Zu0IV6a9Ue9QBJeKD7kN0iWfc3bhRQ==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-cms": "^2.3.8",
-        "@peculiar/asn1-csr": "^2.3.8",
-        "@peculiar/asn1-ecc": "^2.3.8",
-        "@peculiar/asn1-pkcs9": "^2.3.8",
-        "@peculiar/asn1-rsa": "^2.3.8",
-        "@peculiar/asn1-schema": "^2.3.8",
-        "@peculiar/asn1-x509": "^2.3.8",
+        "@peculiar/asn1-cms": "^2.3.13",
+        "@peculiar/asn1-csr": "^2.3.13",
+        "@peculiar/asn1-ecc": "^2.3.14",
+        "@peculiar/asn1-pkcs9": "^2.3.13",
+        "@peculiar/asn1-rsa": "^2.3.13",
+        "@peculiar/asn1-schema": "^2.3.13",
+        "@peculiar/asn1-x509": "^2.3.13",
         "pvtsutils": "^1.3.5",
         "reflect-metadata": "^0.2.2",
-        "tslib": "^2.6.2",
+        "tslib": "^2.7.0",
         "tsyringe": "^4.8.0"
       }
     },
@@ -1601,9 +1602,9 @@
       "license": "MIT"
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-MBIOHVZqVqgfro1euRDWX7OO0fBVUUMrN6Pwm8LQsz8cWhEpihlvR70ENj3f40j58TNxZaWv2ndSkInykNBBJw==",
+      "version": "4.17.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.9.tgz",
+      "integrity": "sha512-w9iWudx1XWOHW5lQRS9iKpK/XuRhnN+0T7HvdCCd802FYkT1AMTnxndJHGrNJwRoRHkslGr4S29tjm1cT7x/7w==",
       "license": "MIT"
     },
     "node_modules/@types/long": {
@@ -2000,6 +2001,26 @@
         "node": ">= 6"
       }
     },
+    "node_modules/aedes-packet/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/aedes-packet/node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -2283,9 +2304,9 @@
       }
     },
     "node_modules/async": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
-      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
     },
     "node_modules/asynckit": {
@@ -6801,61 +6822,61 @@
       "license": "MIT"
     },
     "node_modules/node-opcua": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua/-/node-opcua-2.126.0.tgz",
-      "integrity": "sha512-mnBhWYfTRq+zg3K5tciYo1wZwMGowfPPqMdsKSL4iskAilQi3OKxPM/UmJ4LR8f+lmrHyAD8TnEvo2xZJQnZyQ==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua/-/node-opcua-2.133.0.tgz",
+      "integrity": "sha512-sFz0SrwUXE0SJQ6gre5JdeV4KQbg7NPdKVawSNiZuzpta7EgENyKyI1xh/xClbZBj/zSbwrfO78dgwJChe3JKQ==",
       "license": "MIT",
       "dependencies": {
         "@types/semver": "^7.5.8",
         "chalk": "4.1.2",
-        "node-opcua-address-space": "2.126.0",
-        "node-opcua-address-space-for-conformance-testing": "2.126.0",
-        "node-opcua-aggregates": "2.126.0",
+        "node-opcua-address-space": "2.133.0",
+        "node-opcua-address-space-for-conformance-testing": "2.133.0",
+        "node-opcua-aggregates": "2.133.0",
         "node-opcua-assert": "2.120.0",
-        "node-opcua-basic-types": "2.126.0",
-        "node-opcua-binary-stream": "2.125.0",
-        "node-opcua-certificate-manager": "2.125.0",
-        "node-opcua-client": "2.126.0",
-        "node-opcua-client-proxy": "2.126.0",
-        "node-opcua-common": "2.126.0",
+        "node-opcua-basic-types": "2.133.0",
+        "node-opcua-binary-stream": "2.133.0",
+        "node-opcua-certificate-manager": "2.133.0",
+        "node-opcua-client": "2.133.0",
+        "node-opcua-client-proxy": "2.133.0",
+        "node-opcua-common": "2.133.0",
         "node-opcua-constants": "2.125.0",
-        "node-opcua-crypto": "4.8.0",
-        "node-opcua-data-access": "2.126.0",
-        "node-opcua-data-model": "2.126.0",
-        "node-opcua-data-value": "2.126.0",
-        "node-opcua-debug": "2.125.0",
-        "node-opcua-enum": "2.125.0",
-        "node-opcua-factory": "2.126.0",
-        "node-opcua-hostname": "2.120.0",
-        "node-opcua-nodeid": "2.125.0",
+        "node-opcua-crypto": "4.10.0",
+        "node-opcua-data-access": "2.133.0",
+        "node-opcua-data-model": "2.133.0",
+        "node-opcua-data-value": "2.133.0",
+        "node-opcua-debug": "2.133.0",
+        "node-opcua-enum": "2.133.0",
+        "node-opcua-factory": "2.133.0",
+        "node-opcua-hostname": "2.128.0",
+        "node-opcua-nodeid": "2.133.0",
         "node-opcua-nodesets": "2.121.0",
-        "node-opcua-numeric-range": "2.126.0",
-        "node-opcua-packet-analyzer": "2.126.0",
-        "node-opcua-secure-channel": "2.126.0",
-        "node-opcua-server": "2.126.0",
-        "node-opcua-server-discovery": "2.126.0",
-        "node-opcua-service-browse": "2.126.0",
-        "node-opcua-service-call": "2.126.0",
-        "node-opcua-service-discovery": "2.126.0",
-        "node-opcua-service-endpoints": "2.126.0",
-        "node-opcua-service-filter": "2.126.0",
-        "node-opcua-service-history": "2.126.0",
-        "node-opcua-service-node-management": "2.126.0",
-        "node-opcua-service-query": "2.126.0",
-        "node-opcua-service-read": "2.126.0",
-        "node-opcua-service-register-node": "2.126.0",
-        "node-opcua-service-secure-channel": "2.126.0",
-        "node-opcua-service-session": "2.126.0",
-        "node-opcua-service-subscription": "2.126.0",
-        "node-opcua-service-translate-browse-path": "2.126.0",
-        "node-opcua-service-write": "2.126.0",
-        "node-opcua-status-code": "2.125.0",
-        "node-opcua-transport": "2.126.0",
-        "node-opcua-types": "2.126.0",
-        "node-opcua-utils": "2.125.0",
-        "node-opcua-variant": "2.126.0",
-        "node-opcua-vendor-diagnostic": "2.126.0",
-        "semver": "^7.6.2"
+        "node-opcua-numeric-range": "2.133.0",
+        "node-opcua-packet-analyzer": "2.133.0",
+        "node-opcua-secure-channel": "2.133.0",
+        "node-opcua-server": "2.133.0",
+        "node-opcua-server-discovery": "2.133.0",
+        "node-opcua-service-browse": "2.133.0",
+        "node-opcua-service-call": "2.133.0",
+        "node-opcua-service-discovery": "2.133.0",
+        "node-opcua-service-endpoints": "2.133.0",
+        "node-opcua-service-filter": "2.133.0",
+        "node-opcua-service-history": "2.133.0",
+        "node-opcua-service-node-management": "2.133.0",
+        "node-opcua-service-query": "2.133.0",
+        "node-opcua-service-read": "2.133.0",
+        "node-opcua-service-register-node": "2.133.0",
+        "node-opcua-service-secure-channel": "2.133.0",
+        "node-opcua-service-session": "2.133.0",
+        "node-opcua-service-subscription": "2.133.0",
+        "node-opcua-service-translate-browse-path": "2.133.0",
+        "node-opcua-service-write": "2.133.0",
+        "node-opcua-status-code": "2.133.0",
+        "node-opcua-transport": "2.133.0",
+        "node-opcua-types": "2.133.0",
+        "node-opcua-utils": "2.133.0",
+        "node-opcua-variant": "2.133.0",
+        "node-opcua-vendor-diagnostic": "2.133.0",
+        "semver": "^7.6.3"
       },
       "engines": {
         "node": ">=8.10"
@@ -6865,48 +6886,48 @@
       }
     },
     "node_modules/node-opcua-address-space": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-address-space/-/node-opcua-address-space-2.126.0.tgz",
-      "integrity": "sha512-QhlGN4ytUNii+v5aLts1Egmw6LGr97qJedKg2t8k2nf1XnXDeQ0JQtuN3GAzsN2bCSYrBI/JmC65sLYmgE0kBQ==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-address-space/-/node-opcua-address-space-2.133.0.tgz",
+      "integrity": "sha512-LBHbIe1gjtNpKF3EnntOaH72L+nzzI/qnHc+I+2vMtiSpEcA5eRI8iTPYkI9+iku17CdTIWHv905dKGzy5igOg==",
       "license": "MIT",
       "dependencies": {
-        "@types/lodash": "4.17.5",
+        "@types/lodash": "4.17.9",
         "@types/semver": "^7.5.8",
-        "async": "^3.2.5",
+        "async": "^3.2.6",
         "chalk": "4.1.2",
         "dequeue": "^1.0.5",
         "lodash": "4.17.21",
-        "node-opcua-address-space-base": "2.126.0",
+        "node-opcua-address-space-base": "2.133.0",
         "node-opcua-assert": "2.120.0",
-        "node-opcua-basic-types": "2.126.0",
-        "node-opcua-binary-stream": "2.125.0",
-        "node-opcua-client-dynamic-extension-object": "2.126.0",
+        "node-opcua-basic-types": "2.133.0",
+        "node-opcua-binary-stream": "2.133.0",
+        "node-opcua-client-dynamic-extension-object": "2.133.0",
         "node-opcua-constants": "2.125.0",
-        "node-opcua-crypto": "4.8.0",
-        "node-opcua-data-access": "2.126.0",
-        "node-opcua-data-model": "2.126.0",
-        "node-opcua-data-value": "2.126.0",
-        "node-opcua-date-time": "2.125.0",
-        "node-opcua-debug": "2.125.0",
-        "node-opcua-enum": "2.125.0",
-        "node-opcua-extension-object": "2.126.0",
-        "node-opcua-factory": "2.126.0",
-        "node-opcua-nodeid": "2.125.0",
-        "node-opcua-nodeset-ua": "2.126.0",
-        "node-opcua-numeric-range": "2.126.0",
-        "node-opcua-object-registry": "2.125.0",
-        "node-opcua-pseudo-session": "2.126.0",
-        "node-opcua-service-browse": "2.126.0",
-        "node-opcua-service-call": "2.126.0",
-        "node-opcua-service-history": "2.126.0",
-        "node-opcua-service-translate-browse-path": "2.126.0",
-        "node-opcua-service-write": "2.126.0",
-        "node-opcua-status-code": "2.125.0",
-        "node-opcua-types": "2.126.0",
-        "node-opcua-utils": "2.125.0",
-        "node-opcua-variant": "2.126.0",
-        "node-opcua-xml2json": "2.125.0",
-        "semver": "^7.6.2",
+        "node-opcua-crypto": "4.10.0",
+        "node-opcua-data-access": "2.133.0",
+        "node-opcua-data-model": "2.133.0",
+        "node-opcua-data-value": "2.133.0",
+        "node-opcua-date-time": "2.133.0",
+        "node-opcua-debug": "2.133.0",
+        "node-opcua-enum": "2.133.0",
+        "node-opcua-extension-object": "2.133.0",
+        "node-opcua-factory": "2.133.0",
+        "node-opcua-nodeid": "2.133.0",
+        "node-opcua-nodeset-ua": "2.133.0",
+        "node-opcua-numeric-range": "2.133.0",
+        "node-opcua-object-registry": "2.133.0",
+        "node-opcua-pseudo-session": "2.133.0",
+        "node-opcua-service-browse": "2.133.0",
+        "node-opcua-service-call": "2.133.0",
+        "node-opcua-service-history": "2.133.0",
+        "node-opcua-service-translate-browse-path": "2.133.0",
+        "node-opcua-service-write": "2.133.0",
+        "node-opcua-status-code": "2.133.0",
+        "node-opcua-types": "2.133.0",
+        "node-opcua-utils": "2.133.0",
+        "node-opcua-variant": "2.133.0",
+        "node-opcua-xml2json": "2.133.0",
+        "semver": "^7.6.3",
         "set-prototype-of": "^1.0.0",
         "thenify": "^3.3.1",
         "xml-writer": "^1.7.0"
@@ -6916,93 +6937,93 @@
       }
     },
     "node_modules/node-opcua-address-space-base": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-address-space-base/-/node-opcua-address-space-base-2.126.0.tgz",
-      "integrity": "sha512-ov2dYh7kwSd4AZpBYSpAl+jjVELtEKgk+JognlvMrGSJ+mZjadmk83Vc/a41CHfC/ErqK4Iap2+6ntTNwJu23w==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-address-space-base/-/node-opcua-address-space-base-2.133.0.tgz",
+      "integrity": "sha512-+ysAwyX00mNwhdr+ZVFCqh71z60JcC1r8lyvO5+olFoIIUFF8tlAe9j/yVnImIgkmrJYGzrk48eAv2Ja73WMUg==",
       "license": "MIT",
       "dependencies": {
         "node-opcua-assert": "2.120.0",
-        "node-opcua-basic-types": "2.126.0",
+        "node-opcua-basic-types": "2.133.0",
         "node-opcua-constants": "2.125.0",
-        "node-opcua-crypto": "4.8.0",
-        "node-opcua-data-model": "2.126.0",
-        "node-opcua-data-value": "2.126.0",
-        "node-opcua-date-time": "2.125.0",
-        "node-opcua-debug": "2.125.0",
-        "node-opcua-extension-object": "2.126.0",
-        "node-opcua-nodeid": "2.125.0",
-        "node-opcua-numeric-range": "2.126.0",
-        "node-opcua-schemas": "2.126.0",
-        "node-opcua-status-code": "2.125.0",
-        "node-opcua-types": "2.126.0",
-        "node-opcua-variant": "2.126.0"
+        "node-opcua-crypto": "4.10.0",
+        "node-opcua-data-model": "2.133.0",
+        "node-opcua-data-value": "2.133.0",
+        "node-opcua-date-time": "2.133.0",
+        "node-opcua-debug": "2.133.0",
+        "node-opcua-extension-object": "2.133.0",
+        "node-opcua-nodeid": "2.133.0",
+        "node-opcua-numeric-range": "2.133.0",
+        "node-opcua-schemas": "2.133.0",
+        "node-opcua-status-code": "2.133.0",
+        "node-opcua-types": "2.133.0",
+        "node-opcua-variant": "2.133.0"
       },
       "engines": {
         "node": ">=6.10"
       }
     },
     "node_modules/node-opcua-address-space-for-conformance-testing": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-address-space-for-conformance-testing/-/node-opcua-address-space-for-conformance-testing-2.126.0.tgz",
-      "integrity": "sha512-vIgdVebFL2+BQb1peoLCHzl9Vi7DEncy3E77eiyWF+6Us53b5LqKErjcBnr9S2JqYaP04HnTkvjxxDVeRzbrUA==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-address-space-for-conformance-testing/-/node-opcua-address-space-for-conformance-testing-2.133.0.tgz",
+      "integrity": "sha512-+sdOib9ZYyp/Esgta4eyxr39wOIteL3VAfNElML/KYpHVqDG/tS5STG7+u03haoCCdISYc1iLpIYf7zwbB8C2g==",
       "license": "MIT",
       "dependencies": {
-        "node-opcua-address-space": "2.126.0",
+        "node-opcua-address-space": "2.133.0",
         "node-opcua-assert": "2.120.0",
-        "node-opcua-basic-types": "2.126.0",
-        "node-opcua-data-access": "2.126.0",
-        "node-opcua-data-model": "2.126.0",
-        "node-opcua-data-value": "2.126.0",
-        "node-opcua-debug": "2.125.0",
-        "node-opcua-factory": "2.126.0",
-        "node-opcua-nodeid": "2.125.0",
-        "node-opcua-status-code": "2.125.0",
-        "node-opcua-variant": "2.126.0"
+        "node-opcua-basic-types": "2.133.0",
+        "node-opcua-data-access": "2.133.0",
+        "node-opcua-data-model": "2.133.0",
+        "node-opcua-data-value": "2.133.0",
+        "node-opcua-debug": "2.133.0",
+        "node-opcua-factory": "2.133.0",
+        "node-opcua-nodeid": "2.133.0",
+        "node-opcua-status-code": "2.133.0",
+        "node-opcua-variant": "2.133.0"
       }
     },
     "node_modules/node-opcua-aggregates": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-aggregates/-/node-opcua-aggregates-2.126.0.tgz",
-      "integrity": "sha512-7pNmVog0dSHoLo5FII4+nTjIZS+yMAyGhcjPUWVCQJEzhVIjvuHOl+QA+7vjMGrKoDHCuamVnMT+AiGJBfjEKg==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-aggregates/-/node-opcua-aggregates-2.133.0.tgz",
+      "integrity": "sha512-aTmDKl9BJmYvJbNM55JuXDO6c/FaJemq0DvIRRgI0LuYrtBsTkzBzXDZsK/acmO6OGgAM0KhSd9OmeEqYGs8zw==",
       "license": "MIT",
       "dependencies": {
-        "node-opcua-address-space": "2.126.0",
+        "node-opcua-address-space": "2.133.0",
         "node-opcua-assert": "2.120.0",
         "node-opcua-constants": "2.125.0",
-        "node-opcua-data-model": "2.126.0",
-        "node-opcua-data-value": "2.126.0",
-        "node-opcua-nodeid": "2.125.0",
-        "node-opcua-numeric-range": "2.126.0",
-        "node-opcua-server": "2.126.0",
-        "node-opcua-service-history": "2.126.0",
-        "node-opcua-status-code": "2.125.0",
-        "node-opcua-types": "2.126.0",
-        "node-opcua-utils": "2.125.0",
-        "node-opcua-variant": "2.126.0"
+        "node-opcua-data-model": "2.133.0",
+        "node-opcua-data-value": "2.133.0",
+        "node-opcua-nodeid": "2.133.0",
+        "node-opcua-numeric-range": "2.133.0",
+        "node-opcua-server": "2.133.0",
+        "node-opcua-service-history": "2.133.0",
+        "node-opcua-status-code": "2.133.0",
+        "node-opcua-types": "2.133.0",
+        "node-opcua-utils": "2.133.0",
+        "node-opcua-variant": "2.133.0"
       }
     },
     "node_modules/node-opcua-alarm-condition": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-alarm-condition/-/node-opcua-alarm-condition-2.126.0.tgz",
-      "integrity": "sha512-D6z5yb0zdOKvgzmFFKk55JYDRK8BfHxsgG3Wnb/UcYXWHKagVOH7hFoFNOwTxYj/Ibw5GFFLi0xseT0CVD4dOg==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-alarm-condition/-/node-opcua-alarm-condition-2.133.0.tgz",
+      "integrity": "sha512-27lsDatERfU/pzN1p8/W5t7TW1Mgil1Kj6AFHA3cepWjgCQ2cbAGAJMSh+QLz/u3x7Juue2n3sgPv/3q8PJAyw==",
       "license": "MIT",
       "dependencies": {
         "node-opcua-assert": "2.120.0",
-        "node-opcua-basic-types": "2.126.0",
+        "node-opcua-basic-types": "2.133.0",
         "node-opcua-constants": "2.125.0",
-        "node-opcua-data-model": "2.126.0",
-        "node-opcua-debug": "2.125.0",
-        "node-opcua-nodeid": "2.125.0",
-        "node-opcua-pseudo-session": "2.126.0",
-        "node-opcua-service-browse": "2.126.0",
-        "node-opcua-service-filter": "2.126.0",
-        "node-opcua-service-read": "2.126.0",
-        "node-opcua-service-subscription": "2.126.0",
-        "node-opcua-service-translate-browse-path": "2.126.0",
-        "node-opcua-status-code": "2.125.0",
-        "node-opcua-types": "2.126.0",
-        "node-opcua-utils": "2.125.0",
-        "node-opcua-variant": "2.126.0",
+        "node-opcua-data-model": "2.133.0",
+        "node-opcua-debug": "2.133.0",
+        "node-opcua-nodeid": "2.133.0",
+        "node-opcua-pseudo-session": "2.133.0",
+        "node-opcua-service-browse": "2.133.0",
+        "node-opcua-service-filter": "2.133.0",
+        "node-opcua-service-read": "2.133.0",
+        "node-opcua-service-subscription": "2.133.0",
+        "node-opcua-service-translate-browse-path": "2.133.0",
+        "node-opcua-status-code": "2.133.0",
+        "node-opcua-types": "2.133.0",
+        "node-opcua-utils": "2.133.0",
+        "node-opcua-variant": "2.133.0",
         "thenify": "^3.3.1"
       }
     },
@@ -7016,179 +7037,179 @@
       }
     },
     "node_modules/node-opcua-basic-types": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-basic-types/-/node-opcua-basic-types-2.126.0.tgz",
-      "integrity": "sha512-oE4e9ngJ8W9vk7hs/57qguWPHgE/M2DLCbcXCIH5zkTIxj/W4gMRjJkQuiR25SmbgfobaExMieAaBySo1u8/mA==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-basic-types/-/node-opcua-basic-types-2.133.0.tgz",
+      "integrity": "sha512-DwwcpmWCYEC8XNOdgPXgn3Dj2XaWPIad221ST5A69Bz/UIcAbdfv71S+EO+PKJ5xV5R0lLDwalEAuZMtdkHSJA==",
       "license": "MIT",
       "dependencies": {
         "node-opcua-assert": "2.120.0",
-        "node-opcua-binary-stream": "2.125.0",
-        "node-opcua-buffer-utils": "2.125.0",
-        "node-opcua-date-time": "2.125.0",
-        "node-opcua-guid": "2.120.0",
-        "node-opcua-nodeid": "2.125.0",
-        "node-opcua-status-code": "2.125.0"
+        "node-opcua-binary-stream": "2.133.0",
+        "node-opcua-buffer-utils": "2.133.0",
+        "node-opcua-date-time": "2.133.0",
+        "node-opcua-guid": "2.133.0",
+        "node-opcua-nodeid": "2.133.0",
+        "node-opcua-status-code": "2.133.0"
       }
     },
     "node_modules/node-opcua-binary-stream": {
-      "version": "2.125.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-binary-stream/-/node-opcua-binary-stream-2.125.0.tgz",
-      "integrity": "sha512-ePcFDdLAhNUJSmUjNu517QUGYSYFb44vrtphF4+mvvTi/esdyx1ICURhTYDnfcR8gD85zijOsXtaVmwt8O4gOw==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-binary-stream/-/node-opcua-binary-stream-2.133.0.tgz",
+      "integrity": "sha512-27rmHiglIqlNrZ67GAeqiVb5CMF3A20EXT1UFxaPCiVsWPBAAQQqcynwkep8/a0SrVGhPfXqNt59TPOe1L3iHg==",
       "license": "MIT",
       "dependencies": {
         "node-opcua-assert": "2.120.0",
-        "node-opcua-buffer-utils": "2.125.0"
+        "node-opcua-buffer-utils": "2.133.0"
       }
     },
     "node_modules/node-opcua-buffer-utils": {
-      "version": "2.125.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-buffer-utils/-/node-opcua-buffer-utils-2.125.0.tgz",
-      "integrity": "sha512-lKTlKuSn9hB4GR7vAX83Mp7q6It/yk0mL7zTeLmU15Smv3hC+yND8gBx+g6fMqm97ajXufBC8Mq2/AXM4k2S3A==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-buffer-utils/-/node-opcua-buffer-utils-2.133.0.tgz",
+      "integrity": "sha512-RLGvfCNLyi8g/o3oAMyQqbgQ/RFm2P0JGXN8ejAmHb6WJY7RvvrayK1vJMJXDdSsNiqtjOuTwE2oFiToQY4L9w==",
       "license": "MIT"
     },
     "node_modules/node-opcua-certificate-manager": {
-      "version": "2.125.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-certificate-manager/-/node-opcua-certificate-manager-2.125.0.tgz",
-      "integrity": "sha512-XtSYpmKmDbXrqGkVMG0M98MvUAtX/7Le2TIj0FNHfVRoI7oQTqAmSM3H2ZDYv+upPuSZzCxYFsqvVZcsqflOAw==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-certificate-manager/-/node-opcua-certificate-manager-2.133.0.tgz",
+      "integrity": "sha512-/kHqMkesVzUuz61gUaLQwOqJUsSIzNFXrdPJI85MSrKXXovyW9vx7QSrCPr5yIpFHZMEnGz514JCt5MfgEmf3g==",
       "license": "MIT",
       "dependencies": {
         "@types/mkdirp": "1.0.2",
         "env-paths": "2.2.1",
         "mkdirp": "1.0.4",
         "node-opcua-assert": "2.120.0",
-        "node-opcua-crypto": "4.8.0",
-        "node-opcua-debug": "2.125.0",
-        "node-opcua-object-registry": "2.125.0",
-        "node-opcua-pki": "4.10.0",
-        "node-opcua-status-code": "2.125.0",
+        "node-opcua-crypto": "4.10.0",
+        "node-opcua-debug": "2.133.0",
+        "node-opcua-object-registry": "2.133.0",
+        "node-opcua-pki": "4.14.0",
+        "node-opcua-status-code": "2.133.0",
         "thenify": "^3.3.1"
       }
     },
     "node_modules/node-opcua-chunkmanager": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-chunkmanager/-/node-opcua-chunkmanager-2.126.0.tgz",
-      "integrity": "sha512-t4qZ6RdHgvPXXhrSOdvsJLjr6QHosZk2r3uJH/Ug7gHpHgxeR8/ZYKgu7bb9FUxk1v28z1zsiAriVqRl47nRlg==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-chunkmanager/-/node-opcua-chunkmanager-2.133.0.tgz",
+      "integrity": "sha512-jO2MRExSw36ZTUdQX68ZhCdt9Kw/LRvq+vx0ONjEsHNP9ysxwzVG1RaYmPcjM4RZfMyRqWL77UkXmplxpq5Blw==",
       "license": "MIT",
       "dependencies": {
         "node-opcua-assert": "2.120.0",
-        "node-opcua-basic-types": "2.126.0",
-        "node-opcua-binary-stream": "2.125.0",
-        "node-opcua-buffer-utils": "2.125.0",
-        "node-opcua-factory": "2.126.0",
-        "node-opcua-packet-assembler": "2.125.0"
+        "node-opcua-basic-types": "2.133.0",
+        "node-opcua-binary-stream": "2.133.0",
+        "node-opcua-buffer-utils": "2.133.0",
+        "node-opcua-factory": "2.133.0",
+        "node-opcua-packet-assembler": "2.133.0"
       }
     },
     "node_modules/node-opcua-client": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-client/-/node-opcua-client-2.126.0.tgz",
-      "integrity": "sha512-WaOfBcXZzz6wVCD9irmyTQCuNfYOtikIQ4AtkBhgE+LYNZ4483ukJFaoPogMN8Vc8YLtgTwU1oGZgFWa5fEG0Q==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-client/-/node-opcua-client-2.133.0.tgz",
+      "integrity": "sha512-VFLOTCBOE06AZjlTgwcMP4cpZYY6wEB0ePeXQh3Gu9Y4WmTqWd2jiBUJe6woLMLcKBhuiFx7pTqnLQZYUTRo3Q==",
       "license": "MIT",
       "dependencies": {
         "@ster5/global-mutex": "^2.0.0",
         "@types/async": "^3.2.24",
-        "async": "^3.2.5",
+        "async": "^3.2.6",
         "chalk": "4.1.2",
-        "node-opcua-alarm-condition": "2.126.0",
+        "node-opcua-alarm-condition": "2.133.0",
         "node-opcua-assert": "2.120.0",
-        "node-opcua-basic-types": "2.126.0",
-        "node-opcua-buffer-utils": "2.125.0",
-        "node-opcua-certificate-manager": "2.125.0",
-        "node-opcua-client-dynamic-extension-object": "2.126.0",
-        "node-opcua-common": "2.126.0",
+        "node-opcua-basic-types": "2.133.0",
+        "node-opcua-buffer-utils": "2.133.0",
+        "node-opcua-certificate-manager": "2.133.0",
+        "node-opcua-client-dynamic-extension-object": "2.133.0",
+        "node-opcua-common": "2.133.0",
         "node-opcua-constants": "2.125.0",
-        "node-opcua-crypto": "4.8.0",
-        "node-opcua-data-model": "2.126.0",
-        "node-opcua-data-value": "2.126.0",
-        "node-opcua-date-time": "2.125.0",
-        "node-opcua-debug": "2.125.0",
-        "node-opcua-extension-object": "2.126.0",
-        "node-opcua-hostname": "2.120.0",
-        "node-opcua-nodeid": "2.125.0",
-        "node-opcua-object-registry": "2.125.0",
-        "node-opcua-pki": "4.10.0",
-        "node-opcua-pseudo-session": "2.126.0",
-        "node-opcua-schemas": "2.126.0",
-        "node-opcua-secure-channel": "2.126.0",
-        "node-opcua-service-browse": "2.126.0",
-        "node-opcua-service-call": "2.126.0",
-        "node-opcua-service-discovery": "2.126.0",
-        "node-opcua-service-endpoints": "2.126.0",
-        "node-opcua-service-filter": "2.126.0",
-        "node-opcua-service-history": "2.126.0",
-        "node-opcua-service-query": "2.126.0",
-        "node-opcua-service-read": "2.126.0",
-        "node-opcua-service-register-node": "2.126.0",
-        "node-opcua-service-secure-channel": "2.126.0",
-        "node-opcua-service-session": "2.126.0",
-        "node-opcua-service-subscription": "2.126.0",
-        "node-opcua-service-translate-browse-path": "2.126.0",
-        "node-opcua-service-write": "2.126.0",
-        "node-opcua-status-code": "2.125.0",
-        "node-opcua-types": "2.126.0",
-        "node-opcua-utils": "2.125.0",
-        "node-opcua-variant": "2.126.0",
+        "node-opcua-crypto": "4.10.0",
+        "node-opcua-data-model": "2.133.0",
+        "node-opcua-data-value": "2.133.0",
+        "node-opcua-date-time": "2.133.0",
+        "node-opcua-debug": "2.133.0",
+        "node-opcua-extension-object": "2.133.0",
+        "node-opcua-hostname": "2.128.0",
+        "node-opcua-nodeid": "2.133.0",
+        "node-opcua-object-registry": "2.133.0",
+        "node-opcua-pki": "4.14.0",
+        "node-opcua-pseudo-session": "2.133.0",
+        "node-opcua-schemas": "2.133.0",
+        "node-opcua-secure-channel": "2.133.0",
+        "node-opcua-service-browse": "2.133.0",
+        "node-opcua-service-call": "2.133.0",
+        "node-opcua-service-discovery": "2.133.0",
+        "node-opcua-service-endpoints": "2.133.0",
+        "node-opcua-service-filter": "2.133.0",
+        "node-opcua-service-history": "2.133.0",
+        "node-opcua-service-query": "2.133.0",
+        "node-opcua-service-read": "2.133.0",
+        "node-opcua-service-register-node": "2.133.0",
+        "node-opcua-service-secure-channel": "2.133.0",
+        "node-opcua-service-session": "2.133.0",
+        "node-opcua-service-subscription": "2.133.0",
+        "node-opcua-service-translate-browse-path": "2.133.0",
+        "node-opcua-service-write": "2.133.0",
+        "node-opcua-status-code": "2.133.0",
+        "node-opcua-types": "2.133.0",
+        "node-opcua-utils": "2.133.0",
+        "node-opcua-variant": "2.133.0",
         "thenify": "^3.3.1"
       }
     },
     "node_modules/node-opcua-client-dynamic-extension-object": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-client-dynamic-extension-object/-/node-opcua-client-dynamic-extension-object-2.126.0.tgz",
-      "integrity": "sha512-gf1/oqqqZglUz1o1m2l0TeHc/osx4Cj5l7CBo9dX60PbzEVVBWBNI1TS471PJLlPHdOZZm94BPfYLagSfFiLtg==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-client-dynamic-extension-object/-/node-opcua-client-dynamic-extension-object-2.133.0.tgz",
+      "integrity": "sha512-Jd6Kdr3iMTKMQgyHfiz+MT4570siG8Q1BTnYLF1cehT6PsBzK7bxGcOgvHl4Oy4sg9I0O3Zy1+ZkewLePISTuQ==",
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
         "node-opcua-assert": "2.120.0",
-        "node-opcua-binary-stream": "2.125.0",
+        "node-opcua-binary-stream": "2.133.0",
         "node-opcua-constants": "2.125.0",
-        "node-opcua-data-model": "2.126.0",
-        "node-opcua-data-value": "2.126.0",
-        "node-opcua-debug": "2.125.0",
-        "node-opcua-extension-object": "2.126.0",
-        "node-opcua-factory": "2.126.0",
-        "node-opcua-nodeid": "2.125.0",
-        "node-opcua-pseudo-session": "2.126.0",
-        "node-opcua-schemas": "2.126.0",
-        "node-opcua-service-browse": "2.126.0",
-        "node-opcua-service-translate-browse-path": "2.126.0",
-        "node-opcua-status-code": "2.125.0",
-        "node-opcua-types": "2.126.0",
-        "node-opcua-variant": "2.126.0"
+        "node-opcua-data-model": "2.133.0",
+        "node-opcua-data-value": "2.133.0",
+        "node-opcua-debug": "2.133.0",
+        "node-opcua-extension-object": "2.133.0",
+        "node-opcua-factory": "2.133.0",
+        "node-opcua-nodeid": "2.133.0",
+        "node-opcua-pseudo-session": "2.133.0",
+        "node-opcua-schemas": "2.133.0",
+        "node-opcua-service-browse": "2.133.0",
+        "node-opcua-service-translate-browse-path": "2.133.0",
+        "node-opcua-status-code": "2.133.0",
+        "node-opcua-types": "2.133.0",
+        "node-opcua-variant": "2.133.0"
       }
     },
     "node_modules/node-opcua-client-proxy": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-client-proxy/-/node-opcua-client-proxy-2.126.0.tgz",
-      "integrity": "sha512-T+6g9evVa4Q7sEQ6LD7s0xCFkT9ztjwVJkp1sg4GocQQXkF9j0xyfSvt3P36Qqsvp/jDKcFzlTJO2a7uhP9UJg==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-client-proxy/-/node-opcua-client-proxy-2.133.0.tgz",
+      "integrity": "sha512-daCQDOO7npu8LByizBe1FLQZ4krnik924aGkWv9pnpH6eujMnx9gTl+UM/HkHKRNceY3q3MZD94m+bWcRYe5qg==",
       "license": "MIT",
       "dependencies": {
-        "async": "^3.2.5",
+        "async": "^3.2.6",
         "node-opcua-assert": "2.120.0",
         "node-opcua-constants": "2.125.0",
-        "node-opcua-data-model": "2.126.0",
-        "node-opcua-data-value": "2.126.0",
-        "node-opcua-debug": "2.125.0",
-        "node-opcua-nodeid": "2.125.0",
-        "node-opcua-pseudo-session": "2.126.0",
-        "node-opcua-service-browse": "2.126.0",
-        "node-opcua-service-call": "2.126.0",
-        "node-opcua-service-read": "2.126.0",
-        "node-opcua-service-subscription": "2.126.0",
-        "node-opcua-service-write": "2.126.0",
-        "node-opcua-status-code": "2.125.0",
-        "node-opcua-utils": "2.125.0",
-        "node-opcua-variant": "2.126.0",
+        "node-opcua-data-model": "2.133.0",
+        "node-opcua-data-value": "2.133.0",
+        "node-opcua-debug": "2.133.0",
+        "node-opcua-nodeid": "2.133.0",
+        "node-opcua-pseudo-session": "2.133.0",
+        "node-opcua-service-browse": "2.133.0",
+        "node-opcua-service-call": "2.133.0",
+        "node-opcua-service-read": "2.133.0",
+        "node-opcua-service-subscription": "2.133.0",
+        "node-opcua-service-write": "2.133.0",
+        "node-opcua-status-code": "2.133.0",
+        "node-opcua-utils": "2.133.0",
+        "node-opcua-variant": "2.133.0",
         "thenify": "^3.3.1"
       }
     },
     "node_modules/node-opcua-common": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-common/-/node-opcua-common-2.126.0.tgz",
-      "integrity": "sha512-wxYJw3QoCU3xnt/y+slnjYs9W/saCfxGVXzZCt2XXEwq+zdZK4sE3rteCz3JsqtE8P6nBjTcU1O6kGdBKYfSJA==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-common/-/node-opcua-common-2.133.0.tgz",
+      "integrity": "sha512-j4apicAeLqQBWjAPEAIxTFZ9NaaEMPR1bP5fOTpwccYGg/ZacN5Hl/ieYoRViW30o6fpumt50QxTBcQz62jTyQ==",
       "license": "MIT",
       "dependencies": {
         "node-opcua-assert": "2.120.0",
-        "node-opcua-crypto": "4.8.0",
-        "node-opcua-types": "2.126.0"
+        "node-opcua-crypto": "4.10.0",
+        "node-opcua-types": "2.133.0"
       }
     },
     "node_modules/node-opcua-constants": {
@@ -7198,14 +7219,14 @@
       "license": "MIT"
     },
     "node_modules/node-opcua-crypto": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-crypto/-/node-opcua-crypto-4.8.0.tgz",
-      "integrity": "sha512-JUE2ThN4B68xUDA+Le0GyCoaIPSR0eTnis+gkyt6xCbu43qTN4dKyA7LSxz6rWCUoWp6gQqi89k12scvIJ7b4w==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-crypto/-/node-opcua-crypto-4.10.0.tgz",
+      "integrity": "sha512-my5DQakjFBJWRSj/uAkQMnBDPnNVooVhOc4mtZWoTvkmFToxX6cARo5iI3z6xHMnT8MJsXwk35iya5QH9vmMqQ==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/webcrypto": "^1.4.5",
-        "@peculiar/x509": "^1.9.7",
-        "@types/jsrsasign": "^10.5.12",
+        "@peculiar/webcrypto": "^1.5.0",
+        "@peculiar/x509": "^1.12.2",
+        "@types/jsrsasign": "^10.5.14",
         "@types/sshpk": "^1.17.4",
         "assert": "^2.1.0",
         "chalk": "^4.1.2",
@@ -7215,164 +7236,170 @@
       }
     },
     "node_modules/node-opcua-data-access": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-data-access/-/node-opcua-data-access-2.126.0.tgz",
-      "integrity": "sha512-1GbW4kzd7+n342u7NVvXqPP8OBXflohvE3kwOAhxzfgPr2JrQBsDKds8v4HHIh01B58PKAeP676SxwaNCEQqPQ==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-data-access/-/node-opcua-data-access-2.133.0.tgz",
+      "integrity": "sha512-sE3PUF/AyPgpnuLSFBDISfiL1sBRrGvFfhhbB/oXqtYB/2J8yq+YFNVBomOiimuw1zoKkJGdqTyQNql6tOKJfw==",
       "license": "MIT",
       "dependencies": {
-        "node-opcua-data-model": "2.126.0",
-        "node-opcua-types": "2.126.0"
+        "node-opcua-data-model": "2.133.0",
+        "node-opcua-types": "2.133.0"
       }
     },
     "node_modules/node-opcua-data-model": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-data-model/-/node-opcua-data-model-2.126.0.tgz",
-      "integrity": "sha512-F4yOuBrQsPjRyY9d9BOpt7uhQwda3U9ef0f2t33Q0OWU8nWO5UaEMtLsT7zJJCnRyz8Qlav/l/iho+T42CZNTg==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-data-model/-/node-opcua-data-model-2.133.0.tgz",
+      "integrity": "sha512-ukGNEe6/5bPXpFtH+T1U/jXsf/XPwlnPPnACilK0AGu4JPQhksX4exS1tKUX3FrRLc7Phar4tbUZhiQRej/+OQ==",
       "license": "MIT",
       "dependencies": {
         "node-opcua-assert": "2.120.0",
-        "node-opcua-basic-types": "2.126.0",
-        "node-opcua-binary-stream": "2.125.0",
-        "node-opcua-enum": "2.125.0",
-        "node-opcua-factory": "2.126.0",
-        "node-opcua-nodeid": "2.125.0",
-        "node-opcua-status-code": "2.125.0"
+        "node-opcua-basic-types": "2.133.0",
+        "node-opcua-binary-stream": "2.133.0",
+        "node-opcua-enum": "2.133.0",
+        "node-opcua-factory": "2.133.0",
+        "node-opcua-nodeid": "2.133.0",
+        "node-opcua-status-code": "2.133.0"
       }
     },
     "node_modules/node-opcua-data-value": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-data-value/-/node-opcua-data-value-2.126.0.tgz",
-      "integrity": "sha512-YYPikNkdObgMKF8FXqOt7V3Tk+j/Wh2XU+70zA5f1Heihz1t2VxrQ3TWuK056Ziv64oVGCy2DW3mT+T38icQFg==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-data-value/-/node-opcua-data-value-2.133.0.tgz",
+      "integrity": "sha512-ppeKjCHahMScC/HEFdtz/hfKkQdkejJOn7+/NJxIaY+HdkhXK6qZaeQxyHP3ufpK3nWdcRUT0ulrSIe6H6pPog==",
       "license": "MIT",
       "dependencies": {
         "node-opcua-assert": "2.120.0",
-        "node-opcua-basic-types": "2.126.0",
-        "node-opcua-binary-stream": "2.125.0",
-        "node-opcua-data-model": "2.126.0",
-        "node-opcua-date-time": "2.125.0",
-        "node-opcua-enum": "2.125.0",
-        "node-opcua-factory": "2.126.0",
-        "node-opcua-status-code": "2.125.0",
-        "node-opcua-variant": "2.126.0"
+        "node-opcua-basic-types": "2.133.0",
+        "node-opcua-binary-stream": "2.133.0",
+        "node-opcua-data-model": "2.133.0",
+        "node-opcua-date-time": "2.133.0",
+        "node-opcua-enum": "2.133.0",
+        "node-opcua-factory": "2.133.0",
+        "node-opcua-status-code": "2.133.0",
+        "node-opcua-variant": "2.133.0"
       }
     },
     "node_modules/node-opcua-date-time": {
-      "version": "2.125.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-date-time/-/node-opcua-date-time-2.125.0.tgz",
-      "integrity": "sha512-GD6yzD6FicreAaMvOhSB2sfOMjysTBpfR1NpCs8iJTmaQCZOJKryfvce0YSRM43hlZTxwAJut+RApHbmysRlHQ==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-date-time/-/node-opcua-date-time-2.133.0.tgz",
+      "integrity": "sha512-m9Aya2X6LKIMfzuWUv+CthwtW+yUAdIYgblX0+KbqiC/ONbPzqlk0G/VF2vB9xUTkyujwo6zzThKKTftIqFPvw==",
       "license": "MIT",
       "dependencies": {
-        "long": "^4.0.0",
+        "long": "5.2.3",
         "node-opcua-assert": "2.120.0",
-        "node-opcua-binary-stream": "2.125.0",
-        "node-opcua-utils": "2.125.0"
+        "node-opcua-binary-stream": "2.133.0",
+        "node-opcua-utils": "2.133.0"
       }
     },
+    "node_modules/node-opcua-date-time/node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+      "license": "Apache-2.0"
+    },
     "node_modules/node-opcua-debug": {
-      "version": "2.125.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-debug/-/node-opcua-debug-2.125.0.tgz",
-      "integrity": "sha512-UHmUMiQI8qolKY5apaf+KpBtT1dyqjuNd3BxYrdXNzldEItWTwLQExPfvEC+/c1nNITgDSs2MwLw7LZuMv3eHw==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-debug/-/node-opcua-debug-2.133.0.tgz",
+      "integrity": "sha512-tjoznegN9HuqvmilJrygk9DxWculnmTjQckTjsb5Uw3/0Mu/uysWACQVrMh+aGDaADXgze9uDd8gEvl5a4xMjQ==",
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
         "hexy": "0.3.5",
         "node-opcua-assert": "2.120.0",
-        "node-opcua-buffer-utils": "2.125.0"
+        "node-opcua-buffer-utils": "2.133.0"
       }
     },
     "node_modules/node-opcua-enum": {
-      "version": "2.125.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-enum/-/node-opcua-enum-2.125.0.tgz",
-      "integrity": "sha512-Y5wiFKX+Gc0/7dP7l5ZmeUl4OTZAispLLMM/0i32oXdK4VB5POj2UpMxykwFtWCZBkxWA1z9MfP5N2SMSELdNw==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-enum/-/node-opcua-enum-2.133.0.tgz",
+      "integrity": "sha512-FrcdXPOnankQJ4/rvOZpJdkdN8+WXXQ3IQZOuxPKjc10Hqsnjd5pSGT422D6JPjdpQr5esaCsvA6crzktmtQHQ==",
       "license": "MIT"
     },
     "node_modules/node-opcua-extension-object": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-extension-object/-/node-opcua-extension-object-2.126.0.tgz",
-      "integrity": "sha512-sezdfywGNX+lZUnRmaqceJa0xnvzbN3+T+saMRrN2uIW9EEZp1zp7Fj+OD1L5JBYMRcFhrJbHc7b9gn/tqFpwA==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-extension-object/-/node-opcua-extension-object-2.133.0.tgz",
+      "integrity": "sha512-OvwFY15LMg/zDIQ3dGIwIwDk77D5xDLBxBirrCPzZoKwaZhPwnOtkiZ5QZeiECMxAUUPLFYrI6osJ2vBhKztjQ==",
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
-        "node-opcua-basic-types": "2.126.0",
-        "node-opcua-binary-stream": "2.125.0",
-        "node-opcua-debug": "2.125.0",
-        "node-opcua-factory": "2.126.0",
-        "node-opcua-nodeid": "2.125.0"
+        "node-opcua-basic-types": "2.133.0",
+        "node-opcua-binary-stream": "2.133.0",
+        "node-opcua-debug": "2.133.0",
+        "node-opcua-factory": "2.133.0",
+        "node-opcua-nodeid": "2.133.0"
       }
     },
     "node_modules/node-opcua-factory": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-factory/-/node-opcua-factory-2.126.0.tgz",
-      "integrity": "sha512-qaTS2afZ9b5S5xk9cde0NnfvMtX3PBCJVRucupqQlpw2Y2y+rAyIIGJu7pbmloKf737gk7VuOC9E8UYDmbIKaQ==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-factory/-/node-opcua-factory-2.133.0.tgz",
+      "integrity": "sha512-HbPvrjhh8foPiQxwXRwrmBBbDncM75qkWyPq8/As+VzRkZnHkWqE0yWGnfgELT8X69+G9D1X6qwIV5RavIT7Nw==",
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
         "node-opcua-assert": "2.120.0",
-        "node-opcua-basic-types": "2.126.0",
-        "node-opcua-binary-stream": "2.125.0",
+        "node-opcua-basic-types": "2.133.0",
+        "node-opcua-binary-stream": "2.133.0",
         "node-opcua-constants": "2.125.0",
-        "node-opcua-debug": "2.125.0",
-        "node-opcua-enum": "2.125.0",
-        "node-opcua-guid": "2.120.0",
-        "node-opcua-nodeid": "2.125.0",
-        "node-opcua-status-code": "2.125.0",
-        "node-opcua-utils": "2.125.0"
+        "node-opcua-debug": "2.133.0",
+        "node-opcua-enum": "2.133.0",
+        "node-opcua-guid": "2.133.0",
+        "node-opcua-nodeid": "2.133.0",
+        "node-opcua-status-code": "2.133.0",
+        "node-opcua-utils": "2.133.0"
       }
     },
     "node_modules/node-opcua-generator": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-generator/-/node-opcua-generator-2.126.0.tgz",
-      "integrity": "sha512-KIcJnIgjSkR9dgqcda4U0avmw28JZGW5ZyARIBaYPEQmK1wGrcVWubx4M+Q3aD6gr9d9OaQuOfT2QKzLRFLoyw==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-generator/-/node-opcua-generator-2.133.0.tgz",
+      "integrity": "sha512-z8dcfndG0z9k7W/+nQeYEY+6NxivwmkvngXBsKk8upZg4tOSRnxo2pP4z11vJlrFZjB7IUEdi7kpDphHm9pc0w==",
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
         "node-opcua-assert": "2.120.0",
         "node-opcua-constants": "2.125.0",
-        "node-opcua-debug": "2.125.0",
-        "node-opcua-factory": "2.126.0",
-        "node-opcua-nodeid": "2.125.0",
-        "node-opcua-schemas": "2.126.0",
-        "node-opcua-utils": "2.125.0"
+        "node-opcua-debug": "2.133.0",
+        "node-opcua-factory": "2.133.0",
+        "node-opcua-nodeid": "2.133.0",
+        "node-opcua-schemas": "2.133.0",
+        "node-opcua-utils": "2.133.0"
       }
     },
     "node_modules/node-opcua-guid": {
-      "version": "2.120.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-guid/-/node-opcua-guid-2.120.0.tgz",
-      "integrity": "sha512-PTZboRcRCBaxgqhBnEW0eDZHlvRC1tCJqs8wWhwaQHJMWPwoAezj1O0/Ou0DTnjCG3n8jH1USsrTWCoLKJRp1g==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-guid/-/node-opcua-guid-2.133.0.tgz",
+      "integrity": "sha512-0voHp1ns3BLK09LZynWttC26Sou2KcpBtlbV6FwpQywPdnGxLNJxduYDs7Z0vZoxC8gjFvaOq0skoFEq5CGXew==",
       "license": "MIT"
     },
     "node_modules/node-opcua-hostname": {
-      "version": "2.120.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-hostname/-/node-opcua-hostname-2.120.0.tgz",
-      "integrity": "sha512-OYpptFrXMlO0jZ+747hUH1Hd+Hy8jLvvZaNvL5FStrSOIQqiertjIhqBK0Me7Vcw6FZ+UU4Ys+xDbWBizJR87w==",
+      "version": "2.128.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-hostname/-/node-opcua-hostname-2.128.0.tgz",
+      "integrity": "sha512-g/l0m3RtV7tzrwLDul8hAW+o4vvvxjUuOnbicPS3KaARSWn7ux6Wkg0j3e1+/IphdIcDC1M+hrjFdBRIKTJPQg==",
       "license": "MIT"
     },
     "node_modules/node-opcua-nodeid": {
-      "version": "2.125.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-nodeid/-/node-opcua-nodeid-2.125.0.tgz",
-      "integrity": "sha512-SAKQSoAs/fCUntpS5rBY2qT939UEDgNAp+1kDLZ+GB46kQ7kF1k6n4Xpw0ljTpHtjqr8GOu+683jsb2qrgDWEw==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-nodeid/-/node-opcua-nodeid-2.133.0.tgz",
+      "integrity": "sha512-CCKcKHpw5J1nr95C7QcKM+fl/zEcWqBzDVurSVSnjiXjHNTnnGRTM3RkbcG4PpoLWfRCQuEp2/p8qz/TF2mF4Q==",
       "license": "MIT",
       "dependencies": {
         "node-opcua-assert": "2.120.0",
         "node-opcua-constants": "2.125.0",
-        "node-opcua-guid": "2.120.0"
+        "node-opcua-guid": "2.133.0"
       }
     },
     "node_modules/node-opcua-nodeset-ua": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-nodeset-ua/-/node-opcua-nodeset-ua-2.126.0.tgz",
-      "integrity": "sha512-MMkjxQiYdwZMUgFRuzfF3oWIHcpGC/PIdnpnSjcoQ/02gqDv1NebpChyMtq94jBEtYPiMpI/0sa9T/sNnNi3zw==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-nodeset-ua/-/node-opcua-nodeset-ua-2.133.0.tgz",
+      "integrity": "sha512-MFtA/HJCObBrQithUOWQvj9T2MFyVrV3MmXXma7uasyse3FBKyQE9/4anKvGVlh7JV9hCuPLk/XjFY95OCrpxA==",
       "license": "MIT",
       "dependencies": {
-        "node-opcua-address-space-base": "2.126.0",
-        "node-opcua-basic-types": "2.126.0",
-        "node-opcua-data-access": "2.126.0",
-        "node-opcua-data-model": "2.126.0",
-        "node-opcua-data-value": "2.126.0",
-        "node-opcua-extension-object": "2.126.0",
-        "node-opcua-nodeid": "2.125.0",
-        "node-opcua-status-code": "2.125.0",
-        "node-opcua-variant": "2.126.0"
+        "node-opcua-address-space-base": "2.133.0",
+        "node-opcua-basic-types": "2.133.0",
+        "node-opcua-data-access": "2.133.0",
+        "node-opcua-data-model": "2.133.0",
+        "node-opcua-data-value": "2.133.0",
+        "node-opcua-extension-object": "2.133.0",
+        "node-opcua-nodeid": "2.133.0",
+        "node-opcua-status-code": "2.133.0",
+        "node-opcua-variant": "2.133.0"
       }
     },
     "node_modules/node-opcua-nodesets": {
@@ -7382,72 +7409,72 @@
       "license": "MIT"
     },
     "node_modules/node-opcua-numeric-range": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-numeric-range/-/node-opcua-numeric-range-2.126.0.tgz",
-      "integrity": "sha512-2ZyhLCUWddQeoGoriViMl1Ov/Lbv61lq5Mu7JPUJzE2VEeNCtvgWcMurfpzTcQbI+tsS6Bor+CukD2VaIVNBdw==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-numeric-range/-/node-opcua-numeric-range-2.133.0.tgz",
+      "integrity": "sha512-+vD+Xj6Qe8iBwUHY7cHW+Tkdf4roRfLSIrsSR7MOYgIPnQZFQGc3jwyJ5nCmzAQBPMJC2Fq4RsQ0U0HbAMchBg==",
       "license": "MIT",
       "dependencies": {
         "node-opcua-assert": "2.120.0",
-        "node-opcua-basic-types": "2.126.0",
-        "node-opcua-binary-stream": "2.125.0",
-        "node-opcua-factory": "2.126.0",
-        "node-opcua-status-code": "2.125.0"
+        "node-opcua-basic-types": "2.133.0",
+        "node-opcua-binary-stream": "2.133.0",
+        "node-opcua-factory": "2.133.0",
+        "node-opcua-status-code": "2.133.0"
       }
     },
     "node_modules/node-opcua-object-registry": {
-      "version": "2.125.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-object-registry/-/node-opcua-object-registry-2.125.0.tgz",
-      "integrity": "sha512-SxcRtIVifIUE/N84akPX4e4jcXnfl3T73Tvi9vixYKqarhUIQiB+7sNCUuD719p4jzzszlQiBUgYD/W4WISGeA==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-object-registry/-/node-opcua-object-registry-2.133.0.tgz",
+      "integrity": "sha512-drOopDqzT0khgGCWZ2e2OHZmt8yEpzjMFPLxPHuUF2i2Sb9lKuU4CXeF4LwQ9Y7WPQ8mS2Ub2OdK8YNpsRctew==",
       "license": "MIT",
       "dependencies": {
         "node-opcua-assert": "2.120.0",
-        "node-opcua-debug": "2.125.0"
+        "node-opcua-debug": "2.133.0"
       }
     },
     "node_modules/node-opcua-packet-analyzer": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-packet-analyzer/-/node-opcua-packet-analyzer-2.126.0.tgz",
-      "integrity": "sha512-gikAoX5QBcBQIY2rAc6Li5JWO9lHg3TdHgsNzUPTCA0LMj00v+LZbXRZqR7tHPCmNCshSaN59uBIjjDYBuaO6A==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-packet-analyzer/-/node-opcua-packet-analyzer-2.133.0.tgz",
+      "integrity": "sha512-ItVnJE+3zsAZtYqJgAvUPYB8MwpSbYcQXfs8iSttxVgyWAXzy4OWzdg6NYPkbXgLTl3Sk8AJ2MJ70Favu5xJEQ==",
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
         "node-opcua-assert": "2.120.0",
-        "node-opcua-basic-types": "2.126.0",
-        "node-opcua-binary-stream": "2.125.0",
-        "node-opcua-debug": "2.125.0",
-        "node-opcua-factory": "2.126.0",
-        "node-opcua-utils": "2.125.0"
+        "node-opcua-basic-types": "2.133.0",
+        "node-opcua-binary-stream": "2.133.0",
+        "node-opcua-debug": "2.133.0",
+        "node-opcua-factory": "2.133.0",
+        "node-opcua-utils": "2.133.0"
       }
     },
     "node_modules/node-opcua-packet-assembler": {
-      "version": "2.125.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-packet-assembler/-/node-opcua-packet-assembler-2.125.0.tgz",
-      "integrity": "sha512-4BbZyZCna34aUe/vSnByTtxjOiet+RejIcfv9C9HvihioDvmOdmBhcytOSbt70Rty0erJ8dTnAFmkWUqI4Vq5w==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-packet-assembler/-/node-opcua-packet-assembler-2.133.0.tgz",
+      "integrity": "sha512-Fci1+3Jpj2UdwQI0ClOwwxvyLtbhYZ2z9z7HHFbvfj6rqLizwpM+L3OGRqttNKb+JzKMEe7vuq/w5txvd+gJXg==",
       "license": "MIT",
       "dependencies": {
         "node-opcua-assert": "2.120.0",
-        "node-opcua-debug": "2.125.0"
+        "node-opcua-debug": "2.133.0"
       }
     },
     "node_modules/node-opcua-pki": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-pki/-/node-opcua-pki-4.10.0.tgz",
-      "integrity": "sha512-rSRXUCduHvCTmQBvJb4oAeoNIeHqC2f4DOeZ2v8s+Wy1n3+xKYpNRoU008Gqe2c78GZRNhu305axgsz+4LzOQA==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-pki/-/node-opcua-pki-4.14.0.tgz",
+      "integrity": "sha512-4VoJ827rP3c6yNAr6ZIOqNTGLidB4AxL5GLyA9CjHWb4TOGkeOuQ2bo02bUVduTq7XCe3clYlWRPAtKUg0MjQw==",
       "license": "MIT",
       "dependencies": {
         "@ster5/global-mutex": "^2.0.0",
-        "async": "^3.2.5",
+        "async": "^3.2.6",
         "byline": "^5.0.0",
         "chalk": "4.1.2",
-        "chokidar": "^3.6.0",
+        "chokidar": "4.0.1",
         "cli-table": "^0.3.11",
-        "node-opcua-crypto": "4.8.0",
+        "node-opcua-crypto": "4.10.0",
         "progress": "^2.0.3",
         "rimraf": "4.4.1",
         "thenify": "^3.3.1",
         "wget-improved-2": "^3.3.0",
         "yargs": "17.7.2",
-        "yauzl": "^3.1.0"
+        "yauzl": "^3.1.3"
       },
       "bin": {
         "pki": "bin/crypto_create_CA.js"
@@ -7460,6 +7487,21 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/node-opcua-pki/node_modules/chokidar": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
+      "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/node-opcua-pki/node_modules/cliui": {
@@ -7525,6 +7567,19 @@
       "license": "ISC",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/node-opcua-pki/node_modules/readdirp": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
+      "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/node-opcua-pki/node_modules/rimraf": {
@@ -7613,387 +7668,386 @@
       }
     },
     "node_modules/node-opcua-pseudo-session": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-pseudo-session/-/node-opcua-pseudo-session-2.126.0.tgz",
-      "integrity": "sha512-iAk+Xmxy31NM/XXB5vLTZggtoD43takwt8gQUFnDHD99UlykcIReOYEGfHhWCpIDXul2y8olkMfDZBCcyB+F2Q==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-pseudo-session/-/node-opcua-pseudo-session-2.133.0.tgz",
+      "integrity": "sha512-FImmezqdCVjJ9uh951kb+zSHRmrqaCvSd9OvbaIl3OZL32vs8s7k/USQwVr1q9gQn6iZxZle2fkUQJiNNEyWww==",
       "license": "MIT",
       "dependencies": {
         "node-opcua-assert": "2.120.0",
-        "node-opcua-basic-types": "2.126.0",
+        "node-opcua-basic-types": "2.133.0",
         "node-opcua-constants": "2.125.0",
-        "node-opcua-data-model": "2.126.0",
-        "node-opcua-data-value": "2.126.0",
-        "node-opcua-debug": "2.125.0",
-        "node-opcua-nodeid": "2.125.0",
-        "node-opcua-service-browse": "2.126.0",
-        "node-opcua-service-call": "2.126.0",
-        "node-opcua-service-filter": "2.126.0",
-        "node-opcua-service-read": "2.126.0",
-        "node-opcua-service-subscription": "2.126.0",
-        "node-opcua-service-translate-browse-path": "2.126.0",
-        "node-opcua-service-write": "2.126.0",
-        "node-opcua-status-code": "2.125.0",
-        "node-opcua-types": "2.126.0",
-        "node-opcua-utils": "2.125.0",
-        "node-opcua-variant": "2.126.0",
+        "node-opcua-data-model": "2.133.0",
+        "node-opcua-data-value": "2.133.0",
+        "node-opcua-debug": "2.133.0",
+        "node-opcua-nodeid": "2.133.0",
+        "node-opcua-service-browse": "2.133.0",
+        "node-opcua-service-call": "2.133.0",
+        "node-opcua-service-filter": "2.133.0",
+        "node-opcua-service-read": "2.133.0",
+        "node-opcua-service-subscription": "2.133.0",
+        "node-opcua-service-translate-browse-path": "2.133.0",
+        "node-opcua-service-write": "2.133.0",
+        "node-opcua-status-code": "2.133.0",
+        "node-opcua-types": "2.133.0",
+        "node-opcua-utils": "2.133.0",
+        "node-opcua-variant": "2.133.0",
         "thenify": "^3.3.1"
       }
     },
     "node_modules/node-opcua-schemas": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-schemas/-/node-opcua-schemas-2.126.0.tgz",
-      "integrity": "sha512-3F9Y6FDvsodtCvJcTRJOMghaHewaLCyWc7Y69TwPSboMHKs4PDqx+jPfZs2CtC71pMh58KjKKsxJXrfBeEybeA==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-schemas/-/node-opcua-schemas-2.133.0.tgz",
+      "integrity": "sha512-K/ObgcqHUHp81HKU8RQAzVw5imYNppnbm8/75FHQMzJnaZcqfiIs3vpIyKUQ1hLh0SAvOVWhiFtnn2PExRwlEw==",
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
         "node-opcua-assert": "2.120.0",
-        "node-opcua-binary-stream": "2.125.0",
-        "node-opcua-debug": "2.125.0",
-        "node-opcua-extension-object": "2.126.0",
-        "node-opcua-factory": "2.126.0",
-        "node-opcua-nodeid": "2.125.0",
-        "node-opcua-variant": "2.126.0",
-        "node-opcua-xml2json": "2.125.0"
+        "node-opcua-binary-stream": "2.133.0",
+        "node-opcua-debug": "2.133.0",
+        "node-opcua-extension-object": "2.133.0",
+        "node-opcua-factory": "2.133.0",
+        "node-opcua-nodeid": "2.133.0",
+        "node-opcua-variant": "2.133.0",
+        "node-opcua-xml2json": "2.133.0"
       }
     },
     "node_modules/node-opcua-secure-channel": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-secure-channel/-/node-opcua-secure-channel-2.126.0.tgz",
-      "integrity": "sha512-G4cU64ahb8sPsM4uctScwjeMJeTCEsdTY7U8oGIJLjFK4Ejj76t6G6a+8P2pA5DaC76Izkqcp/EAWfhkTEpoNQ==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-secure-channel/-/node-opcua-secure-channel-2.133.0.tgz",
+      "integrity": "sha512-vzzOi8vvK9+uYfA4mcpjePkIazAp8JDR1Ldm0qU53y5LVr5gg3VBvyzGlDulxCSGriiWm6FNuVsWe2tYBxIR4g==",
       "license": "MIT",
       "dependencies": {
-        "async": "^3.2.5",
         "backoff": "^2.5.0",
         "chalk": "4.1.2",
         "node-opcua-assert": "2.120.0",
-        "node-opcua-basic-types": "2.126.0",
-        "node-opcua-binary-stream": "2.125.0",
-        "node-opcua-certificate-manager": "2.125.0",
-        "node-opcua-chunkmanager": "2.126.0",
-        "node-opcua-common": "2.126.0",
-        "node-opcua-crypto": "4.8.0",
-        "node-opcua-debug": "2.125.0",
-        "node-opcua-factory": "2.126.0",
-        "node-opcua-nodeid": "2.125.0",
-        "node-opcua-object-registry": "2.125.0",
-        "node-opcua-packet-analyzer": "2.126.0",
-        "node-opcua-service-endpoints": "2.126.0",
-        "node-opcua-service-secure-channel": "2.126.0",
-        "node-opcua-status-code": "2.125.0",
-        "node-opcua-transport": "2.126.0",
-        "node-opcua-types": "2.126.0",
-        "node-opcua-utils": "2.125.0"
+        "node-opcua-basic-types": "2.133.0",
+        "node-opcua-binary-stream": "2.133.0",
+        "node-opcua-certificate-manager": "2.133.0",
+        "node-opcua-chunkmanager": "2.133.0",
+        "node-opcua-common": "2.133.0",
+        "node-opcua-crypto": "4.10.0",
+        "node-opcua-debug": "2.133.0",
+        "node-opcua-factory": "2.133.0",
+        "node-opcua-nodeid": "2.133.0",
+        "node-opcua-object-registry": "2.133.0",
+        "node-opcua-packet-analyzer": "2.133.0",
+        "node-opcua-service-endpoints": "2.133.0",
+        "node-opcua-service-secure-channel": "2.133.0",
+        "node-opcua-status-code": "2.133.0",
+        "node-opcua-transport": "2.133.0",
+        "node-opcua-types": "2.133.0",
+        "node-opcua-utils": "2.133.0"
       }
     },
     "node_modules/node-opcua-server": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-server/-/node-opcua-server-2.126.0.tgz",
-      "integrity": "sha512-pcdbZajrgpLYAFIqfHXuYeBMPJzE1amfDyn86xDpbxer+qjmgy2k5UN1mh9wuk6eHU9eFXRf8H1xV+PXBaPXHA==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-server/-/node-opcua-server-2.133.0.tgz",
+      "integrity": "sha512-2ctAPJAta/+pKYx/L5X/srgLz8PSN4uFNUCeiUAwx1DIPXJuWZbxTL00A9vv08NtzyQ/Zd6taiPTRCg6nQvS2A==",
       "license": "MIT",
       "dependencies": {
         "@ster5/global-mutex": "^2.0.0",
-        "async": "^3.2.5",
+        "async": "^3.2.6",
         "chalk": "4.1.2",
         "dequeue": "^1.0.5",
         "lodash": "4.17.21",
-        "node-opcua-address-space": "2.126.0",
-        "node-opcua-address-space-base": "2.126.0",
+        "node-opcua-address-space": "2.133.0",
+        "node-opcua-address-space-base": "2.133.0",
         "node-opcua-assert": "2.120.0",
-        "node-opcua-basic-types": "2.126.0",
-        "node-opcua-binary-stream": "2.125.0",
-        "node-opcua-certificate-manager": "2.125.0",
-        "node-opcua-client": "2.126.0",
-        "node-opcua-client-dynamic-extension-object": "2.126.0",
-        "node-opcua-common": "2.126.0",
+        "node-opcua-basic-types": "2.133.0",
+        "node-opcua-binary-stream": "2.133.0",
+        "node-opcua-certificate-manager": "2.133.0",
+        "node-opcua-client": "2.133.0",
+        "node-opcua-client-dynamic-extension-object": "2.133.0",
+        "node-opcua-common": "2.133.0",
         "node-opcua-constants": "2.125.0",
-        "node-opcua-crypto": "4.8.0",
-        "node-opcua-data-model": "2.126.0",
-        "node-opcua-data-value": "2.126.0",
-        "node-opcua-date-time": "2.125.0",
-        "node-opcua-debug": "2.125.0",
-        "node-opcua-extension-object": "2.126.0",
-        "node-opcua-factory": "2.126.0",
-        "node-opcua-hostname": "2.120.0",
-        "node-opcua-nodeid": "2.125.0",
+        "node-opcua-crypto": "4.10.0",
+        "node-opcua-data-model": "2.133.0",
+        "node-opcua-data-value": "2.133.0",
+        "node-opcua-date-time": "2.133.0",
+        "node-opcua-debug": "2.133.0",
+        "node-opcua-extension-object": "2.133.0",
+        "node-opcua-factory": "2.133.0",
+        "node-opcua-hostname": "2.128.0",
+        "node-opcua-nodeid": "2.133.0",
         "node-opcua-nodesets": "2.121.0",
-        "node-opcua-numeric-range": "2.126.0",
-        "node-opcua-object-registry": "2.125.0",
-        "node-opcua-secure-channel": "2.126.0",
-        "node-opcua-service-browse": "2.126.0",
-        "node-opcua-service-call": "2.126.0",
-        "node-opcua-service-discovery": "2.126.0",
-        "node-opcua-service-endpoints": "2.126.0",
-        "node-opcua-service-filter": "2.126.0",
-        "node-opcua-service-history": "2.126.0",
-        "node-opcua-service-node-management": "2.126.0",
-        "node-opcua-service-query": "2.126.0",
-        "node-opcua-service-read": "2.126.0",
-        "node-opcua-service-register-node": "2.126.0",
-        "node-opcua-service-secure-channel": "2.126.0",
-        "node-opcua-service-session": "2.126.0",
-        "node-opcua-service-subscription": "2.126.0",
-        "node-opcua-service-translate-browse-path": "2.126.0",
-        "node-opcua-service-write": "2.126.0",
-        "node-opcua-status-code": "2.125.0",
-        "node-opcua-transport": "2.126.0",
-        "node-opcua-types": "2.126.0",
-        "node-opcua-utils": "2.125.0",
-        "node-opcua-variant": "2.126.0",
+        "node-opcua-numeric-range": "2.133.0",
+        "node-opcua-object-registry": "2.133.0",
+        "node-opcua-secure-channel": "2.133.0",
+        "node-opcua-service-browse": "2.133.0",
+        "node-opcua-service-call": "2.133.0",
+        "node-opcua-service-discovery": "2.133.0",
+        "node-opcua-service-endpoints": "2.133.0",
+        "node-opcua-service-filter": "2.133.0",
+        "node-opcua-service-history": "2.133.0",
+        "node-opcua-service-node-management": "2.133.0",
+        "node-opcua-service-query": "2.133.0",
+        "node-opcua-service-read": "2.133.0",
+        "node-opcua-service-register-node": "2.133.0",
+        "node-opcua-service-secure-channel": "2.133.0",
+        "node-opcua-service-session": "2.133.0",
+        "node-opcua-service-subscription": "2.133.0",
+        "node-opcua-service-translate-browse-path": "2.133.0",
+        "node-opcua-service-write": "2.133.0",
+        "node-opcua-status-code": "2.133.0",
+        "node-opcua-transport": "2.133.0",
+        "node-opcua-types": "2.133.0",
+        "node-opcua-utils": "2.133.0",
+        "node-opcua-variant": "2.133.0",
         "thenify": "^3.3.1"
       }
     },
     "node_modules/node-opcua-server-discovery": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-server-discovery/-/node-opcua-server-discovery-2.126.0.tgz",
-      "integrity": "sha512-ael/SVE+J/wxZxEdDk5lhv2YvQXk51EK6UglKfRVfR+CEyE/upjU2Vfot0Krt4GoR22cAlhSFTqtbzkSKuCcEw==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-server-discovery/-/node-opcua-server-discovery-2.133.0.tgz",
+      "integrity": "sha512-M2fCdXd9nwEUVUXgPCd0CHMbfCJ+Zq64DWdH8cXFyIhaWgjl8l9gn6Igl5J9yityAqsrHvJT2F4H5GsFc5cG0w==",
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
         "env-paths": "2.2.1",
         "node-opcua-assert": "2.120.0",
-        "node-opcua-basic-types": "2.126.0",
-        "node-opcua-certificate-manager": "2.125.0",
-        "node-opcua-common": "2.126.0",
-        "node-opcua-debug": "2.125.0",
-        "node-opcua-hostname": "2.120.0",
-        "node-opcua-object-registry": "2.125.0",
-        "node-opcua-secure-channel": "2.126.0",
-        "node-opcua-server": "2.126.0",
-        "node-opcua-service-discovery": "2.126.0",
-        "node-opcua-service-endpoints": "2.126.0",
-        "node-opcua-status-code": "2.125.0",
+        "node-opcua-basic-types": "2.133.0",
+        "node-opcua-certificate-manager": "2.133.0",
+        "node-opcua-common": "2.133.0",
+        "node-opcua-debug": "2.133.0",
+        "node-opcua-hostname": "2.128.0",
+        "node-opcua-object-registry": "2.133.0",
+        "node-opcua-secure-channel": "2.133.0",
+        "node-opcua-server": "2.133.0",
+        "node-opcua-service-discovery": "2.133.0",
+        "node-opcua-service-endpoints": "2.133.0",
+        "node-opcua-status-code": "2.133.0",
         "sterfive-bonjour-service": "1.1.4",
         "thenify": "^3.3.1"
       }
     },
     "node_modules/node-opcua-service-browse": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-browse/-/node-opcua-service-browse-2.126.0.tgz",
-      "integrity": "sha512-W/2oCMFeycwXJx0Mm2qNHuMxsQJ9Z1j5NC020n3Gg/G4ZnRbbA+QB1/4La4a/tz9UWQ9Dw6e/hR8/OT5i8Zvsg==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-service-browse/-/node-opcua-service-browse-2.133.0.tgz",
+      "integrity": "sha512-YyOUdhpF1e31rbRm9pIpTDA9nhd8674daKJfbZzL/eGIfJeg0jYsxsHgaOdHUXtxnL0k5OF3ImArM6FUOv0y/w==",
       "license": "MIT",
       "dependencies": {
-        "node-opcua-data-model": "2.126.0",
-        "node-opcua-types": "2.126.0"
+        "node-opcua-data-model": "2.133.0",
+        "node-opcua-types": "2.133.0"
       }
     },
     "node_modules/node-opcua-service-call": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-call/-/node-opcua-service-call-2.126.0.tgz",
-      "integrity": "sha512-w+0NgAhItMktpuChaYnlLvqngu7fy3f2aIs7VBEdlqZs9O/P6SbIsGIeRc/gVNz8arsiLNSSFv9kqEfrazcE4g==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-service-call/-/node-opcua-service-call-2.133.0.tgz",
+      "integrity": "sha512-fhNekSyQld1sy2zHPMNL7DV04e3yhccf+tqxuenKDo0YsOYkIcuZ0FxJAHIoafc2vLPQZE2O0FDlhhGaBeJjcw==",
       "license": "MIT",
       "dependencies": {
         "node-opcua-assert": "2.120.0",
-        "node-opcua-nodeid": "2.125.0",
-        "node-opcua-types": "2.126.0",
-        "node-opcua-variant": "2.126.0"
+        "node-opcua-nodeid": "2.133.0",
+        "node-opcua-types": "2.133.0",
+        "node-opcua-variant": "2.133.0"
       }
     },
     "node_modules/node-opcua-service-discovery": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-discovery/-/node-opcua-service-discovery-2.126.0.tgz",
-      "integrity": "sha512-GOS0pz7aBBRu44e1m+4ZE0rPSfJA/gXNB/DKYSbLEzZ+ZFbX+6p0z3+gJVm9uSTqk/OcvJedJZAwZ4q/AhsRag==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-service-discovery/-/node-opcua-service-discovery-2.133.0.tgz",
+      "integrity": "sha512-z2m3A94eFAWbjKC6PW0Z/HCxY0+zcg5Sxhc7eL79ooZPLRkkMY/uS5Wqav4yxT8Bv0m164fNEeW2uZhOh6uzQQ==",
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
         "node-opcua-assert": "2.120.0",
-        "node-opcua-debug": "2.125.0",
-        "node-opcua-object-registry": "2.125.0",
-        "node-opcua-types": "2.126.0",
+        "node-opcua-debug": "2.133.0",
+        "node-opcua-object-registry": "2.133.0",
+        "node-opcua-types": "2.133.0",
         "sterfive-bonjour-service": "1.1.4"
       }
     },
     "node_modules/node-opcua-service-endpoints": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-endpoints/-/node-opcua-service-endpoints-2.126.0.tgz",
-      "integrity": "sha512-W5SSY3Zkhcc78hBs8+I31vjWYL/gjJydfyJmayKC0uKrRRCgLZrTQp4ZeKEYZcG+UJatOON8cKr+WFD1ExHDxw==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-service-endpoints/-/node-opcua-service-endpoints-2.133.0.tgz",
+      "integrity": "sha512-fwdqWQ4/eZuX92VOS/byHA3G0ltE0mpMQWGrJKnhtwDQftV+hLO80RmuDyQmF9NXnJXzjZKkPAvVZYB+RGNehQ==",
       "license": "MIT",
       "dependencies": {
-        "node-opcua-types": "2.126.0"
+        "node-opcua-types": "2.133.0"
       }
     },
     "node_modules/node-opcua-service-filter": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-filter/-/node-opcua-service-filter-2.126.0.tgz",
-      "integrity": "sha512-DStbk7snB02iwL5kWqzV4I35mzk55TtjTmh8ZomktIiem5OIBTmD2ewIwnsqMzZC4TCP+Fo2mgwKy82KcYJh0g==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-service-filter/-/node-opcua-service-filter-2.133.0.tgz",
+      "integrity": "sha512-mOvHlNANjhoEy43tGvdDzhSq82yOE6ih18s7n89WQagGKQrWZOHXOFLjX62eTfO01ZfnRAYNSMFWBgn5GMKfcg==",
       "license": "MIT",
       "dependencies": {
-        "node-opcua-address-space-base": "2.126.0",
+        "node-opcua-address-space-base": "2.133.0",
         "node-opcua-assert": "2.120.0",
-        "node-opcua-basic-types": "2.126.0",
+        "node-opcua-basic-types": "2.133.0",
         "node-opcua-constants": "2.125.0",
-        "node-opcua-data-model": "2.126.0",
-        "node-opcua-data-value": "2.126.0",
-        "node-opcua-debug": "2.125.0",
-        "node-opcua-extension-object": "2.126.0",
-        "node-opcua-nodeid": "2.125.0",
-        "node-opcua-service-translate-browse-path": "2.126.0",
-        "node-opcua-status-code": "2.125.0",
-        "node-opcua-types": "2.126.0",
-        "node-opcua-variant": "2.126.0"
+        "node-opcua-data-model": "2.133.0",
+        "node-opcua-data-value": "2.133.0",
+        "node-opcua-debug": "2.133.0",
+        "node-opcua-extension-object": "2.133.0",
+        "node-opcua-nodeid": "2.133.0",
+        "node-opcua-service-translate-browse-path": "2.133.0",
+        "node-opcua-status-code": "2.133.0",
+        "node-opcua-types": "2.133.0",
+        "node-opcua-variant": "2.133.0"
       }
     },
     "node_modules/node-opcua-service-history": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-history/-/node-opcua-service-history-2.126.0.tgz",
-      "integrity": "sha512-lrXYKqoL8allBDP/LiFxjs9QN8eBBKe5j4TEWAgEO9F6KSynGn5OZE8cygW7ZQ4fjbFunTBA1Pg74uvGPFZRfw==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-service-history/-/node-opcua-service-history-2.133.0.tgz",
+      "integrity": "sha512-lifBLtn8rZx5JDQ0VnQgM5wzk6xKSCmYeik4oAiQw0lijGYYDpaxbvPJfxPrR/J5SxZD0ve9rHM3G5RXzGqHuA==",
       "license": "MIT",
       "dependencies": {
         "node-opcua-assert": "2.120.0",
-        "node-opcua-data-value": "2.126.0",
-        "node-opcua-types": "2.126.0"
+        "node-opcua-data-value": "2.133.0",
+        "node-opcua-types": "2.133.0"
       }
     },
     "node_modules/node-opcua-service-node-management": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-node-management/-/node-opcua-service-node-management-2.126.0.tgz",
-      "integrity": "sha512-1WLCqWQa8bp3dCsQ4bzMvD5fM7+8j7E7KoWbSQEseZc+Lqdxj51V7muWBL7Fa+4Wk/1CAV+xp7R05D32yUR9Iw==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-service-node-management/-/node-opcua-service-node-management-2.133.0.tgz",
+      "integrity": "sha512-Mx2wv5xLoZiHl5EiQD11ta3xBfe6O63TRZBOUQrs7IgXYaCnUh6eMcYvvXBo1XcSTKUfcdDoZD5Rx2zCnbn2bA==",
       "license": "MIT",
       "dependencies": {
-        "node-opcua-types": "2.126.0"
+        "node-opcua-types": "2.133.0"
       }
     },
     "node_modules/node-opcua-service-query": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-query/-/node-opcua-service-query-2.126.0.tgz",
-      "integrity": "sha512-WRVi7RgTgIxqF42A+dCFWe3felo0EMKRjvHN1N3GCgJqQvrjv0UdbiDMMZrj8CUwLyy2l8ZktAnmlDLLENKfkA==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-service-query/-/node-opcua-service-query-2.133.0.tgz",
+      "integrity": "sha512-5hSvbxyjphWLEoZJmyOOSQD9Jim/ycBMJx63wfQr5J+IUl/Q0gibHQ4ZWH/SmOxBRwYkZFVefS/aUoGx9q2CgQ==",
       "license": "MIT",
       "dependencies": {
-        "node-opcua-types": "2.126.0"
+        "node-opcua-types": "2.133.0"
       }
     },
     "node_modules/node-opcua-service-read": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-read/-/node-opcua-service-read-2.126.0.tgz",
-      "integrity": "sha512-RZGayRJkUA2CXkPGCDfEcO6/OLI2VNPRUJ9tyzAVvcYx1d7i90wE4daBX2miotu76pZNueAthEp+x6SB7LYtJg==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-service-read/-/node-opcua-service-read-2.133.0.tgz",
+      "integrity": "sha512-zHcYxqqnQAUgFNnxyTLzTuO/QuyQJAvEeQFS1zL1BfOhA4ftkTxj3zNgS9Kxxp3u0TMnxZ+B+LiGmku4dTn3QA==",
       "license": "MIT",
       "dependencies": {
         "node-opcua-assert": "2.120.0",
-        "node-opcua-data-model": "2.126.0",
-        "node-opcua-data-value": "2.126.0",
-        "node-opcua-service-secure-channel": "2.126.0",
-        "node-opcua-types": "2.126.0"
+        "node-opcua-data-model": "2.133.0",
+        "node-opcua-data-value": "2.133.0",
+        "node-opcua-service-secure-channel": "2.133.0",
+        "node-opcua-types": "2.133.0"
       }
     },
     "node_modules/node-opcua-service-register-node": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-register-node/-/node-opcua-service-register-node-2.126.0.tgz",
-      "integrity": "sha512-wezjw43ZnJYVxFwuFVYZ753ezFs4wdMQQg7sIfWEl7O7MAN1E14c4keNKgG8RTcrYrHLEOUIzSoIKFIFf34qtQ==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-service-register-node/-/node-opcua-service-register-node-2.133.0.tgz",
+      "integrity": "sha512-GTTgzLzZGl/1tUNNECgWSMrY2xv9zzmA8IFSWjYJ+eha8G5GEzKQHu5vml05NpQabqzDGKGjKecyT4/taQfYwA==",
       "license": "MIT",
       "dependencies": {
-        "node-opcua-types": "2.126.0"
+        "node-opcua-types": "2.133.0"
       }
     },
     "node_modules/node-opcua-service-secure-channel": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-secure-channel/-/node-opcua-service-secure-channel-2.126.0.tgz",
-      "integrity": "sha512-b9rF/mJF1YH1SXwjCx0L0wfMpIyIEiGpC/j6vImhN2If1TZhoxqGjowv3Rlz1UEoidIV3gRVEt4J7DGbkacBLw==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-service-secure-channel/-/node-opcua-service-secure-channel-2.133.0.tgz",
+      "integrity": "sha512-/+M+kvMy58PnrMmuB4/zkaoctzEudJ5fTv5133WrRuZpqXB8z8ziP6fhHbieMQY0jps/2dMRAt93m7e/hjaUrg==",
       "license": "MIT",
       "dependencies": {
         "node-opcua-assert": "2.120.0",
-        "node-opcua-basic-types": "2.126.0",
-        "node-opcua-binary-stream": "2.125.0",
-        "node-opcua-factory": "2.126.0",
-        "node-opcua-types": "2.126.0"
+        "node-opcua-basic-types": "2.133.0",
+        "node-opcua-binary-stream": "2.133.0",
+        "node-opcua-factory": "2.133.0",
+        "node-opcua-types": "2.133.0"
       }
     },
     "node_modules/node-opcua-service-session": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-session/-/node-opcua-service-session-2.126.0.tgz",
-      "integrity": "sha512-CP45xifRqzflQJvvbbEcmEG+mqEMeYWvhgapOqd9d64/6QqdZIpTd0peFYlE4ikcfLzARy5XsgWpJ5YhpBo3fw==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-service-session/-/node-opcua-service-session-2.133.0.tgz",
+      "integrity": "sha512-0nS2NYI5n/n0vOJAibP/7bKkZzyJGghcOGoDhJhYQSgkPG0AdfJJgL3Af0qxcQThfB7TQWh5OgDQmgHw7Lx5vw==",
       "license": "MIT",
       "dependencies": {
-        "node-opcua-factory": "2.126.0",
-        "node-opcua-types": "2.126.0"
+        "node-opcua-factory": "2.133.0",
+        "node-opcua-types": "2.133.0"
       }
     },
     "node_modules/node-opcua-service-subscription": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-subscription/-/node-opcua-service-subscription-2.126.0.tgz",
-      "integrity": "sha512-gT3b6yuLuN/a0Bck8h/rCo2FwcCPt4cNMD3PZLstJdj/pKfxEBp+hQqFzWUlWBKAe6T+WRliw1+hWKoTjAU4qA==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-service-subscription/-/node-opcua-service-subscription-2.133.0.tgz",
+      "integrity": "sha512-I2aquyawXwklyLEJ6M8eEbWLY5G5E+6BM9BQ/ExcFtjooD0wynkS55mlpccAqxQ2YKjLPsp5DfTqUwUGpGNI4w==",
       "license": "MIT",
       "dependencies": {
         "node-opcua-assert": "2.120.0",
-        "node-opcua-types": "2.126.0",
-        "node-opcua-variant": "2.126.0"
+        "node-opcua-types": "2.133.0",
+        "node-opcua-variant": "2.133.0"
       }
     },
     "node_modules/node-opcua-service-translate-browse-path": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-translate-browse-path/-/node-opcua-service-translate-browse-path-2.126.0.tgz",
-      "integrity": "sha512-BqM1h/inI18O0vgDGKb42xMUfi5qmZg0sGdvzd4l5UKV+kFmIUJPIEji2wHIRedDkBRNQmt9KhnyngJY45nCIw==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-service-translate-browse-path/-/node-opcua-service-translate-browse-path-2.133.0.tgz",
+      "integrity": "sha512-4mdz0PStsySFLXEd/Fx+gEUxeZhrpTUA6lNqZqQl74Z4ouFyMTSZZkvxPUC50kunLvXiGnXzpjn06P/G2tLqPg==",
       "license": "MIT",
       "dependencies": {
         "node-opcua-assert": "2.120.0",
         "node-opcua-constants": "2.125.0",
-        "node-opcua-data-model": "2.126.0",
-        "node-opcua-nodeid": "2.125.0",
-        "node-opcua-types": "2.126.0"
+        "node-opcua-data-model": "2.133.0",
+        "node-opcua-nodeid": "2.133.0",
+        "node-opcua-types": "2.133.0"
       }
     },
     "node_modules/node-opcua-service-write": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-service-write/-/node-opcua-service-write-2.126.0.tgz",
-      "integrity": "sha512-xfTqTEDWkk72LRZKjZ92Fyq1bTQvPju1JTrZtPbyS+8oTPhhnZCXivr/uIo9ZVKYhqE5Vz8xIFflo/7nNFUvIQ==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-service-write/-/node-opcua-service-write-2.133.0.tgz",
+      "integrity": "sha512-jR0SYzx9l3Im67MqEJE4u12TChvH4jkQ4sY0cYZ5a6ERhq8bnRAP6in374cCffU+CGk6dryNS+/S3wUyAMGxYg==",
       "license": "MIT",
       "dependencies": {
-        "node-opcua-types": "2.126.0"
+        "node-opcua-types": "2.133.0"
       }
     },
     "node_modules/node-opcua-status-code": {
-      "version": "2.125.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-status-code/-/node-opcua-status-code-2.125.0.tgz",
-      "integrity": "sha512-d+0aFXjnwGWLUDLQpH7eJ7hsDZ/t2WJbtWpAVmC0mx8dln8Cn+PMrenOz8krUKl2qBBcWZQSDIR9Xz9k2ML3lw==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-status-code/-/node-opcua-status-code-2.133.0.tgz",
+      "integrity": "sha512-loypdDHeM6o81brZ9ALYrlm5dYOQ4rAFDLS3L9YgEhqISxf70cUFw4hgAGv36C3F8frab3nI9vJYu21i7IgF/g==",
       "license": "MIT",
       "dependencies": {
         "node-opcua-assert": "2.120.0",
-        "node-opcua-binary-stream": "2.125.0"
+        "node-opcua-binary-stream": "2.133.0"
       }
     },
     "node_modules/node-opcua-transport": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-transport/-/node-opcua-transport-2.126.0.tgz",
-      "integrity": "sha512-XVcmecp2gGqgpdF6/j24F+eSiba9pt6x5gyzfEUNlF+G40GaZoIHnXgL99mohGQemsKIuVfDE4qNMqINaxtWZA==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-transport/-/node-opcua-transport-2.133.0.tgz",
+      "integrity": "sha512-alVzSW3jVrv/rVgO8qIQuRKe5tDvyQ95TgwoxR37JRFltiNbuqqnorYQvsAG4R7u+PR6KDUj3uwl9Vwnxi0Zcg==",
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
         "node-opcua-assert": "2.120.0",
-        "node-opcua-basic-types": "2.126.0",
-        "node-opcua-binary-stream": "2.125.0",
-        "node-opcua-buffer-utils": "2.125.0",
-        "node-opcua-chunkmanager": "2.126.0",
-        "node-opcua-debug": "2.125.0",
-        "node-opcua-factory": "2.126.0",
-        "node-opcua-object-registry": "2.125.0",
-        "node-opcua-packet-assembler": "2.125.0",
-        "node-opcua-status-code": "2.125.0",
-        "node-opcua-utils": "2.125.0"
+        "node-opcua-basic-types": "2.133.0",
+        "node-opcua-binary-stream": "2.133.0",
+        "node-opcua-buffer-utils": "2.133.0",
+        "node-opcua-chunkmanager": "2.133.0",
+        "node-opcua-debug": "2.133.0",
+        "node-opcua-factory": "2.133.0",
+        "node-opcua-object-registry": "2.133.0",
+        "node-opcua-packet-assembler": "2.133.0",
+        "node-opcua-status-code": "2.133.0",
+        "node-opcua-utils": "2.133.0"
       }
     },
     "node_modules/node-opcua-types": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-types/-/node-opcua-types-2.126.0.tgz",
-      "integrity": "sha512-0oSq2VZFw8maZb5IRLK8r9Pi4KoAJ3P2vXLEErXdvXhsP+XbVptZrxojVqx1veg1xyJTOtP3L8xu+rwSUhXQ2A==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-types/-/node-opcua-types-2.133.0.tgz",
+      "integrity": "sha512-hyx1qmf1sUUM0K7Bh6/Rzsiju4FX1cT/DHU7oYaW30mObyRLpDrSGBDAC9zH537df8JDSynn88JqPaqjZtW+sg==",
       "license": "MIT",
       "dependencies": {
         "node-opcua-assert": "2.120.0",
-        "node-opcua-basic-types": "2.126.0",
-        "node-opcua-binary-stream": "2.125.0",
-        "node-opcua-data-model": "2.126.0",
-        "node-opcua-data-value": "2.126.0",
-        "node-opcua-enum": "2.125.0",
-        "node-opcua-extension-object": "2.126.0",
-        "node-opcua-factory": "2.126.0",
-        "node-opcua-generator": "2.126.0",
-        "node-opcua-nodeid": "2.125.0",
-        "node-opcua-numeric-range": "2.126.0",
-        "node-opcua-status-code": "2.125.0",
-        "node-opcua-variant": "2.126.0"
+        "node-opcua-basic-types": "2.133.0",
+        "node-opcua-binary-stream": "2.133.0",
+        "node-opcua-data-model": "2.133.0",
+        "node-opcua-data-value": "2.133.0",
+        "node-opcua-enum": "2.133.0",
+        "node-opcua-extension-object": "2.133.0",
+        "node-opcua-factory": "2.133.0",
+        "node-opcua-generator": "2.133.0",
+        "node-opcua-nodeid": "2.133.0",
+        "node-opcua-numeric-range": "2.133.0",
+        "node-opcua-status-code": "2.133.0",
+        "node-opcua-variant": "2.133.0"
       }
     },
     "node_modules/node-opcua-utils": {
-      "version": "2.125.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-utils/-/node-opcua-utils-2.125.0.tgz",
-      "integrity": "sha512-IOFQlPz9vBMPcect4CkA+apQNnfZzlGJo9unerroECNBEHkOBZ1dOluQayEQoosyVOzU/bqmJD/e1H/3RYq1pg==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-utils/-/node-opcua-utils-2.133.0.tgz",
+      "integrity": "sha512-AJT3ABOVijn8ggA3dASmg1r6vml93R7aLrBRjCHmH/HN4BCpTdZDR/vdoK+/Q9eApXlV8tRGKB01GYzDezIT5A==",
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
@@ -8001,46 +8055,46 @@
       }
     },
     "node_modules/node-opcua-variant": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-variant/-/node-opcua-variant-2.126.0.tgz",
-      "integrity": "sha512-+GT8NauBYdLpSe859UN1uMWY+uVmchEiibgcZNEuCQUoowfg51XGqr2hoj1iaWF6fNK96adLQdCWF6Na90PCEw==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-variant/-/node-opcua-variant-2.133.0.tgz",
+      "integrity": "sha512-08x5XCBiwbyPABT33EFOQTec0dkfJ4V2rjUG8Pc5dVJyjICSC2jBarypnng2MmmHjqRqCA1OMqldErQUtJ/cpg==",
       "license": "MIT",
       "dependencies": {
         "node-opcua-assert": "2.120.0",
-        "node-opcua-basic-types": "2.126.0",
-        "node-opcua-binary-stream": "2.125.0",
-        "node-opcua-data-model": "2.126.0",
-        "node-opcua-enum": "2.125.0",
-        "node-opcua-factory": "2.126.0",
-        "node-opcua-nodeid": "2.125.0",
-        "node-opcua-utils": "2.125.0"
+        "node-opcua-basic-types": "2.133.0",
+        "node-opcua-binary-stream": "2.133.0",
+        "node-opcua-data-model": "2.133.0",
+        "node-opcua-enum": "2.133.0",
+        "node-opcua-factory": "2.133.0",
+        "node-opcua-nodeid": "2.133.0",
+        "node-opcua-utils": "2.133.0"
       }
     },
     "node_modules/node-opcua-vendor-diagnostic": {
-      "version": "2.126.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-vendor-diagnostic/-/node-opcua-vendor-diagnostic-2.126.0.tgz",
-      "integrity": "sha512-jua6yUe9kp2+ssMPaQWubKgvQrnuNHXbVCfH0Usm9kJ/MOaSrzOj28riUPRRvx1KxkCGCMyvC231jc1Va8Rjwg==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-vendor-diagnostic/-/node-opcua-vendor-diagnostic-2.133.0.tgz",
+      "integrity": "sha512-tvaIFODZw4JTv94J62ZXyP7U6duZC4fgaqIZBvulZ6ScOfij2bDM7q6e+SNMeTlUD00lCjDhro728lTGaH2kVw==",
       "license": "MIT",
       "dependencies": {
         "humanize": "0.0.9",
-        "node-opcua-address-space": "2.126.0",
+        "node-opcua-address-space": "2.133.0",
         "node-opcua-assert": "2.120.0",
         "node-opcua-constants": "2.125.0",
-        "node-opcua-debug": "2.125.0",
-        "node-opcua-server": "2.126.0",
-        "node-opcua-status-code": "2.125.0",
-        "node-opcua-variant": "2.126.0"
+        "node-opcua-debug": "2.133.0",
+        "node-opcua-server": "2.133.0",
+        "node-opcua-status-code": "2.133.0",
+        "node-opcua-variant": "2.133.0"
       }
     },
     "node_modules/node-opcua-xml2json": {
-      "version": "2.125.0",
-      "resolved": "https://registry.npmjs.org/node-opcua-xml2json/-/node-opcua-xml2json-2.125.0.tgz",
-      "integrity": "sha512-bgGSZxrrBDUQSnMf7n5aggoIoMMt5oounlztp/q14L/6+FJPLFNFjwh2Vs/XI/2sV5D1V1vM4u+lPkWfxMudJA==",
+      "version": "2.133.0",
+      "resolved": "https://registry.npmjs.org/node-opcua-xml2json/-/node-opcua-xml2json-2.133.0.tgz",
+      "integrity": "sha512-2bxV3Wgn9/cGn3UCGD1bdE8WmClxjLuh05ccf4bwIt7GLn3UqYW2/a3LSm4KoE1mTf+r4q81laGDWP36lBOv8A==",
       "license": "MIT",
       "dependencies": {
         "ltx": "^3.0.0",
         "node-opcua-assert": "2.120.0",
-        "node-opcua-utils": "2.125.0",
+        "node-opcua-utils": "2.133.0",
         "thenify": "^3.3.1",
         "xml-writer": "^1.7.0"
       }
@@ -8482,13 +8536,10 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
-      "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
-      "license": "ISC",
-      "engines": {
-        "node": "14 || >=16.14"
-      }
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/path-scurry/node_modules/minipass": {
       "version": "7.1.2",
@@ -8896,12 +8947,12 @@
       }
     },
     "node_modules/pvtsutils": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.5.tgz",
-      "integrity": "sha512-ARvb14YB9Nm2Xi6nBq1ZX6dAM0FsJnuk+31aUp4TrcZEdKUlSqOqsxJHUPJDNE3qiIp+iUPEIeR6Je/tgV7zsA==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
       "license": "MIT",
       "dependencies": {
-        "tslib": "^2.6.1"
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/pvutils": {
@@ -9247,9 +9298,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -10088,9 +10139,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
     "node_modules/tsyringe": {
@@ -10441,16 +10492,16 @@
       }
     },
     "node_modules/webcrypto-core": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.8.0.tgz",
-      "integrity": "sha512-kR1UQNH8MD42CYuLzvibfakG5Ew5seG85dMMoAM/1LqvckxaF6pUiidLuraIu4V+YCIFabYecUZAW0TuxAoaqw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.8.1.tgz",
+      "integrity": "sha512-P+x1MvlNCXlKbLSOY4cYrdreqPG5hbzkmawbcXLKN/mf6DZW0SdNNkZ+sjwsqVkI4A4Ko2sPZmkZtCKY58w83A==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/asn1-schema": "^2.3.13",
         "@peculiar/json-schema": "^1.1.12",
-        "asn1js": "^3.0.1",
+        "asn1js": "^3.0.5",
         "pvtsutils": "^1.3.5",
-        "tslib": "^2.6.2"
+        "tslib": "^2.7.0"
       }
     },
     "node_modules/webidl-conversions": {
@@ -10765,9 +10816,9 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.1.3.tgz",
-      "integrity": "sha512-JCCdmlJJWv7L0q/KylOekyRaUrdEoUxWkWVcgorosTROCFWiS9p2NNPE9Yb91ak7b1N5SxAZEliWpspbZccivw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.0.tgz",
+      "integrity": "sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==",
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",

--- a/acs-edge/package.json
+++ b/acs-edge/package.json
@@ -46,7 +46,7 @@
     "jsonpath-plus": "^5.0.7",
     "jsonpointer": "^5.0.1",
     "long": "4.0.0",
-    "node-opcua": "^2.103.0",
+    "node-opcua": "2.133.0",
     "st-ethernet-ip": "^2.7.1",
     "ts-node-dev": "^1.1.8",
     "uuid": "^9.0.0",


### PR DESCRIPTION
After quite comprehensive testing, I've discovered that the issue [preventing the `acs-edge` from building](https://github.com/AMRC-FactoryPlus/amrc-connectivity-stack/actions/runs/11775006916/job/32794900849) is the `node-opcua` package.

This module seems to depend on [node-opcua-crypto](https://github.com/node-opcua/node-opcua-crypto) package which had a breaking change to its exports in [`v4.11.0`](https://github.com/node-opcua/node-opcua-crypto/releases/tag/v4.11.0).

This seems to have effected the following modules:

* `node-opcua-address-space-base`
* `node-opcua-address-space`
* `node-opcua-certificate-manager`
* `node-opcua-client`
* `node-opcua-common`
* `node-opcua-secure-channel`
* `node-opcua-server`
* `node-opcua-crypto`

All of which the node-opcua package depends on.

The last working version of this package seems to be `2.133.0` therefore I have pinned in to that until the upstream issue is resolved.

I have created an issue on the libs repo (https://github.com/node-opcua/node-opcua-crypto/issues/61) relating to this.