### PR TITLE
Fix finalizers preventing namespace deletion

### DIFF
--- a/deploy/templates/hooks/post-delete.yaml
+++ b/deploy/templates/hooks/post-delete.yaml
@@ -1,0 +1,71 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: post-delete-cleanup
+  annotations:
+    "helm.sh/hook": post-delete
+spec:
+  ttlSecondsAfterFinished: 30
+  template:
+    spec:
+      serviceAccountName: {{ .Release.Namespace }}-cleanup
+      containers:
+        - name: script-runner
+          image: bitnami/kubectl:latest
+          command:
+            - /bin/sh
+            - -c
+            - |
+              # Your shell script starts here
+              echo "Starting cleanup..."
+              for i in $(kubectl -n {{ .Release.Namespace }} get kerberos-keys -o name); do kubectl -n {{ .Release.Namespace }} patch $i --type=json -p='[{"op": "remove", "path": "/metadata/finalizers"}]'; done
+              echo "Cleanup complete!"
+      restartPolicy: Never
+  backoffLimit: 3
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Namespace }}-cleanup
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-delete,post-delete
+    "helm.sh/hook-delete-policy": before-hook-creation
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Namespace }}-cleanup-role
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-delete,post-delete
+    "helm.sh/hook-delete-policy": before-hook-creation
+
+rules:
+  - apiGroups: [ "factoryplus.app.amrc.co.uk" ]
+    resources: [ "kerberos-keys" ]
+    verbs: [ "get", "list", "patch" ] # Specify only necessary actions
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Namespace }}-cleanup-binding
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-delete,post-delete
+    "helm.sh/hook-delete-policy": before-hook-creation
+
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Namespace }}-cleanup
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Release.Namespace }}-cleanup-role
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/templates/hooks/post-delete.yaml
+++ b/deploy/templates/hooks/post-delete.yaml
@@ -16,7 +16,6 @@ spec:
             - /bin/sh
             - -c
             - |
-              # Your shell script starts here
               echo "Starting cleanup..."
               for i in $(kubectl -n {{ .Release.Namespace }} get kerberos-keys -o name); do kubectl -n {{ .Release.Namespace }} patch $i --type=json -p='[{"op": "remove", "path": "/metadata/finalizers"}]'; done
               echo "Cleanup complete!"
@@ -59,7 +58,6 @@ metadata:
   annotations:
     "helm.sh/hook": pre-delete,post-delete
     "helm.sh/hook-delete-policy": before-hook-creation
-
 subjects:
   - kind: ServiceAccount
     name: post-delete-cleanup

--- a/deploy/templates/hooks/post-delete.yaml
+++ b/deploy/templates/hooks/post-delete.yaml
@@ -8,7 +8,7 @@ spec:
   ttlSecondsAfterFinished: 30
   template:
     spec:
-      serviceAccountName: {{ .Release.Namespace }}-cleanup
+      serviceAccountName: post-delete-cleanup
       containers:
         - name: script-runner
           image: bitnami/kubectl:latest
@@ -28,7 +28,7 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Namespace }}-cleanup
+  name: post-delete-cleanup
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-delete,post-delete
@@ -39,12 +39,11 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Release.Namespace }}-cleanup-role
+  name: post-delete-cleanup-role
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-delete,post-delete
     "helm.sh/hook-delete-policy": before-hook-creation
-
 rules:
   - apiGroups: [ "factoryplus.app.amrc.co.uk" ]
     resources: [ "kerberos-keys" ]
@@ -55,7 +54,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Release.Namespace }}-cleanup-binding
+  name: post-delete-cleanup-binding
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-delete,post-delete
@@ -63,9 +62,9 @@ metadata:
 
 subjects:
   - kind: ServiceAccount
-    name: {{ .Release.Namespace }}-cleanup
+    name: post-delete-cleanup
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: {{ .Release.Namespace }}-cleanup-role
+  name: post-delete-cleanup-role
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Finalizers on custom resource definitions cause both the factory-plus namespace to be stuck in a terminating state. The added job runs on the helm post delete hook and patches the Kerberos Key to remove the finalizers. 
- [x] Fix factory-plus namespace deletion.

## How to test 
1. Run `Helm uninstall acs -n factory-plus`.
2. Wait for the job to complete.
3. Run `kubectl delete namesapce factory-plus` to delete the factory-plus namespace.
4. The namespace should delete and not be stuck in a terminating state. 