### PR TITLE
Fix mqtt restart on failure

### DIFF
--- a/deploy/templates/service-setup.yaml
+++ b/deploy/templates/service-setup.yaml
@@ -72,9 +72,22 @@ spec:
             - /bin/sh
             - -c
             - |
-              echo "Restarting MQTT..."
-              kubectl rollout restart deployment mqtt -n factory-plus
-              echo "Complete!"
+              DEPLOYMENT_NAME=mqtt
+              NAMESPACE={{.Release.Namespace}}
+
+              echo "Attempting to restart deployment: $DEPLOYMENT_NAME"
+
+              # Try to rollout restart the deployment
+              kubectl rollout restart deployment/$DEPLOYMENT_NAME -n $NAMESPACE
+
+              # Wait and check rollout status
+              if kubectl rollout status deployment/$DEPLOYMENT_NAME -n $NAMESPACE --timeout=60s; then
+                echo "Deployment restarted successfully!"
+                exit 0  # Exit successfully, no pod restart needed
+              else
+                echo "Deployment restart failed, retrying..."
+                exit 1  # Exit with error, pod will restart
+              fi
 ---
 
 apiVersion: v1

--- a/deploy/templates/service-setup.yaml
+++ b/deploy/templates/service-setup.yaml
@@ -9,7 +9,7 @@ metadata:
   name: service-setup-{{ randAlphaNum 8 | lower }}
 spec:
   ttlSecondsAfterFinished: 300
-  backoffLimit: 8
+  backoffLimit: 10
   template:
     spec:
       serviceAccountName: service-setup


### PR DESCRIPTION
If an error occurred during the restart of mqtt, the container would not restart. The added changes check if the restart was successful and retries if not.