### PR TITLE
Fix service-setup circular dependency

### DIFF
--- a/deploy/templates/service-setup.yaml
+++ b/deploy/templates/service-setup.yaml
@@ -5,9 +5,8 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: service-setup
-  annotations:
-    helm.sh/hook: post-install, post-upgrade
+  # Give the job a random id so helm reruns it on helm upgrade.
+  name: service-setup-{{ randAlphaNum 8 | lower }}
 spec:
   ttlSecondsAfterFinished: 300
   template:


### PR DESCRIPTION
Service setup previously run on helm post-install but services dependant on it would never run. This is fixed by removing the hook annotation and naming the job with a random string. The job runs on helm install and will run again on helm upgrade, terminating any previous running instance of the job.

## How to test
1. Change /deploy/service-setup.yaml line 70 to command: `["/bin/sleep 1000"]` (this prevents the job from completing to test the job termination on helm upgrade).
2. Run:
`helm install acs <local repo path>/amrc-connectivity-stack/deploy --version 3.4.2 -f values.yaml --namespace factory-plus --wait --timeout 30m`
3. Wait for all service to be running and service-setup init containers to complete. 
4. Run:
`helm upgrade acs <local repo path>/amrc-connectivity-stack/deploy --version 3.4.2 -f values.yaml --namespace factory-plus --wait --timeout 30m`
5. Ensure the initial service setup job terminates after the new job starts. 