### PR TITLE
Add Internal Traefik Redirect

### DIFF
--- a/deploy/templates/coredns/traefik-redirect.yaml
+++ b/deploy/templates/coredns/traefik-redirect.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.k3s.traefikRedirect.enabled }}
+{{ if .Values.coreDNS.traefikRedirect.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/deploy/templates/coredns/traefik-redirect.yaml
+++ b/deploy/templates/coredns/traefik-redirect.yaml
@@ -1,0 +1,10 @@
+{{ if .Values.k3s.traefikRedirect.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-custom
+  namespace: kube-system
+data:
+  rewrite.override: |
+    rewrite stop name regex .*\.{{.Values.acs.baseUrl}} acs-traefik.{{.Release.Namespace}}.svc.cluster.local answer auto
+{{ end }}

--- a/deploy/templates/coredns/traefik-redirect.yaml
+++ b/deploy/templates/coredns/traefik-redirect.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.coreDNS.traefikRedirect.enabled }}
+{{ if .Values.coredns.traefikRedirect.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -26,6 +26,10 @@ acs:
   # own section. Deployments from a Git checkout must set this value.
   #defaultTag: ''
 
+k3s:
+  traefikRedirect:
+    enabled: true
+
 identity:
   # -- Whether or not to enable the Identity component
   enabled: true

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -26,7 +26,7 @@ acs:
   # own section. Deployments from a Git checkout must set this value.
   #defaultTag: ''
 
-coreDNS:
+coredns:
   # -- An option to enable the redirecting of external URL's back
   # to the internal Traefik service. This is done through a config map
   # override to coredns in the kube-system namespace. The override rewrites

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -27,8 +27,11 @@ acs:
   #defaultTag: ''
 
 k3s:
+  # -- An option to enable redirecting all external URLs back to the
+  # internal Traefik service. ACS deployments without external DNS
+  # should enable this.
   traefikRedirect:
-    enabled: true
+    enabled: false
 
 identity:
   # -- Whether or not to enable the Identity component

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -26,10 +26,13 @@ acs:
   # own section. Deployments from a Git checkout must set this value.
   #defaultTag: ''
 
-k3s:
-  # -- An option to enable redirecting all external URLs back to the
-  # internal Traefik service. ACS deployments without external DNS
-  # should enable this.
+coreDNS:
+  # -- An option to enable the redirecting of external URL's back
+  # to the internal Traefik service. This is done through a config map
+  # override to coredns in the kube-system namespace. The override rewrites
+  # queries matching .*.<baseURL> to acs-traefik.<namespace>.svc.cluster.local,
+  # ensuring correct internal service resolution. ACS deployments without
+  # external DNS should enable this.
   traefikRedirect:
     enabled: false
 


### PR DESCRIPTION
The added coredns config map redirects all external URLs back to the internal Traefik service. This fixes issues caused by ACS instances which don't have external DNS setup.