### PR TITLE
Fix undefined path check for edge agent

### DIFF
--- a/acs-edge/lib/devices/MQTT.ts
+++ b/acs-edge/lib/devices/MQTT.ts
@@ -1,11 +1,9 @@
 /*
- *  Factory+ / AMRC Connectivity Stack (ACS) Edge component
- *  Copyright 2023 AMRC
+ * Copyright (c) University of Sheffield AMRC 2025.
  */
 
-import {Device, DeviceConnection, deviceOptions} from "../device.js";
+import {DeviceConnection} from "../device.js";
 import {log} from "../helpers/log.js";
-import {SparkplugNode} from "../sparkplugNode.js";
 import {Metrics, writeValuesToPayload} from "../helpers/typeHandler.js";
 import * as mqtt from "mqtt";
 import {v4 as uuidv4} from 'uuid';

--- a/acs-edge/lib/helpers/typeHandler.ts
+++ b/acs-edge/lib/helpers/typeHandler.ts
@@ -1,6 +1,5 @@
 /*
- *  Factory+ / AMRC Connectivity Stack (ACS) Edge component
- *  Copyright 2023 AMRC
+ * Copyright (c) University of Sheffield AMRC 2025.
  */
 
 import {JSONPath} from "jsonpath-plus";
@@ -365,9 +364,11 @@ export function parseValueFromPayload(msg: any, metric: sparkplugMetric, payload
                 .split(delimiter) : msg.toString();
 
             // Handle no path parsing
-            let newVal = (path != '') ? payload[path] : payload;
-
-            return parseTypeFromString(metric.type, newVal);
+            if (path == null || path == '') {
+                return parseTypeFromString(metric.type, payload);
+            } else {
+                return parseTypeFromString(metric.type, payload[path]);
+            }
         case serialisationType.JSON:
             try { // Handles error if invalid JSON is sent in
                 if (typeof msg == "string") {


### PR DESCRIPTION
This commit makes the edge agent check for null and undefined paths. Previously, it only checked `''`, which didn't work because the manager keeps them as undefined by default.