### PR TITLE
Start the v2 API

### DIFF
--- a/acs-auth/.gitignore
+++ b/acs-auth/.gitignore
@@ -16,6 +16,9 @@ lib/git-version.js
 
 /tmp/
 
+# Generated files
+lib/git-version.js
+
 # IDE
 .idea/
 /node_modules/

--- a/acs-auth/bin/authn.js
+++ b/acs-auth/bin/authn.js
@@ -10,6 +10,7 @@ import { RxClient } from "@amrc-factoryplus/rx-client";
 import { WebAPI } from "@amrc-factoryplus/service-api";
 import { UUIDs } from "@amrc-factoryplus/service-client";
 
+import { APIv2 } from "../lib/api_v2.js";
 import AuthN from "../lib/authn.js";
 import AuthZ from "../lib/authz.js";
 import { DataFlow } from "../lib/dataflow.js";
@@ -32,7 +33,8 @@ const model  = await new Model({
 const data = new DataFlow({ fplus, model });
 
 const authn = await new AuthN({ }).init();
-const authz = await new AuthZ({ model });
+const authz = await new AuthZ({ debug, model });
+const apiv2 = new APIv2({ data, debug, model });
 
 const editor = await new Editor({
     services: {
@@ -61,6 +63,7 @@ const api = await new WebAPI({
     routes: app => {
         app.use("/authn", authn.routes);
         app.use("/authz", authz.routes);
+        app.use("/v2", apiv2.routes);
         app.use("/editor", editor.routes);
     },
 }).init();

--- a/acs-auth/bin/authn.js
+++ b/acs-auth/bin/authn.js
@@ -6,11 +6,14 @@
  * Copyright 2022 AMRC
  */
 
+import { RxClient } from "@amrc-factoryplus/rx-client";
 import { WebAPI } from "@amrc-factoryplus/service-api";
-import { Debug, UUIDs } from "@amrc-factoryplus/service-client";
+import { UUIDs } from "@amrc-factoryplus/service-client";
 
 import AuthN from "../lib/authn.js";
 import AuthZ from "../lib/authz.js";
+import { DataFlow } from "../lib/dataflow.js";
+import Model from "../lib/model.js";
 import Editor from "../lib/editor.js";
 
 import { GIT_VERSION } from "../lib/git-version.js";
@@ -18,14 +21,18 @@ import { GIT_VERSION } from "../lib/git-version.js";
 /* This is the F+ service spec version */
 const Version = "2.0.0";
 
-const debug = new Debug({ verbose: process.env.VERBOSE });
+const fplus = new RxClient({ env: process.env });
+const debug = fplus.debug;
 
-const authn = await new AuthN({ }).init();
-const authz = await new AuthZ({
+const model  = await new Model({
     debug,
     acl_cache:          process.env.ACL_CACHE ?? 5,
     root_principal:     process.env.ROOT_PRINCIPAL,
 }).init();
+const data = new DataFlow({ fplus, model });
+
+const authn = await new AuthN({ }).init();
+const authz = await new AuthZ({ model });
 
 const editor = await new Editor({
     services: {
@@ -58,4 +65,5 @@ const api = await new WebAPI({
     },
 }).init();
     
+data.run();
 api.run();

--- a/acs-auth/editor/editor.js
+++ b/acs-auth/editor/editor.js
@@ -230,12 +230,13 @@ function ACEs (props) {
 
     return html`
         <table>
-            <tr><th>Principal</th><th>Permission</th><th>Target</th></tr>
+            <tr><th>Principal</th><th>Permission</th><th>Target</th><th>Plural</th></tr>
             ${ aces.map(a => html`
             <tr key=${`${a.principal}/${a.permission}/${a.target}`}>
                 <td><${Obj} obj=${a.principal}/></td>
                 <td><${Obj} obj=${a.permission}/></td>
                 <td><${Obj} obj=${a.target}/></td>
+                <td>${ a.plural ? "🗸" : "🗴" }</td>
                 <td><button onClick=${() => del_ace(a)}>Delete ACE</button></td>
             </tr>
             `) }

--- a/acs-auth/lib/api_v2.js
+++ b/acs-auth/lib/api_v2.js
@@ -15,9 +15,10 @@ import { booleans, valid_krb, valid_uuid } from "./validate.js";
 
 export class APIv2 {
     constructor(opts) {
-        this.debug  = opts.debug;
         this.model = opts.model;
         this.data = opts.data;
+
+        this.log = opts.debug.bound("apiv2");
 
         this.routes = this.setup_routes();
     }
@@ -34,8 +35,10 @@ export class APIv2 {
         /* XXX No auth for now */
         const { principal } = req.params;
 
+        this.log("Fetching ACL for %s", principal);
         const acl = await rx.firstValueFrom(
             this.data.acl_for(principal));
+        this.log("Got ACL for %s", principal);
 
         if (!acl) return res.status(404).end();
         return res.status(200).json(acl);

--- a/acs-auth/lib/api_v2.js
+++ b/acs-auth/lib/api_v2.js
@@ -5,6 +5,7 @@
  */
 
 import express from "express";
+import * as imm from "immutable";
 import * as rx from "rxjs";
 
 import { UUIDs } from "@amrc-factoryplus/service-client";
@@ -12,6 +13,10 @@ import { UUIDs } from "@amrc-factoryplus/service-client";
 import Model from "./model.js";
 import {Perm} from "./uuids.js";
 import { booleans, valid_krb, valid_uuid } from "./validate.js";
+
+function fail (status) {
+    throw { status };
+}
 
 export class APIv2 {
     constructor(opts) {
@@ -31,16 +36,40 @@ export class APIv2 {
         return api;
     }
 
-    async get_acl (req, res) {
-        /* XXX No auth for now */
-        const { principal } = req.params;
-
-        this.log("Fetching ACL for %s", principal);
-        const acl = await rx.firstValueFrom(
+    async fetch_acl (principal) {
+        const acl = rx.firstValueFrom(
             this.data.acl_for(principal));
-        this.log("Got ACL for %s", principal);
+        this.log("Fetched ACL for %s: %o", principal, acl);
+        return acl;
+    }
 
-        if (!acl) return res.status(404).end();
-        return res.status(200).json(acl);
+    async check_acl (krb, perm, targ, wild) {
+        const princ = await this.model.principal_find_by_krb(krb);
+        if (!princ) fail(403);
+
+        const acl = await this.fetch_acl(princ);
+        throw "incomplete";
+    }
+
+    async get_acl (req, res) {
+        const { principal } = req.params;
+        if (!valid_uuid(principal)) fail(410);
+
+        const acl = await this.fetch_acl(principal);
+        if (!acl) fail(404);
+
+        const permitted = await this.model.principal_find_by_krb(req.auth)
+            .then(r => this.fetch_acl(r))
+            .then(acl => imm.Seq(acl)
+                .filter(e => e.permission == Perm.Read_ACL)
+                .map(e => e.target)
+                .toSet());
+        this.log("Permitted Read_ACL for %s: %o", req.auth, permitted.toJS());
+
+        const rv = permitted.has(UUIDs.Special.Null) ? acl
+            : acl.filter(e => permitted.has(e.permission));
+        this.log("Returning ACL %o", rv);
+
+        return res.status(200).json(rv);
     }
 }

--- a/acs-auth/lib/api_v2.js
+++ b/acs-auth/lib/api_v2.js
@@ -1,0 +1,43 @@
+/*
+ * ACS Auth service
+ * HTTP API v2
+ * Copyright 2025 University of Sheffield AMRC
+ */
+
+import express from "express";
+import * as rx from "rxjs";
+
+import { UUIDs } from "@amrc-factoryplus/service-client";
+
+import Model from "./model.js";
+import {Perm} from "./uuids.js";
+import { booleans, valid_krb, valid_uuid } from "./validate.js";
+
+export class APIv2 {
+    constructor(opts) {
+        this.debug  = opts.debug;
+        this.model = opts.model;
+        this.data = opts.data;
+
+        this.routes = this.setup_routes();
+    }
+
+    setup_routes() {
+        let api = express.Router();
+
+        api.get("/acl/:principal", this.get_acl.bind(this));
+
+        return api;
+    }
+
+    async get_acl (req, res) {
+        /* XXX No auth for now */
+        const { principal } = req.params;
+
+        const acl = await rx.firstValueFrom(
+            this.data.acl_for(principal));
+
+        if (!acl) return res.status(404).end();
+        return res.status(200).json(acl);
+    }
+}

--- a/acs-auth/lib/authz.js
+++ b/acs-auth/lib/authz.js
@@ -8,7 +8,6 @@ import express from "express";
 
 import { UUIDs } from "@amrc-factoryplus/service-client";
 
-import Model from "./model.js";
 import {Perm} from "./uuids.js";
 import { booleans, valid_krb, valid_uuid } from "./validate.js";
 
@@ -108,7 +107,7 @@ export default class AuthZ {
             req.auth, Perm.Manage_ACL, UUIDs.Null, false);
         if (!ok) return res.status(403).end();
 
-        const aces = await this.model.ace_get_all();
+        const aces = await this.model.grant_get_all();
         return res.status(200).json(aces);
     }
 

--- a/acs-auth/lib/authz.js
+++ b/acs-auth/lib/authz.js
@@ -10,31 +10,7 @@ import { UUIDs } from "@amrc-factoryplus/service-client";
 
 import Model from "./model.js";
 import {Perm} from "./uuids.js";
-
-const UUID_rx = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
-const KRB_rx = /^[a-zA-Z0-9_./-]+@[A-Z0-9-.]+$/;
-
-const booleans = {
-    undefined: false,
-    "true": true, "false": false,
-    "1": true, "0": false,
-    on: true, off: false,
-    yes: true, no: false,
-};
-
-function valid_uuid(uuid) {
-    if (UUID_rx.test(uuid))
-        return true;
-    //debug.log("debug", `Ignoring invalid UUID [${uuid}]`);
-    return false;
-}
-
-function valid_krb(krb) {
-    if (KRB_rx.test(krb))
-        return true;
-    //debug.log("debug", `Ignoring invalid principal [${krb}]`);
-    return false;
-}
+import { booleans, valid_krb, valid_uuid } from "./validate.js";
 
 export default class AuthZ {
     constructor(opts) {

--- a/acs-auth/lib/authz.js
+++ b/acs-auth/lib/authz.js
@@ -82,7 +82,7 @@ export default class AuthZ {
     }
 
     async get_acl(req, res) {
-        const {principal, permission} = req.query;
+        const { principal, permission } = req.query;
         const by_uuid = booleans[req.query["by-uuid"]];
 
         if (by_uuid == undefined)

--- a/acs-auth/lib/authz.js
+++ b/acs-auth/lib/authz.js
@@ -39,18 +39,13 @@ function valid_krb(krb) {
 export default class AuthZ {
     constructor(opts) {
         this.debug  = opts.debug;
-        this.model  = new Model(opts);
-        this.routes = express.Router();
-    }
+        this.model = opts.model;
 
-    async init() {
-        await this.model.init();
-        this.setup_routes();
-        return this;
+        this.routes = this.setup_routes();
     }
 
     setup_routes() {
-        let api = this.routes;
+        let api = express.Router();
 
         /* Validate against the spec */
         //const spec = url.fileURLToPath(new URL("openapi.yaml", import.meta.url));
@@ -107,6 +102,8 @@ export default class AuthZ {
 
         api.post("/load", this.dump_load.bind(this));
         api.get("/save", this.dump_save.bind(this));
+
+        return api;
     }
 
     async get_acl(req, res) {

--- a/acs-auth/lib/dataflow.js
+++ b/acs-auth/lib/dataflow.js
@@ -1,0 +1,51 @@
+/*
+ * ACS Auth service
+ * Data-flow / sequence management
+ * Copyright 2025 University of Sheffield AMRC
+ */
+
+import imm from "immutable";
+import rx from "rxjs";
+
+import * as rxx from "@amrc-factoryplus/rx-util";
+
+import { Class } from "./uuids.js";
+
+export class DataFlow {
+    constructor (opts) {
+        const { fplus } = opts;
+
+        this.model = opts.model;
+
+        this.log = fplus.debug.bound("data");
+        this.cdb = fplus.ConfigDB;
+
+        this.aces = this._build_aces();
+        this.groups = this._build_groups();
+    }
+
+    _build_aces () {
+        return rxx.rx(
+            rx.defer(() => this.model.ace_get_all()),
+            rx.shareReplay(1));
+    }
+
+    _build_groups () {
+        const { cdb } = this;
+
+        return rxx.rx(
+            rx.combineLatest({
+                princ:      cdb.watch_members(Class.Principal),
+                princ_grp:  cdb.watch_powerset(Class.Principal),
+                perm:       cdb.watch_members(Class.Permission),
+                perm_grp:   cdb.watch_powerset(Class.Permission),
+            }),
+            rx.shareReplay(1));
+    }
+
+    run () {
+        this.groups.subscribe(gs => this.log("GROUPS UPDATE"));
+            //imm.Map(gs).toJS()));
+        this.aces.subscribe(es => this.log("ACES: %o", es));
+    }
+}

--- a/acs-auth/lib/dataflow.js
+++ b/acs-auth/lib/dataflow.js
@@ -59,12 +59,14 @@ export class DataFlow {
                 if (!groups.princ.has(principal))
                     return;
                 /* Find groups this principal is member of */
-                const roles = groups.princ_grp
+                const accept_princ = groups.princ_grp
                     .filter(ms => ms.has(principal))
-                    .keySeq().toSet();
+                    .keySeq()
+                    .concat(principal)
+                    .toSet();
                 return aces
                     /* Filter ACEs by principal or group */
-                    .filter(e => roles.has(e.principal))
+                    .filter(e => accept_princ.has(e.principal))
                     /* Expand composite permissions */
                     .flatMap(e => 
                         groups.perm.has(e.permission) ? [e]

--- a/acs-auth/lib/dataflow.js
+++ b/acs-auth/lib/dataflow.js
@@ -58,7 +58,7 @@ export class DataFlow {
             rx.map(({ groups, aces }) => {
                 if (!groups.princ.has(principal))
                     return;
-                /* Find groups this principal is member of */
+                /* Find principals we will accept in an ACE */
                 const accept_princ = groups.princ_grp
                     .filter(ms => ms.has(principal))
                     .keySeq()
@@ -75,10 +75,10 @@ export class DataFlow {
                                 .toArray()
                                 .map(m => ({ ...e, permission: m }))
                         : [])
-                    /* Substitute Self */
+                    /* Substitute Self and remove unwanted properties */
                     .map(e => ({
-                        ...e,
-                        target: e.target == Special.Self ? principal : e.target,
+                        permission: e.permission,
+                        target:     e.target == Special.Self ? principal : e.target,
                     }));
             }));
     }

--- a/acs-auth/lib/uuids.js
+++ b/acs-auth/lib/uuids.js
@@ -5,7 +5,7 @@
  */
 
 export const Class = {
-    Principal:      "c0157038-ccff-11ef-a4db-63c6212e998f",
+    Principal:      "11614546-b6d7-11ef-aebd-8fbb45451d7c",
     Permission:     "8ae784bb-c4b5-4995-9bf6-799b3c7f21ad",
 };
 

--- a/acs-auth/lib/uuids.js
+++ b/acs-auth/lib/uuids.js
@@ -4,6 +4,11 @@
  * Copyright 2022 AMRC
  */
 
+export const Class = {
+    Principal:      "c0157038-ccff-11ef-a4db-63c6212e998f",
+    Permission:     "8ae784bb-c4b5-4995-9bf6-799b3c7f21ad",
+};
+
 export const Perm = {
     All:            "50b727d4-3faa-40dc-b347-01c99a226c58",
     Read_ACL:       "ba566181-0e8a-405b-b16e-3fb89130fbee",

--- a/acs-auth/lib/validate.js
+++ b/acs-auth/lib/validate.js
@@ -5,7 +5,7 @@
  */
 
 export const UUID_rx = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
-export const KRB_rx = /^[a-zA-Z0-9_./-]+@[A-Z0-9-.]+$/;
+export const KRB_rx = /^[a-zA-Z0-9_./-]+@[A-Za-z0-9-.]+$/;
 
 export const booleans = {
     undefined: false,

--- a/acs-auth/lib/validate.js
+++ b/acs-auth/lib/validate.js
@@ -1,0 +1,31 @@
+/*
+ * ACS Auth service
+ * Data validation routines
+ * Copyright 2025 University of Sheffield AMRC
+ */
+
+export const UUID_rx = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+export const KRB_rx = /^[a-zA-Z0-9_./-]+@[A-Z0-9-.]+$/;
+
+export const booleans = {
+    undefined: false,
+    "true": true, "false": false,
+    "1": true, "0": false,
+    on: true, off: false,
+    yes: true, no: false,
+};
+
+export function valid_uuid(uuid) {
+    if (UUID_rx.test(uuid))
+        return true;
+    //debug.log("debug", `Ignoring invalid UUID [${uuid}]`);
+    return false;
+}
+
+export function valid_krb(krb) {
+    if (KRB_rx.test(krb))
+        return true;
+    //debug.log("debug", `Ignoring invalid principal [${krb}]`);
+    return false;
+}
+

--- a/acs-auth/lib/validate.js
+++ b/acs-auth/lib/validate.js
@@ -15,6 +15,8 @@ export const booleans = {
     yes: true, no: false,
 };
 
+export const Wildcard = "00000000-0000-0000-0000-000000000000";
+
 export function valid_uuid(uuid) {
     if (UUID_rx.test(uuid))
         return true;
@@ -29,3 +31,6 @@ export function valid_krb(krb) {
     return false;
 }
 
+export function has_wild (set, member) {
+    return set.has(member) || set.has(Wildcard);
+}

--- a/acs-auth/package-lock.json
+++ b/acs-auth/package-lock.json
@@ -10,6 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@amrc-factoryplus/pg-client": "^0.0.1",
+        "@amrc-factoryplus/rx-client": "0.0.1-bmz.7",
+        "@amrc-factoryplus/rx-util": "0.0.4-bmz.1",
         "@amrc-factoryplus/service-api": "^0.1.0-bmz.1",
         "@amrc-factoryplus/service-client": "^1.4.0-bmz.2",
         "express": "^5.0.1"
@@ -30,10 +32,67 @@
         "pg-native": "^3.2.0"
       }
     },
+    "node_modules/@amrc-factoryplus/rx-client": {
+      "version": "0.0.1-bmz.7",
+      "resolved": "https://npm.amrc-factoryplus-dev.shef.ac.uk/@amrc-factoryplus%2frx-client/-/rx-client-0.0.1-bmz.7.tgz",
+      "integrity": "sha512-osC62nx9fkPtfRofv52HVdexXG809M3Rl14VC/ZoB3G0O3yVZdHA6fh8SthuA9Fj0tf9SJh+r0XLaxHBLN7S1A==",
+      "license": "ISC",
+      "dependencies": {
+        "@amrc-factoryplus/rx-util": "0.0.4-bmz.1",
+        "@amrc-factoryplus/service-client": "1.3.7-bmz.2",
+        "immutable": "^5.0.0-rc.2",
+        "rxjs": "^7.8.1",
+        "uuid": "^11.0.2"
+      }
+    },
+    "node_modules/@amrc-factoryplus/rx-client/node_modules/@amrc-factoryplus/service-client": {
+      "version": "1.3.7-bmz.2",
+      "resolved": "https://npm.amrc-factoryplus-dev.shef.ac.uk/@amrc-factoryplus%2fservice-client/-/service-client-1.3.7-bmz.2.tgz",
+      "integrity": "sha512-JWihFlP9Q0ojDKZCOs6tWXvuQI/Zign291crHaAdc+6KsptRhiBpXfknL6/EW1qwW4j33zWVjivNh1gKZjcRlQ==",
+      "license": "ISC",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "isomorphic-ws": "^5.0.0",
+        "mqtt": "^5.3.6",
+        "optional-js": "^2.3.0",
+        "semver": "^7.6.0",
+        "sparkplug-payload": "^1.0.3",
+        "uuid": "^10.0.0"
+      },
+      "optionalDependencies": {
+        "got-fetch": "^5.1.8",
+        "gssapi.js": "^2.0.1"
+      }
+    },
+    "node_modules/@amrc-factoryplus/rx-client/node_modules/@amrc-factoryplus/service-client/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@amrc-factoryplus/rx-client/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@amrc-factoryplus/rx-util": {
-      "version": "0.0.3",
-      "resolved": "https://npm.amrc-factoryplus-dev.shef.ac.uk/@amrc-factoryplus%2frx-util/-/rx-util-0.0.3.tgz",
-      "integrity": "sha512-gOwVxPtY+dynSeSYqb/Qv2UbZ2I+MURcNA7qZquYiBwl4nuCJ7dD8UYuAiNXC5dCdEzEzcYi4KWZGkYZQSIKOQ==",
+      "version": "0.0.4-bmz.1",
+      "resolved": "https://npm.amrc-factoryplus-dev.shef.ac.uk/@amrc-factoryplus%2frx-util/-/rx-util-0.0.4-bmz.1.tgz",
+      "integrity": "sha512-BwK7WNpQ+Z4lkTt/vtd/DTaHU6oPzruy17Srm2w19xCj/7e2k0cnuBcTc8mEmrU3Y4wH9eU0/jHMaCHOAmXr1Q==",
       "license": "ISC",
       "dependencies": {
         "immutable": "^5.0.0-beta.5",
@@ -62,32 +121,21 @@
         "ws": "^8.18.0"
       }
     },
+    "node_modules/@amrc-factoryplus/service-api/node_modules/@amrc-factoryplus/rx-util": {
+      "version": "0.0.3",
+      "resolved": "https://npm.amrc-factoryplus-dev.shef.ac.uk/@amrc-factoryplus%2frx-util/-/rx-util-0.0.3.tgz",
+      "integrity": "sha512-gOwVxPtY+dynSeSYqb/Qv2UbZ2I+MURcNA7qZquYiBwl4nuCJ7dD8UYuAiNXC5dCdEzEzcYi4KWZGkYZQSIKOQ==",
+      "license": "ISC",
+      "dependencies": {
+        "immutable": "^5.0.0-beta.5",
+        "rxjs": "^7.8.1"
+      }
+    },
     "node_modules/@amrc-factoryplus/service-api/node_modules/path-to-regexp": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "license": "MIT"
-    },
-    "node_modules/@amrc-factoryplus/service-api/node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@amrc-factoryplus/service-client": {
       "version": "1.4.0-bmz.2",
@@ -107,142 +155,6 @@
         "gssapi.js": "^2.0.1"
       }
     },
-    "node_modules/@amrc-factoryplus/service-client/node_modules/bl": {
-      "version": "6.0.18",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.18.tgz",
-      "integrity": "sha512-2k76XmWCuvu9HTvu3tFOl5HDdCH0wLZ/jHYva/LBVJmc9oX8yUtNQjxrFmbTdXsCSmIxwVTANZPNDfMQrvHFUw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/readable-stream": "^4.0.0",
-        "buffer": "^6.0.3",
-        "inherits": "^2.0.4",
-        "readable-stream": "^4.2.0"
-      }
-    },
-    "node_modules/@amrc-factoryplus/service-client/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/@amrc-factoryplus/service-client/node_modules/commist": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/commist/-/commist-3.2.0.tgz",
-      "integrity": "sha512-4PIMoPniho+LqXmpS5d3NuGYncG6XWlkBSVGiWycL22dd42OYdUGil2CWuzklaJoNxyxUSpO4MKIBU94viWNAw==",
-      "license": "MIT"
-    },
-    "node_modules/@amrc-factoryplus/service-client/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@amrc-factoryplus/service-client/node_modules/help-me": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
-      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
-      "license": "MIT"
-    },
-    "node_modules/@amrc-factoryplus/service-client/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
-    },
-    "node_modules/@amrc-factoryplus/service-client/node_modules/mqtt": {
-      "version": "5.10.3",
-      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-5.10.3.tgz",
-      "integrity": "sha512-hA/6YrUS4fywhBGCjH/XXUuLeueJiPqruVVWjK2A24Ma4KcWfZ/x8x07aoesBV+HXDWBC08tbT4IWfSXNW0Jtw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/readable-stream": "^4.0.5",
-        "@types/ws": "^8.5.9",
-        "commist": "^3.2.0",
-        "concat-stream": "^2.0.0",
-        "debug": "^4.3.4",
-        "help-me": "^5.0.0",
-        "lru-cache": "^10.0.1",
-        "minimist": "^1.2.8",
-        "mqtt-packet": "^9.0.1",
-        "number-allocator": "^1.0.14",
-        "readable-stream": "^4.4.2",
-        "reinterval": "^1.1.0",
-        "rfdc": "^1.3.0",
-        "split2": "^4.2.0",
-        "worker-timers": "^7.1.4",
-        "ws": "^8.17.1"
-      },
-      "bin": {
-        "mqtt": "build/bin/mqtt.js",
-        "mqtt_pub": "build/bin/pub.js",
-        "mqtt_sub": "build/bin/sub.js"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@amrc-factoryplus/service-client/node_modules/mqtt-packet": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-9.0.1.tgz",
-      "integrity": "sha512-koZF1V/X2RZUI6uD9wN5OK1JxxcG1ofAR4H3LjCw1FkeKzruZQ26aAA6v2m1lZyWONZIR5wMMJFrZJDRNzbiQw==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^6.0.8",
-        "debug": "^4.3.4",
-        "process-nextick-args": "^2.0.1"
-      }
-    },
-    "node_modules/@amrc-factoryplus/service-client/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/@amrc-factoryplus/service-client/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
     "node_modules/@amrc-factoryplus/service-client/node_modules/semver": {
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
@@ -253,45 +165,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@amrc-factoryplus/service-client/node_modules/split2": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
-      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 10.x"
-      }
-    },
-    "node_modules/@amrc-factoryplus/service-client/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/@amrc-factoryplus/service-client/node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/@babel/runtime": {
@@ -915,7 +788,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/big-integer": {
       "version": "1.6.51",
@@ -943,6 +817,43 @@
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "dependencies": {
         "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "6.0.18",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.18.tgz",
+      "integrity": "sha512-2k76XmWCuvu9HTvu3tFOl5HDdCH0wLZ/jHYva/LBVJmc9oX8yUtNQjxrFmbTdXsCSmIxwVTANZPNDfMQrvHFUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/readable-stream": "^4.0.0",
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/bl/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/bluebird": {
@@ -1036,6 +947,30 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -1265,6 +1200,12 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commist": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/commist/-/commist-3.2.0.tgz",
+      "integrity": "sha512-4PIMoPniho+LqXmpS5d3NuGYncG6XWlkBSVGiWycL22dd42OYdUGil2CWuzklaJoNxyxUSpO4MKIBU94viWNAw==",
       "license": "MIT"
     },
     "node_modules/concat-map": {
@@ -2451,6 +2392,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "license": "MIT"
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
@@ -2516,7 +2463,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -3062,6 +3010,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3192,6 +3146,120 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mqtt": {
+      "version": "5.10.3",
+      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-5.10.3.tgz",
+      "integrity": "sha512-hA/6YrUS4fywhBGCjH/XXUuLeueJiPqruVVWjK2A24Ma4KcWfZ/x8x07aoesBV+HXDWBC08tbT4IWfSXNW0Jtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/readable-stream": "^4.0.5",
+        "@types/ws": "^8.5.9",
+        "commist": "^3.2.0",
+        "concat-stream": "^2.0.0",
+        "debug": "^4.3.4",
+        "help-me": "^5.0.0",
+        "lru-cache": "^10.0.1",
+        "minimist": "^1.2.8",
+        "mqtt-packet": "^9.0.1",
+        "number-allocator": "^1.0.14",
+        "readable-stream": "^4.4.2",
+        "reinterval": "^1.1.0",
+        "rfdc": "^1.3.0",
+        "split2": "^4.2.0",
+        "worker-timers": "^7.1.4",
+        "ws": "^8.17.1"
+      },
+      "bin": {
+        "mqtt": "build/bin/mqtt.js",
+        "mqtt_pub": "build/bin/pub.js",
+        "mqtt_sub": "build/bin/sub.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/mqtt-packet": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-9.0.1.tgz",
+      "integrity": "sha512-koZF1V/X2RZUI6uD9wN5OK1JxxcG1ofAR4H3LjCw1FkeKzruZQ26aAA6v2m1lZyWONZIR5wMMJFrZJDRNzbiQw==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^6.0.8",
+        "debug": "^4.3.4",
+        "process-nextick-args": "^2.0.1"
+      }
+    },
+    "node_modules/mqtt-packet/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mqtt-packet/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/mqtt/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mqtt/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/mqtt/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/mqtt/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/ms": {
@@ -3591,14 +3659,6 @@
       "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
       "dependencies": {
         "split2": "^4.1.0"
-      }
-    },
-    "node_modules/pgpass/node_modules/split2": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
-      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-      "engines": {
-        "node": ">= 10.x"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -4198,6 +4258,15 @@
         "protobufjs": "^6.11.3"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/splitargs": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/splitargs/-/splitargs-0.0.7.tgz",
@@ -4602,16 +4671,16 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "peer": true,
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {

--- a/acs-auth/package-lock.json
+++ b/acs-auth/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@amrc-factoryplus/pg-client": "^0.0.1",
-        "@amrc-factoryplus/rx-client": "0.0.1-bmz.8",
+        "@amrc-factoryplus/rx-client": "0.0.1-bmz.9",
         "@amrc-factoryplus/rx-util": "0.0.4-bmz.1",
         "@amrc-factoryplus/service-api": "^0.1.0-bmz.1",
         "@amrc-factoryplus/service-client": "^1.4.0-bmz.2",
@@ -33,9 +33,9 @@
       }
     },
     "node_modules/@amrc-factoryplus/rx-client": {
-      "version": "0.0.1-bmz.8",
-      "resolved": "https://npm.amrc-factoryplus-dev.shef.ac.uk/@amrc-factoryplus%2frx-client/-/rx-client-0.0.1-bmz.8.tgz",
-      "integrity": "sha512-z8sy/MCq7WEJezkFpj6TA1G5JQcze+8DGlZiMLGMV3vmr4Fwwk+3jA0wTjB6/+kG8eqPOLCOgKgv68dQ7btU2g==",
+      "version": "0.0.1-bmz.9",
+      "resolved": "https://npm.amrc-factoryplus-dev.shef.ac.uk/@amrc-factoryplus%2frx-client/-/rx-client-0.0.1-bmz.9.tgz",
+      "integrity": "sha512-1w4rYBgms2AiX60A9sBcqnZ+2hCRZUwUslRE+SnQ7knkTXMhrEwRH6QoCGbqUQPv7FoddxdwiIWNuYmvXC8dag==",
       "license": "ISC",
       "dependencies": {
         "@amrc-factoryplus/rx-util": "0.0.4-bmz.1",

--- a/acs-auth/package-lock.json
+++ b/acs-auth/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@amrc-factoryplus/pg-client": "^0.0.1",
-        "@amrc-factoryplus/rx-client": "0.0.1-bmz.7",
+        "@amrc-factoryplus/rx-client": "0.0.1-bmz.8",
         "@amrc-factoryplus/rx-util": "0.0.4-bmz.1",
         "@amrc-factoryplus/service-api": "^0.1.0-bmz.1",
         "@amrc-factoryplus/service-client": "^1.4.0-bmz.2",
@@ -33,9 +33,9 @@
       }
     },
     "node_modules/@amrc-factoryplus/rx-client": {
-      "version": "0.0.1-bmz.7",
-      "resolved": "https://npm.amrc-factoryplus-dev.shef.ac.uk/@amrc-factoryplus%2frx-client/-/rx-client-0.0.1-bmz.7.tgz",
-      "integrity": "sha512-osC62nx9fkPtfRofv52HVdexXG809M3Rl14VC/ZoB3G0O3yVZdHA6fh8SthuA9Fj0tf9SJh+r0XLaxHBLN7S1A==",
+      "version": "0.0.1-bmz.8",
+      "resolved": "https://npm.amrc-factoryplus-dev.shef.ac.uk/@amrc-factoryplus%2frx-client/-/rx-client-0.0.1-bmz.8.tgz",
+      "integrity": "sha512-z8sy/MCq7WEJezkFpj6TA1G5JQcze+8DGlZiMLGMV3vmr4Fwwk+3jA0wTjB6/+kG8eqPOLCOgKgv68dQ7btU2g==",
       "license": "ISC",
       "dependencies": {
         "@amrc-factoryplus/rx-util": "0.0.4-bmz.1",

--- a/acs-auth/package-lock.json
+++ b/acs-auth/package-lock.json
@@ -14,7 +14,8 @@
         "@amrc-factoryplus/rx-util": "0.0.4-bmz.1",
         "@amrc-factoryplus/service-api": "^0.1.0-bmz.1",
         "@amrc-factoryplus/service-client": "^1.4.0-bmz.2",
-        "express": "^5.0.1"
+        "express": "^5.0.1",
+        "uuid": "^11.0.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.18.0",

--- a/acs-auth/package.json
+++ b/acs-auth/package.json
@@ -22,6 +22,8 @@
   "license": "MIT",
   "dependencies": {
     "@amrc-factoryplus/pg-client": "^0.0.1",
+    "@amrc-factoryplus/rx-client": "0.0.1-bmz.7",
+    "@amrc-factoryplus/rx-util": "0.0.4-bmz.1",
     "@amrc-factoryplus/service-api": "^0.1.0-bmz.1",
     "@amrc-factoryplus/service-client": "^1.4.0-bmz.2",
     "express": "^5.0.1"

--- a/acs-auth/package.json
+++ b/acs-auth/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "@amrc-factoryplus/pg-client": "^0.0.1",
-    "@amrc-factoryplus/rx-client": "0.0.1-bmz.8",
+    "@amrc-factoryplus/rx-client": "0.0.1-bmz.9",
     "@amrc-factoryplus/rx-util": "0.0.4-bmz.1",
     "@amrc-factoryplus/service-api": "^0.1.0-bmz.1",
     "@amrc-factoryplus/service-client": "^1.4.0-bmz.2",

--- a/acs-auth/package.json
+++ b/acs-auth/package.json
@@ -26,7 +26,8 @@
     "@amrc-factoryplus/rx-util": "0.0.4-bmz.1",
     "@amrc-factoryplus/service-api": "^0.1.0-bmz.1",
     "@amrc-factoryplus/service-client": "^1.4.0-bmz.2",
-    "express": "^5.0.1"
+    "express": "^5.0.1",
+    "uuid": "^11.0.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",

--- a/acs-auth/package.json
+++ b/acs-auth/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "@amrc-factoryplus/pg-client": "^0.0.1",
-    "@amrc-factoryplus/rx-client": "0.0.1-bmz.7",
+    "@amrc-factoryplus/rx-client": "0.0.1-bmz.8",
     "@amrc-factoryplus/rx-util": "0.0.4-bmz.1",
     "@amrc-factoryplus/service-api": "^0.1.0-bmz.1",
     "@amrc-factoryplus/service-client": "^1.4.0-bmz.2",

--- a/acs-configdb/lib/model.js
+++ b/acs-configdb/lib/model.js
@@ -382,6 +382,7 @@ export default class Model extends EventEmitter {
             return [st, info];
         });
 
+        this.log("OBJECT CREATE: %s", st);
         if (st < 299) {
             this.updates.next({
                 type:   "config",
@@ -389,6 +390,7 @@ export default class Model extends EventEmitter {
                 object: config.uuid,
                 config,
             });
+            this.log("SENDING class UPDATE");
             this.updates.next({ type: "class" });
         }
         return [st, config];

--- a/acs-configdb/lib/notify.js
+++ b/acs-configdb/lib/notify.js
@@ -207,8 +207,10 @@ function class_watch (rel, session, klass) {
     return rxx.rx(
         model.updates,
         rx.filter(u => u.type == "class"),
+        rx.tap(v => model.log("CLASS UPDATE: %s %s", rel, klass)),
         set_contents(() => model.class_lookup(klass, rel)),
-        ck_acl);
+        ck_acl,
+        rx.tap(l => model.log("SENDING CLASS UPDATE: %s %s: %o", rel, klass, l)));
 }
 
 export class CDBNotify extends Notify {

--- a/acs-service-setup/lib/auth-group.js
+++ b/acs-service-setup/lib/auth-group.js
@@ -1,0 +1,56 @@
+/*
+ * ACS service setup
+ * Migrate Auth groups to the ConfigDB
+ * Copyright 2025 University of Sheffield AMRC
+ */
+
+import { UUIDs } from "@amrc-factoryplus/service-client";
+
+export async function migrate_auth_groups (ss) {
+    const { fplus } = ss;
+
+    const auth = fplus.Auth;
+    const cdb = fplus.ConfigDB;
+    const log = fplus.debug.bound("groups");
+
+    /* This endpoint is not mapped in the ServiceClient */
+    const [st, grps] = await auth.fetch("authz/group/all");
+    if (st != 200)
+        throw `Can't fetch legacy Auth groups: ${st}`;
+
+    const uuids = new Set(grps.flatMap(m => [m.parent, m.child]));
+    const reg = await Promise.all(
+        [...uuids].map(u =>
+            cdb.get_config(UUIDs.App.Registration, u)
+                .then(r => [u, r])));
+    const unreg = new Set(reg.filter(e => !e[1]));
+    const rank = new Map(reg.filter(e => e[1]).map(([u, i]) => [u, i.rank]));
+
+    /* XXX The list needs filtering to remove entries which will be
+     * handled correctly in the dumps. We only need to forward-port
+     * group entries made by local admins. */
+
+    for (const { parent, child } of grps) {
+        if (unreg.has(parent) || unreg.has(child)) {
+            log("Can't migrate %s ∈ %s: unregistered object", child, parent);
+            continue;
+        }
+
+        const [pr, cr] = [parent, child].map(o => rank.get(o));
+        if (pr == cr) {
+            log("Migrating %s ⊂ %s", child, parent);
+            await cdb.class_add_subclass(parent, child);
+        }
+        else if (pr == cr + 1) {
+            log("Migrating %s ∈ %s", child, parent);
+            await cdb.class_add_member(parent, child);
+        }
+        else {
+            log("Can't migrate %s ∈ %s: rank mismatch", child, parent);
+        }
+
+        /* XXX We want to DELETE authz/group to remove the memberships
+         * we have deleted; but leave them for now so the auth service
+         * keeps working. */
+    }
+}

--- a/acs-service-setup/lib/service-setup.js
+++ b/acs-service-setup/lib/service-setup.js
@@ -5,6 +5,7 @@
 
 import { ServiceClient } from "@amrc-factoryplus/service-client";
 
+import { migrate_auth_groups }  from "./auth-group.js";
 import { setup_clusters }       from "./clusters.js";
 import { load_dumps }           from "./dumps.js";
 import { fixups }               from "./fixups.js";
@@ -38,6 +39,9 @@ export class ServiceSetup {
 
         this.log("Loading service dump files");
         await load_dumps(this);
+
+        this.log("Migrating legacy Auth groups");
+        await migrate_auth_groups(this);
 
         this.log("Creating Helm chart templates");
         const helm = await setup_helm(this);

--- a/deploy/templates/service-setup.yaml
+++ b/deploy/templates/service-setup.yaml
@@ -9,7 +9,6 @@ metadata:
 #  annotations:
 #    helm.sh/hook: post-install, post-upgrade
 spec:
-  ttlSecondsAfterFinished: 300
   backoffLimit: 9999
   template:
     spec:


### PR DESCRIPTION
The v2 API implementation is driven by Rx rather than fetching from the database all the time. This will allow a notify/v2 interface to be implemented straightforwardly.

* Track the classes we need from the ConfigDB.
* Track grants from the database.
* Implement correct (limited) group expansion for ACLs, respecting the `plural` field.
* Provide ACL-fetching endpoints `v2/acl/:uuid` and `v2/acl/kerberos/:upn`.
* Provide endpoints to edit the grants.