### PR TITLE
Fix incorrect service account permissions

### DIFF
--- a/deploy/templates/service-setup.yaml
+++ b/deploy/templates/service-setup.yaml
@@ -106,7 +106,7 @@ metadata:
 rules:
   - apiGroups: [ "apps" ]
     resources: [ "deployments" ]
-    verbs: [ "get", "patch", "update" ]
+    verbs: [ "get", "patch", "update", "list", "watch" ]
 
 ---
 


### PR DESCRIPTION
The service setup service account permissions did not account for the addition of deployment status checking causing the container to always exit with code 1. The added permissions fix the issue. 