### PR TITLE
Create an edge MQTT broker helm chart

### DIFF
--- a/acs-service-setup/dumps/helm.yaml
+++ b/acs-service-setup/dumps/helm.yaml
@@ -2,6 +2,7 @@ service: !u UUIDs.Service.ConfigDB
 version: 1
 classes:
   - !u Clusters.Class.HelmChart
+  - !u ACS.Class.EdgeDeployment
 objects:
   !u UUIDs.Class.App:
     - !u Clusters.App.HelmRelease
@@ -11,6 +12,7 @@ objects:
 configs:
   !u UUIDs.App.Info:
     !u Clusters.Class.HelmChart:    { name: "Helm chart" }
+    !u Clusters.Class.EdgeDeployment: { name: "Edge deployment" }
     !u Clusters.App.HelmRelease:    { name: "HelmRelease template" }
     !u Clusters.App.HelmTemplate:   { name: "Helm chart template" }
   !u UUIDs.App.ConfigSchema:

--- a/acs-service-setup/lib/helm.js
+++ b/acs-service-setup/lib/helm.js
@@ -136,6 +136,13 @@ export async function setup_helm (ss) {
                 uuid:       "{{uuid}}",
                 hostname:   "{{hostname}}",
         } }],
+        ["mqtt", "Edge MQTT broker", {
+            chart:  "mqtt-broker",
+            values: {
+                name:       "{{name}}",
+                uuid:       "{{uuid}}",
+                hostname:   "{{hostname}}",
+        } }],
     );
 
     return await conf.finish();

--- a/acs-service-setup/lib/uuids.js
+++ b/acs-service-setup/lib/uuids.js
@@ -11,6 +11,7 @@ export const ACS = {
         Permission:         "8ae784bb-c4b5-4995-9bf6-799b3c7f21ad",
         UserAccount:        "8b3e8f35-78e5-4f93-bf21-7238bcb2ba9d",
         UserGroup:          "f1fabdd1-de90-4399-b3da-ccf6c2b2c08b",
+        EdgeDeployment:     "e6f6a6e6-f6b2-422a-bc86-2dcb417a362a",
     },
     App: {
         SchemaIcon:         "65c0ccba-151d-48d3-97b4-d0026a811900",

--- a/edge-helm-charts/charts/mqtt-broker/Chart.yaml
+++ b/edge-helm-charts/charts/mqtt-broker/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: mqtt-broker
+version: "0.0.1"
+description: "ACS edge MQTT broker"

--- a/edge-helm-charts/charts/mqtt-broker/templates/_helpers.tpl
+++ b/edge-helm-charts/charts/mqtt-broker/templates/_helpers.tpl
@@ -1,0 +1,12 @@
+{{- define "acs.image" -}}
+{{- $root := index . 0 -}}
+{{- $key := index . 1 -}}
+{{- $image := $root.Values.image -}}
+{{- $spec := merge (get $image $key) $image.default -}}
+image: "{{ $spec.registry }}/{{ $spec.repository }}:{{ $spec.tag }}"
+imagePullPolicy: {{ $spec.pullPolicy }}
+{{- end }}
+
+{{- define "acs.k8sname" }}
+{{- .Values.name | lower | replace "_" "-" }}
+{{- end }}

--- a/edge-helm-charts/charts/mqtt-broker/templates/mqtt-broker.yaml
+++ b/edge-helm-charts/charts/mqtt-broker/templates/mqtt-broker.yaml
@@ -1,0 +1,52 @@
+{{- $k8sname := include "acs.k8sname" . }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}-{{ $k8sname }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    factory-plus.app: {{ .Chart.Name }}
+    factory-plus.uuid: {{ .Values.uuid }}
+    factory-plus.name: {{ .Values.name }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      factory-plus.app: {{ .Chart.Name }}
+      factory-plus.uuid: {{ .Values.uuid }}
+  template:
+    metadata:
+      labels:
+        factory-plus.app: {{ .Chart.Name }}
+        factory-plus.uuid: {{ .Values.uuid }}
+        factory-plus.name: {{ .Values.name }}
+    spec:
+{{ if .Values.hostname }}
+      nodeSelector:
+        kubernetes.io/hostname: {{ .Values.hostname | quote }}
+      tolerations: {{ .Values.tolerations.specific | toYaml | nindent 8 }}
+{{ else }}
+      tolerations: {{ .Values.tolerations.floating | toYaml | nindent 8 }}
+{{ end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ .Chart.Name }}-{{ $k8sname }} 
+      containers:
+        - name: mqtt-broker
+{{ list . "mosquitto" | include "acs.image" | indent 10 }}
+          volumeMounts:
+            - mountPath: /mosquitto/config
+              name: config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Chart.Name }}-{{ $k8sname }}
+data:
+  mosquitto.conf: |
+    listener 1883
+    allow_anonymous true

--- a/edge-helm-charts/charts/mqtt-broker/templates/service.yaml
+++ b/edge-helm-charts/charts/mqtt-broker/templates/service.yaml
@@ -1,0 +1,18 @@
+{{- $k8sname := include "acs.k8sname" . }}
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Chart.Name }}-{{ $k8sname }}
+spec:
+  selector:
+    factory-plus.app: {{ .Chart.Name }}
+    factory-plus.uuid: {{ .Values.uuid }}
+{{- with .Values.expose }}
+  internalTrafficPolicy: {{ .internalTrafficPolicy }}
+  ports:
+    - name: mqtt
+      port: {{ .port }}
+      targetPort: 1883
+  externalIPs: {{ .externalIPs }}
+{{- end }}

--- a/edge-helm-charts/charts/mqtt-broker/values.yaml
+++ b/edge-helm-charts/charts/mqtt-broker/values.yaml
@@ -1,0 +1,27 @@
+# This is required
+# uuid: 12345
+# This deploys to a specific host
+#hostname: foo
+image:
+  default:
+    pullPolicy: IfNotPresent
+  mosquitto:
+    registry: docker.io
+    repository: eclipse-mosquitto
+    tag: "2.0"
+tolerations:
+  # Tolerations to apply to pods deployed to a specific host
+  specific:
+    - key: factoryplus.app.amrc.co.uk/specialised
+      operator: Exists
+  # Tolerations to apply to floating pods
+  floating: []
+# Whether to expose the broker externally
+expose:
+  # Expose on an existing external IP
+  externalIPs: []
+  # Port to expose on
+  port: 1883
+  # How to route cluster-internal traffic. Setting this to Local will
+  # prevent pods on different nodes from contacting the service.
+  internalTrafficPolicy: Local


### PR DESCRIPTION
Create a new edge helm chart which deploys an MQTT broker. This broker is exposed to the cluster as service; the chart also provides the option to expose it on an external IP.

No security is currently implemented, beyond a default of `internalTrafficPolicy: Local` which should prevent off-node pods from contacting the broker but is not intended as a security feature.