### PR TITLE
Support dark mode on the admin interface

### DIFF
--- a/acs-admin/src/App.vue
+++ b/acs-admin/src/App.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="grid h-screen overflow-auto w-full"
-      :class="!l.fullscreen ? 'md:grid-cols-[220px_1fr] lg:grid-cols-[280px_1fr]' : 'grid-cols-1'">
-    <div v-if="!l.fullscreen" class="hidden border-r bg-muted/40 md:block">
+  <div class="grid h-screen overflow-auto w-full dark:bg-slate-950 dark:text-slate-50"
+       :class="!l.fullscreen ? 'md:grid-cols-[220px_1fr] lg:grid-cols-[280px_1fr]' : 'grid-cols-1'">
+    <div id="sidebar" v-if="!l.fullscreen" class="hidden border-r dark:border-slate-800 bg-muted/40 md:block">
       <div class="flex h-full max-h-screen flex-col">
-        <div class="flex h-14 items-center border-b px-4 lg:h-[60px] lg:px-6">
+        <div class="flex h-14 items-center justify-between border-b dark:border-slate-800 px-4 lg:h-[60px] lg:px-6">
           <a href="/" class="flex items-center gap-2 font-semibold">
-            <img class="size-4" src="/favicon.svg">
+            <img class="size-4 dark:invert" src="/favicon.svg">
             <span class="">ACS</span>
           </a>
         </div>
@@ -13,7 +13,7 @@
           <Nav/>
         </div>
         <div class="mt-auto p-4">
-          <Card>
+          <Card class="dark:bg-slate-900">
             <CardHeader class="p-2 pt-0 md:p-4">
               <CardTitle>Factory+</CardTitle>
               <CardDescription>
@@ -34,7 +34,7 @@
     </div>
     <div class="flex flex-col overflow-auto">
       <header v-if="!l.fullscreen"
-          class="flex justify-between items-center border-b px-4 lg:h-[60px] flex-shrink-0 lg:px-6">
+          class="flex justify-between items-center border-b dark:border-slate-800 px-4 lg:h-[60px] flex-shrink-0 lg:px-6">
         <div class="flex items-center justify-center gap-2">
           <i :class="`fa-solid fa-${$route.meta.icon}`"></i>
           <h3 class="text-lg font-bold tracking-tight">{{$route.meta.name}}</h3>

