### PR TITLE
Add MQTT restart container

### DIFF
--- a/deploy/templates/service-setup.yaml
+++ b/deploy/templates/service-setup.yaml
@@ -9,6 +9,7 @@ metadata:
   name: service-setup-{{ randAlphaNum 8 | lower }}
 spec:
   ttlSecondsAfterFinished: 300
+  backoffLimit: 8
   template:
     spec:
       serviceAccountName: service-setup

--- a/deploy/templates/service-setup.yaml
+++ b/deploy/templates/service-setup.yaml
@@ -11,10 +11,11 @@ spec:
   ttlSecondsAfterFinished: 300
   template:
     spec:
+      serviceAccountName: service-setup
       restartPolicy: OnFailure
       volumes:
         - name: git-checkouts
-          emptyDir:
+          emptyDir: { }
       initContainers:
         - name: service-setup
 {{ include "amrc-connectivity-stack.image" (list . .Values.serviceSetup) | indent 10 }}
@@ -67,4 +68,48 @@ spec:
         # We need a do-nothing container to keep k8s happy
         - name: done
 {{ include "amrc-connectivity-stack.image" (list . .Values.shell) | indent 10 }}
-          command: ["/bin/true"]
+          command: [ "/bin/true" ]
+        - name: restart-mqtt
+          image: bitnami/kubectl:latest
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Restarting MQTT..."
+              kubectl rollout restart deployment mqtt -n factory-plus
+              echo "Complete!"
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: service-setup
+  namespace: {{ .Release.Namespace }}
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: service-setup-role
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [ "apps" ]
+    resources: [ "deployments" ]
+    verbs: [ "get", "patch", "update" ]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: service-setup-binding
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: service-setup
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: service-setup-role
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/templates/service-setup.yaml
+++ b/deploy/templates/service-setup.yaml
@@ -65,10 +65,6 @@ spec:
             - name: GIT_REPO_PATH
               value: {{ .Values.edgeHelm.repoPath }}
       containers:
-        # We need a do-nothing container to keep k8s happy
-        - name: done
-{{ include "amrc-connectivity-stack.image" (list . .Values.shell) | indent 10 }}
-          command: [ "/bin/true" ]
         - name: restart-mqtt
           image: bitnami/kubectl:latest
           command:


### PR DESCRIPTION
After the init containers have finished MQTT needs to be restarted for the ACL changes to pull through. The added restart container restarts the MQTT deployment to fix this issue.

## How to test
1. Create the factory-plus namespace and helm install acs.
2. All acs services should finish in a healthy state, mqtt shouldn't need to be restated. 