### PR TITLE
Build python-kadmv correctly

### DIFF
--- a/acs-krb-keys-operator/Dockerfile
+++ b/acs-krb-keys-operator/Dockerfile
@@ -4,13 +4,16 @@ FROM alpine AS build
 
 ARG kubeseal_ver=0.19.5
 
+COPY ./python-kadmv /tmp/python-kadmv
+
+
 RUN /bin/sh <<SHELL
-    apk add curl python3 py3-pip python3-dev gcc musl-dev krb5 krb5-dev
+    apk add bison curl python3 py3-pip python3-dev gcc musl-dev krb5 krb5-dev
 
     pip install -t /usr/local/python krb5 kubernetes kopf \
         "optional.py<2.0" \
         requests requests-cache requests-kerberos
-    pip install -t /usr/local/python ./python-kadmv
+    pip install -t /usr/local/python /tmp/python-kadmv
 
     curl -L https://github.com/bitnami-labs/sealed-secrets/releases/download/v${kubeseal_ver}/kubeseal-${kubeseal_ver}-linux-amd64.tar.gz \
         | tar -xzvf - -C /usr/local/bin kubeseal


### PR DESCRIPTION
The source must be copied into the build.