--- a/acs-admin/src/components/ui/card/Card.vue
+++ b/acs-admin/src/components/ui/card/Card.vue
@@ -10,7 +10,7 @@ const props = defineProps({
   <div
     :class="
       cn(
-        'rounded-lg border border-slate-200 bg-white text-slate-950 shadow-sm dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50',
+        'rounded-lg border border-slate-200 bg-white text-slate-950 shadow-sm dark:border-slate-800 dark:text-slate-50',
         props.class
       )
     "

--- a/acs-admin/src/components/ui/table/TableBody.vue
+++ b/acs-admin/src/components/ui/table/TableBody.vue
@@ -7,7 +7,7 @@ const props = defineProps({
 </script>
 
 <template>
-  <tbody :class="cn('[&_tr:last-child]:border-0', props.class)">
+  <tbody :class="cn('[&_tr:last-child]:border-0 dark:border-slate-800', props.class)">
     <slot />
   </tbody>
 </template>

--- a/acs-admin/src/components/ui/table/TableFooter.vue
+++ b/acs-admin/src/components/ui/table/TableFooter.vue
@@ -10,7 +10,7 @@ const props = defineProps({
   <tfoot
     :class="
       cn(
-        'border-t bg-slate-100/50 font-medium [&>tr]:last:border-b-0 dark:bg-slate-800/50',
+        'border-t dark:border-slate-800 bg-slate-100/50 font-medium [&>tr]:last:border-b-0 dark:bg-slate-800/50',
         props.class
       )
     "

--- a/acs-admin/src/components/ui/table/TableHeader.vue
+++ b/acs-admin/src/components/ui/table/TableHeader.vue
@@ -7,7 +7,7 @@ const props = defineProps({
 </script>
 
 <template>
-  <thead :class="cn('[&_tr]:border-b', props.class)">
+  <thead :class="cn('[&_tr]:border-b dark:border-slate-800', props.class)">
     <slot />
   </thead>
 </template>

--- a/acs-admin/src/components/ui/table/TableRow.vue
+++ b/acs-admin/src/components/ui/table/TableRow.vue
@@ -10,7 +10,7 @@ const props = defineProps({
   <tr
     :class="
       cn(
-        'border-b transition-colors hover:bg-slate-100/50 data-[state=selected]:bg-slate-100 dark:hover:bg-slate-800/50 dark:data-[state=selected]:bg-slate-800',
+        'border-b dark:border-slate-800 transition-colors hover:bg-slate-100/50 data-[state=selected]:bg-slate-100 dark:hover:bg-slate-800/50 dark:data-[state=selected]:bg-slate-800',
         props.class
       )
     "

--- a/acs-admin/src/pages/Activity.vue
+++ b/acs-admin/src/pages/Activity.vue
@@ -2,7 +2,7 @@
   <div class="flex flex-col flex-1">
     <div v-if="s.loaded && connected" id="app"
         class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 w-full gap-1 p-1 line">
-      <div class="rounded-lg" :key="topic.path" :ref="topic.path" v-for="topic in topics">
+      <div class="rounded-lg dark:bg-slate-900" :key="topic.path" :ref="topic.path" v-for="topic in topics">
         <Card class="bg-transparent">
           <CardHeader class="flex flex-row items-center justify-between space-y-0 !pb-0">
             <CardTitle class="text-sm font-medium">
@@ -166,18 +166,18 @@ export default {
           if (this.flashTimeouts[path]) {
             clearTimeout(this.flashTimeouts[path])
             if (this.$refs[path] && this.$refs[path][0]) {
-              this.$refs[path][0].classList.remove('bg-gray-200');
+              this.$refs[path][0].classList.remove('!bg-gray-200', 'dark:!bg-slate-800');
             }
           }
 
           // Apply flash effect and set a new timeout
           if (this.$refs[path] && this.$refs[path][0]) {
-            this.$refs[path][0].classList.add('bg-gray-200');
+            this.$refs[path][0].classList.add('!bg-gray-200', 'dark:!bg-slate-800');
             this.flashTimeouts[path] = setTimeout(() => {
-              this.$refs[path][0].classList.remove('bg-gray-200');
+              this.$refs[path][0].classList.remove('!bg-gray-200', 'dark:!bg-slate-800');
               // Clean up after the timeout executes
               delete this.flashTimeouts[path]
-            }, 200)
+            }, 150)
           }
         }
         else {

--- a/acs-admin/src/pages/Alerts/DataTable.vue
+++ b/acs-admin/src/pages/Alerts/DataTable.vue
@@ -71,7 +71,7 @@ const table = useVueTable({
 <template>
   <div class="space-y-4">
     <DataTableToolbar v-if="!l.fullscreen" :table="table"/>
-    <div class="rounded-md border">
+    <div class="rounded-md border dark:border-slate-800">
       <Table>
         <TableHeader>
           <TableRow v-for="headerGroup in table.getHeaderGroups()" :key="headerGroup.id">

--- a/acs-admin/src/pages/Alerts/DataTableFacetedFilter.vue
+++ b/acs-admin/src/pages/Alerts/DataTableFacetedFilter.vue
@@ -34,8 +34,8 @@ const selectedValues = computed(() => new Set(props.column?.getFilterValue() as 
 <template>
   <Popover>
     <PopoverTrigger as-child>
-      <Button variant="outline" size="sm" class="h-8 border-dashed flex items-center justify-center gap-1.5">
-        <i class="fa-solid fa-filter text-gray-900"></i>
+      <Button variant="outline" size="sm" class="h-8 border-dashed flex items-center justify-center gap-1.5 dark:text-slate-50 dark:bg-slate-800">
+        <i class="fa-solid fa-filter"></i>
         {{ title }}
         <template v-if="selectedValues.size > 0">
           <Separator orientation="vertical" class="mx-2 h-4" />

--- a/acs-admin/src/pages/Alerts/DataTableViewOptions.vue
+++ b/acs-admin/src/pages/Alerts/DataTableViewOptions.vue
@@ -32,7 +32,7 @@ const columns = computed(() => props.table.getAllColumns()
       <Button
         variant="outline"
         size="sm"
-        class="ml-auto hidden h-8 lg:flex items-center justify-center gap-1.5"
+        class="ml-auto hidden h-8 lg:flex items-center justify-center gap-1.5 dark:text-slate-50 dark:bg-slate-800"
       >
         <i class="fa-solid fa-sliders"></i>
         View

--- a/acs-admin/src/pages/Home.vue
+++ b/acs-admin/src/pages/Home.vue
@@ -1,6 +1,6 @@
 <template>
     <div v-if="s.loaded" class="flex flex-col gap-4">
-      <Card>
+      <Card class="dark:bg-slate-900">
         <CardHeader class="pb-2">
           <CardDescription>MQTT Server</CardDescription>
           <CardTitle class="text-4xl hover:underline hover:cursor-pointer flex items-center gap-2 group" @click="copy">
@@ -18,7 +18,7 @@
         </CardContent>
       </Card>
       <div class="grid gap-4 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-2 xl:grid-cols-4">
-        <Card class="sm:col-span-2">
+        <Card class="sm:col-span-2 dark:bg-slate-900">
           <CardHeader class="pb-3">
             <CardTitle>Graph</CardTitle>
             <CardDescription class="max-w-lg text-balance leading-relaxed">
@@ -31,7 +31,7 @@
             </Button>
           </CardFooter>
         </Card>
-        <Card class="sm:col-span-2">
+        <Card class="sm:col-span-2 dark:bg-slate-900">
           <CardHeader class="pb-3">
             <CardTitle>Activity</CardTitle>
             <CardDescription class="max-w-lg text-balance leading-relaxed">


### PR DESCRIPTION
Previously only half the interface would "support" dark mode (some elements would go dark and the text would be unreadable). Now, an optional dark mode has been applied across the admin interface, which is enabled based upon your system setting. This is how it was already half-implemented by the component library.

Before:
![image](https://github.com/user-attachments/assets/2f7ee138-24a9-487e-90a2-7338d0bdb944)

After:
![image](https://github.com/user-attachments/assets/62270c63-56f3-48cf-a9f2-51d249e3a1fd)

## How to Test

1. `bun dev`
2. Open the admin interface http://localhost:5173/#/
3. Navigate through pages and see the standard light theme.
4. Change your OS theme to dark. This seems to be different to the browser setting (which doesn't change websites, just the browser UI like tabs and menus).
5. The admin interface should update with a dark theme when the OS theme changes. Navigate through the pages to evaluate the dark mode.