### PR TITLE
Update krbkeys to the Auth v2 API

### DIFF
--- a/acs-auth/lib/api_v2.js
+++ b/acs-auth/lib/api_v2.js
@@ -125,7 +125,7 @@ export class APIv2 {
     async grant_new (req, res) {
         const grant = req.body;
 
-        const permitted = await this.data.check_targ(req.auth, Perm.WriteACL);
+        const permitted = await this.data.check_targ(req.auth, Perm.WriteACL, true);
         const rv = await this.data.request({ type: "grant", grant, permitted });
         if (rv.status != 201)
             fail(rv.status);
@@ -138,7 +138,7 @@ export class APIv2 {
         if (!valid_uuid(uuid)) fail(410);
 
         const grant = req.method == "PUT" ? req.body : null;
-        const permitted = await this.data.check_targ(req.auth, Perm.WriteACL);
+        const permitted = await this.data.check_targ(req.auth, Perm.WriteACL, true);
 
         const rv = await this.data.request({ type: "grant", uuid, grant, permitted });
         return res.status(rv.status).end();

--- a/acs-auth/lib/api_v2.js
+++ b/acs-auth/lib/api_v2.js
@@ -8,7 +8,7 @@ import express from "express";
 import * as rx from "rxjs";
 
 import { Perm } from "./uuids.js";
-import { valid_krb, valid_uuid } from "./validate.js";
+import { valid_grant, valid_krb, valid_uuid } from "./validate.js";
 
 function fail (status) {
     throw { status };
@@ -124,6 +124,8 @@ export class APIv2 {
 
     async grant_new (req, res) {
         const grant = req.body;
+        if (!valid_grant(grant))
+            fail(422);
 
         const permitted = await this.data.check_targ(req.auth, Perm.WriteACL, true);
         const rv = await this.data.request({ type: "grant", grant, permitted });
@@ -138,6 +140,7 @@ export class APIv2 {
         if (!valid_uuid(uuid)) fail(410);
 
         const grant = req.method == "PUT" ? req.body : null;
+        if (!valid_grant(grant)) fail(422);
         const permitted = await this.data.check_targ(req.auth, Perm.WriteACL, true);
 
         const rv = await this.data.request({ type: "grant", uuid, grant, permitted });

--- a/acs-auth/lib/dataflow.js
+++ b/acs-auth/lib/dataflow.js
@@ -47,7 +47,8 @@ export class DataFlow {
 
                 return updater.call(model, r)
                     .then(rv => ({ ...rv, type: r.type, request: r.request }));
-            }));
+            }),
+            rx.share());
     }
 
     /* XXX This is not the best way to do this; we refetch the entire

--- a/acs-auth/lib/dataflow.js
+++ b/acs-auth/lib/dataflow.js
@@ -182,7 +182,8 @@ export class DataFlow {
             rx.first(),
             rx.mergeMap(ids => ids
                 .filter(i => i.kind == "kerberos" && i.name == upn)
-                .map(i => i.uuid))));
+                .map(i => i.uuid)),
+            rx.defaultIfEmpty(null)));
     }
 
     permitted (upn, perm) {

--- a/acs-auth/lib/model.js
+++ b/acs-auth/lib/model.js
@@ -66,9 +66,10 @@ export default class Model extends Queries {
         return this.txn(async q => {
             const pid = await q.uuid_find(r.uuid);
             const kid = await q.idkind_find(r.kind);
-            if (!kid) return 404;
+            if (!kid) return { status: 404 };
 
-            return q.identity_add(pid, kid, r.name);
+            const status = await q.identity_add(pid, kid, r.name);
+            return { status };
         });
     }
 

--- a/acs-auth/lib/model.js
+++ b/acs-auth/lib/model.js
@@ -59,18 +59,22 @@ export default class Model extends Queries {
     }
 
     /* This request does not check permissions. */
-    identity_request (r) {
+    _identity_request (r) {
         if (r.name == null)
             return this.identity_delete(r.uuid, r.kind);
 
         return this.txn(async q => {
             const pid = await q.uuid_find(r.uuid);
             const kid = await q.idkind_find(r.kind);
-            if (!kid) return { status: 404 };
+            if (!kid) return 404;
 
-            const status = await q.identity_add(pid, kid, r.name);
-            return { status };
+            return q.identity_add(pid, kid, r.name);
         });
+    }
+
+    async identity_request (r) {
+        const status = await this._identity_request(r);
+        return { status };
     }
 
     /* The dump must be valid. We will get database errors (at best) if

--- a/acs-auth/lib/queries.js
+++ b/acs-auth/lib/queries.js
@@ -139,14 +139,14 @@ export default class Queries {
         `);
     }
 
-    async identity_add (pid, kid, name) {
-        const ok = await this.q_single(`
+    identity_add (pid, kid, name) {
+        return this.query(`
             insert into identity (principal, kind, name)
-            values ($1, $2, $3)
-            on conflict do nothing
-            returning 1 ok
-        `, [pid, kid, name]);
-        return ok ? 204 : 409;
+            values ($1::integer, $2::integer, $3::text)
+            except select principal, kind, name from identity
+        `, [pid, kid, name])
+            .then(() => 204)
+            .catch(e => e?.code == "23505" ? 409 : Promise.reject(e));
     }
 
     async identity_delete (uuid, kind) {

--- a/acs-auth/lib/queries.js
+++ b/acs-auth/lib/queries.js
@@ -140,17 +140,17 @@ export default class Queries {
     }
 
     async identity_add (pid, kid, name) {
-        const dbr = await this.query(`
+        const ok = await this.q_single(`
             insert into identity (principal, kind, name)
             values ($1, $2, $3)
             on conflict do nothing
             returning 1 ok
         `, [pid, kid, name]);
-        return dbr.rows[0]?.ok ? 204 : 409;
+        return ok ? 204 : 409;
     }
 
     async identity_delete (uuid, kind) {
-        const dbr = await this.query(`
+        const ok = await this.q_single(`
             delete from identity i
             using uuid u, idkind k
             where i.principal = u.id
@@ -159,7 +159,7 @@ export default class Queries {
                 and k.kind = $2
             returning 1 ok
         `, [uuid, kind]);
-        return dbr.rows[0]?.ok ? 204 : 404;
+        return ok ? 204 : 404;
     }
 
     async group_all () {

--- a/acs-auth/lib/validate.js
+++ b/acs-auth/lib/validate.js
@@ -28,3 +28,10 @@ export function valid_krb(krb) {
     //debug.log("debug", `Ignoring invalid principal [${krb}]`);
     return false;
 }
+
+export function valid_grant (grant) {
+    if (!valid_uuid(grant.principal)) return false;
+    if (!valid_uuid(grant.permission)) return false;
+    if (!valid_uuid(grant.target)) return false;
+    return (grant.plural === true || grant.plural === false);
+}

--- a/acs-configdb/lib/model.js
+++ b/acs-configdb/lib/model.js
@@ -495,7 +495,7 @@ export default class Model extends EventEmitter {
                 join object o on o.id = r.id
             where c.uuid = $1 and o.uuid = $2
         `, [klass, obj]);
-        return !!dbr.rows;
+        return !!dbr.rows.length;
     }
 
     async _class_relation (klass, obj, perform) {

--- a/acs-krb-keys-operator/.gitignore
+++ b/acs-krb-keys-operator/.gitignore
@@ -7,6 +7,9 @@
 # Random temp files
 tmp/
 
+# Python venv
+venv/
+
 # Local build config
 config.mk
 

--- a/acs-krb-keys-operator/lib/amrc/factoryplus/krbkeys/__init__.py
+++ b/acs-krb-keys-operator/lib/amrc/factoryplus/krbkeys/__init__.py
@@ -58,6 +58,9 @@ class KrbKeys:
         def handler (**kw):
             with Context(self, kw):
                 ev = event(kw)
+                if ev.suspended:
+                    log("Resource suspended, skipping")
+                    return
                 return ev.process()
         return handler
 

--- a/acs-krb-keys-operator/lib/amrc/factoryplus/krbkeys/event.py
+++ b/acs-krb-keys-operator/lib/amrc/factoryplus/krbkeys/event.py
@@ -16,6 +16,8 @@ class KrbKeyEvent:
         self.ns, self.name, self.reason = dslice(args, "namespace", "name", "reason")
         self.annotations, self.patch = dslice(args, "annotations", "patch")
 
+        self.suspended = Identifiers.SUSPEND in self.annotations
+
     def process (self):
         raise NotImplementedError()
 

--- a/acs-krb-keys-operator/lib/amrc/factoryplus/krbkeys/event.py
+++ b/acs-krb-keys-operator/lib/amrc/factoryplus/krbkeys/event.py
@@ -35,7 +35,7 @@ class Rekey (KrbKeyEvent):
             return True
 
         if self.reason != "resume":
-            log("No change")
+            log("No change to spec, skipping rekey")
             return False
 
         if not self.new.can_verify():
@@ -93,6 +93,9 @@ class AccUuid (KrbKeyEvent):
 
         key = Identifiers.ACCOUNT_UUID
         p_annot = self.patch.metadata.annotations
+        def set_annot (uuid):
+            log(f"Setting account annotation to {uuid}")
+            p_annot[key] = uuid
 
         annot = self.annotations.get(key)
         spec = self.account.get("uuid")
@@ -108,7 +111,7 @@ class AccUuid (KrbKeyEvent):
         if klass is None:
             # We are not managing this object.
             log(f"Account is unmanaged. Using UUID {spec}.")
-            p_annot[key] = spec
+            set_annot(spec)
         elif annot is None:
             # We are managing this object but it's new. Start by
             # checking the Auth service for a principal mapping.
@@ -124,14 +127,14 @@ class AccUuid (KrbKeyEvent):
             # We need to make sure that if the object creation succeeds,
             # the annotation will be recorded. Otherwise we keep
             # creating ConfigDB objects.
-            p_annot[key] = str(uuid)
+            set_annot(str(uuid))
         elif spec is not None and annot != spec:
             # This should not normally happen. Probably someone has
             # added an explicit uuid field to an object with a class.
             # Perhaps I should just forbid explicit uuids if we are
             # managing the object?
             log(f"Annotation exists but is overridden to {spec}")
-            p_annot[key] = spec
+            set_annot(spec)
         else:
             log(f"Annotation should be correct: {annot}")
 

--- a/acs-krb-keys-operator/lib/amrc/factoryplus/krbkeys/event.py
+++ b/acs-krb-keys-operator/lib/amrc/factoryplus/krbkeys/event.py
@@ -116,9 +116,11 @@ class AccUuid (KrbKeyEvent):
             set_annot(spec)
         elif annot is None:
             # We are managing this object but it's new. Start by
-            # checking the Auth service for a principal mapping.
+            # checking the Auth service for a principal mapping. Make
+            # sure to bust the cache.
             log(f"Checking Auth service for existing account for {self.principal}")
-            uuid = fplus.auth.find_principal("kerberos", self.principal);
+            uuid = fplus.auth.with_fetch_opts(force_refresh=True) \
+                .find_principal("kerberos", self.principal);
 
             # Otherwise, create a new object in the ConfigDB.
             if uuid is None:

--- a/acs-krb-keys-operator/lib/amrc/factoryplus/krbkeys/util.py
+++ b/acs-krb-keys-operator/lib/amrc/factoryplus/krbkeys/util.py
@@ -21,6 +21,7 @@ class Identifiers:
     FORCE_REKEY = f"{APPID}/force-rekey"
     HAS_OLD_KEYS = f"{APPID}/has-old-keys"
     ACCOUNT_UUID = f"{APPID}/account-uuid"
+    SUSPEND = f"{APPID}/suspend"
 
     MANAGED_BY = "app.kubernetes.io/managed-by"
 

--- a/acs-krb-keys-operator/lib/amrc/factoryplus/service_client/auth.py
+++ b/acs-krb-keys-operator/lib/amrc/factoryplus/service_client/auth.py
@@ -4,6 +4,7 @@
 
 import  logging
 from    uuid                import UUID
+from    urllib.parse        import quote as urlquote
 
 from .service_interface     import ServiceInterface
 from ..                     import uuids
@@ -17,76 +18,35 @@ class Auth (ServiceInterface):
         self.service = uuids.Service.Authentication
 
     def get_principal (self, uuid):
-        st, json = self.fetch(f"authz/principal/{uuid}")
+        st, json = self.fetch(f"v2/principal/{uuid}")
         if st == 404:
             return
         if st != 200:
             self.error(f"Can't fetch principal {uuid}", st)
         return json
 
-    def add_principal (self, uuid, kerberos=None):
-        json = { "uuid": str(uuid) }
-        if kerberos is not None:
-            json["kerberos"] = str(kerberos)
+    def find_principal (self, kind, name):
+        quoted = urlquote(name, safe="")
+        st, uuid = self.fetch(f"v2/identity/{kind}/{name}")
+        if st == 200:
+            return UUID(uuid)
+        if st == 404:
+            return None
+        self.error(f"Can't search for {kind} identity {name}", st)
 
-        st, _ = self.fetch(
-            method="POST",
-            url=f"authz/principal",
-            json=json)
-        if st == 204:
-            return
-        self.error(f"Can't create principal {json}", st)
-
-    def delete_principal (self, uuid):
-        st, _ = self.fetch(
-            method="DELETE",
-            url=f"authz/principal/{uuid}")
-        if st == 204:
-            return
-        self.error(f"Can't delete principal {uuid}", st)
-
-    def add_to_group (self, group, member):
+    def add_identity (self, uuid, kind, name):
         st, _ = self.fetch(
             method="PUT",
-            url=f"authz/group/{group}/{member}")
+            url=f"v2/principal/{uuid}/{kind}",
+            json=name)
         if st == 204:
             return
-        self.error(f"Can't add {member} to {group}", st)
+        self.error(f"Can't set {kind} identity for {uuid}", st)
 
-    def remove_from_group (self, group, member):
+    def delete_identity (self, uuid, kind):
         st, _ = self.fetch(
             method="DELETE",
-            url=f"authz/group/{group}/{member}")
+            url=f"v2/principal/{uuid}/{kind}")
         if st == 204:
             return
-        self.error(f"Can't remove {member} from {group}", st)
-
-    # This API endpoint is awful.
-    
-    def add_ace (self, principal, permission, target):
-        st, _ = self.fetch(
-            method="POST",
-            url=f"authz/ace",
-            json={
-                "action": "add",
-                "principal": str(principal),
-                "permission": str(permission),
-                "target": str(target),
-            })
-        if st == 204:
-            return
-        self.error(f"Can't add ACE {principal},{permission},{target}", st)
-    
-    def delete_ace (self, principal, permission, target):
-        st, _ = self.fetch(
-            method="POST",
-            url=f"authz/ace",
-            json={
-                "action": "delete",
-                "principal": str(principal),
-                "permission": str(permission),
-                "target": str(target),
-            })
-        if st == 204:
-            return
-        self.error(f"Can't add ACE {principal},{permission},{target}", st)
+        self.error(f"Can't delete {kind} identity for {uuid}", st)

--- a/acs-krb-keys-operator/lib/amrc/factoryplus/service_client/configdb.py
+++ b/acs-krb-keys-operator/lib/amrc/factoryplus/service_client/configdb.py
@@ -92,9 +92,9 @@ class ConfigDB (ServiceInterface):
         url = f"v2/class/{klass}/{rel}/{obj}"
         st, _ = self.fetch(url)
         if st == 204:
-            return true
+            return True
         if st == 404:
-            return false
+            return False
         self.error(f"Can't check {rel} for {klass}", st)
 
     def class_has_member (self, klass, obj):

--- a/acs-krb-keys-operator/lib/amrc/factoryplus/service_client/configdb.py
+++ b/acs-krb-keys-operator/lib/amrc/factoryplus/service_client/configdb.py
@@ -71,3 +71,57 @@ class ConfigDB (ServiceInterface):
             self.error(f"Creating new {klass} failed", st)
         else:
             self.error(f"Creating {obj} of {klass} failed", st)
+
+    def _class_list (self, rel, klass):
+        url = f"v2/class/{klass}/{rel}"
+        st, uuids = self.fetch(url)
+        if st == 200:
+            return [UUID(u) for u in uuids]
+        self.error(f"Can't list {rel} for {klass}", st)
+
+    def class_members (self, klass):
+        return self._class_list("member", klass)
+    def class_subclasses (self, klass):
+        return self._class_list("subclass", klass)
+    def class_direct_members (self, klass):
+        return self._class_list("direct/member", klass)
+    def class_direct_subclasses (self, klass):
+        return self._class_list("direct/subclass", klass)
+
+    def _class_has (self, rel, klass, obj):
+        url = f"v2/class/{klass}/{rel}/{obj}"
+        st, _ = self.fetch(url)
+        if st == 204:
+            return true
+        if st == 404:
+            return false
+        self.error(f"Can't check {rel} for {klass}", st)
+
+    def class_has_member (self, klass, obj):
+        return self._class_has("member", klass, obj)
+    def class_has_subclass (self, klass, obj):
+        return self._class_has("subclass", klass, obj)
+    def class_has_direct_member (self, klass, obj):
+        return self._class_has("direct/member", klass, obj)
+    def class_has_direct_subclass (self, klass, obj):
+        return self._class_has("direct/subclass", klass, obj)
+
+    def _class_op (self, method, rel, klass, obj):
+        url = f"v2/class/{klass}/direct/{rel}/{obj}"
+        st, _ = self.fetch(method=method, url=url)
+        if st == 204:
+            return
+        if method == "PUT":
+            self.error(f"Adding {rel} {obj} to {klass} failed", st)
+        else:
+            self.error(f"Removing {rel} {obj} from {klass} failed", st)
+
+    def class_add_member (self, klass, obj):
+        return self._class_op("PUT", "member", klass, obj)
+    def class_remove_member (self, klass, obj):
+        return self._class_op("DELETE", "member", klass, obj)
+    def class_add_subclass (self, klass, obj):
+        return self._class_op("PUT", "subclass", klass, obj)
+    def class_remove_subclass (self, klass, obj):
+        return self._class_op("DELETE", klass, obj)
+

--- a/acs-krb-keys-operator/lib/amrc/factoryplus/service_client/service_interface.py
+++ b/acs-krb-keys-operator/lib/amrc/factoryplus/service_client/service_interface.py
@@ -18,11 +18,18 @@ def content_type (res):
 class ServiceInterface:
     def __init__ (self, fplus, **opts):
         self.fplus = fplus
+        self.fetch_opts = {}
 
     def error (self, msg, status=None):
         raise ServiceError(msg, service=self.service, status=status)
 
-    def fetch (self, url, **opts):
+    def with_fetch_opts (self, **opts):
+        rv = type(self)(self.fplus)
+        rv.fetch_opts = self.fetch_opts | opts;
+        return rv
+
+    def fetch (self, url, **kw):
+        opts = self.fetch_opts | kw;
         method = opts.pop("method", "GET")
 
         headers = opts.pop("headers", {})


### PR DESCRIPTION
This means pushing group memberships to the ConfigDB rather than the Auth service.

* Fix some bugs this turned up in the Auth service.
* When we have a new KerberosKey, look up the principal in the Auth service initially. This should mean we can respin an edge cluster without losing the edge account identities.
* Allow KerberosKeys to be suspended. This will be required to migrate `sv1git` from a static to a dynamic UUID.