### PR TITLE
Fix service-setup linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,4 +69,7 @@ all: git.check-committed
 setup: git.check-committed
 	+${recurse} setup ${subdirs}
 
+lint: git.check-committed
+	+${recurse} lint ${subdirs}
+
 include ${mk}/acs.git.mk

--- a/acs-service-setup/bin/check-yaml.js
+++ b/acs-service-setup/bin/check-yaml.js
@@ -1,14 +1,25 @@
 import fsp from "fs/promises";
 import process from "process";
-import {load_yaml} from "../lib/dumps.js";
+import { DumpLoader } from "../lib/dumps.js";
 
-const files = await fsp.readdir("dumps");
+const dumps = new DumpLoader({
+    dumps:      "dumps",
+    acs_config: {
+        namespace:      "factory-plus",
+        url_protocol:   "https",
+        base_url:       "my.domain",
+    },
+});
+
+/* XXX For now this can't use the for_all_dumps as we want to continue
+ * on parse errors. */
 let exit = 0;
+const files = await fsp.readdir(dumps.dumps);
 for (const f of files) {
     if (!f.endsWith(".yaml"))
         continue;
     try { 
-        await load_yaml(f);
+        await dumps.load_yaml(f);
     } 
     catch (e) {
         exit = 1;

--- a/acs-service-setup/lib/dumps.js
+++ b/acs-service-setup/lib/dumps.js
@@ -7,7 +7,6 @@ import fsp from "fs/promises";
 import yaml from "yaml";
 
 import { UUIDs } from "@amrc-factoryplus/service-client";
-import process from "process";
 
 import * as local_UUIDs from "./uuids.js";
 
@@ -17,105 +16,118 @@ const Paths = new Map([
     [UUIDs.Service.ConfigDB,        "/v1/load"],
     [UUIDs.Service.Directory,       "/load"],
 ]);
-const config = JSON.parse(process.env.ACS_CONFIG);
 
 const UUID_SOURCES = { UUIDs, ...local_UUIDs };
 
-function resolve (str) {
-    const cpts = str.split(".");
-    let it = UUID_SOURCES;
-    for (const c of cpts) {
-        if (!(c in it))
-            throw new Error(`UUID ref ${str} not found`);
-        it = it[c];
+export class DumpLoader {
+    constructor (opts) {
+        this.dumps  = opts.dumps;
+        this.fplus  = opts.fplus;
+        this.log    = opts.log || console.log;
+        
+        const acs = opts.acs_config;
+        this.url_replacements = {
+            NAMESPACE: acs.namespace,
+            BASE_URL: acs.base_url,
+            PROTOCOL: acs.url_protocol,
+        };
+
+        this.yamlOpts = {
+            customTags: [
+                ["u",   this.resolveUUID],
+                ["url", this.resolveURL],
+            ].map(([t, f]) => ({ tag: `!${t}`, resolve: f.bind(this) })),
+        };
     }
-    return it;
-}
 
-/**
- * Resolves the namespace in the yaml string with the ACS namespace or domain.
- * @param str The string to resolve.
- * @return {*} The resolved URL.
- */
-function resolveNamespace (str) {
-    const replacements = {
-        NAMESPACE: config.namespace,
-        BASE_URL: config.base_url,
-        PROTOCOL: config.url_protocol,
-    }
-    return str.replace(/\${(.*?)}/g, (match, key) => {
-        return replacements[key] || match; // Replace if key exists, otherwise keep original placeholder
-    });
-}
-
-const yamlOpts = {
-    customTags: [
-        {
-            tag:        "!u",
-            resolve:    str => resolve(str),
-        },
-        {
-            tag:        "!url",
-            resolve:    str => resolveNamespace(str),
-        },
-    ],
-};
-
-/**
- * Parses and converts yaml file to JSON.
- * @param file Yaml file to parse.
- * @return {Promise<any[]>} An JSON array of the parsed yaml files.
- */
-export async function load_yaml (file) {
-    const yamlString = await fsp.readFile(`dumps/${file}`, { encoding: "utf8" });
-    return yaml.parseAllDocuments(yamlString, yamlOpts)
-        .map(document => {
-            if (document.errors.length)
-                throw new Error(`YAML error in ${file}`, {cause: document.errors});
-            return document.toJS();
-        });
-}
-
-async function load_dump (fplus, dump) {
-    const { service } = dump;
-
-    const url = Paths.get(service);
-    if (url == undefined)
-        throw new Error(`Unrecognised service UUID ${service}`);
-
-    /* The ConfigDB should accept this in the dump */
-    const query = service == UUIDs.Service.ConfigDB
-        ? { overwrite: dump.overwrite ? "true" : "false" }
-        : {};
-    const res = await fplus.Fetch.fetch({
-        service, url, query,
-        method:         "POST",
-        body:           JSON.stringify(dump),
-        headers:        { "Content-Type": "application/json" },
-    });
-    return res.status;
-}
-
-export async function load_dumps (serviceSetup, early) {
-    // service client
-    const { fplus } = serviceSetup;
-
-    const files = await fsp.readdir("dumps");
-    files.sort();
-
-    for (const file of files) {
-        if (!file.endsWith(".yaml")) continue;
-        serviceSetup.log("== %s", file);
-        const documents = await load_yaml(file);
-        for (let document of documents) {
-            if(document.service !== UUIDs.Service.Directory && early ||
-                document.service === UUIDs.Service.Directory && !early){
-                continue;
-            }
-            serviceSetup.log("=== %s", document.service);
-            const status = await load_dump(fplus, document);
-            if (status > 300)
-                throw new Error(`Service dump ${file} failed: ${status}`);
+    resolveUUID (str) {
+        const cpts = str.split(".");
+        let it = UUID_SOURCES;
+        for (const c of cpts) {
+            if (!(c in it))
+                throw new Error(`UUID ref ${str} not found`);
+            it = it[c];
         }
+        return it;
+    }
+
+
+    /**
+     * Resolves the namespace in the yaml string with the ACS namespace or domain.
+     * @param str The string to resolve.
+     * @return {*} The resolved URL.
+     */
+    resolveURL (str) {
+        const { url_replacements } = this;
+        return str.replace(/\${(.*?)}/g, (match, key) => {
+            if (!(key in url_replacements))
+                throw new Error(`URL substitution ${key} not found`);
+            return url_replacements[key];
+        });
+    }
+
+    /**
+     * Parses and converts yaml file to JSON.
+     * @param file Yaml file to parse.
+     * @return {Promise<any[]>} An JSON array of the parsed yaml files.
+     */
+    async load_yaml (file) {
+        const { dumps, yamlOpts } = this;
+        const yamlString = await fsp.readFile(`${dumps}/${file}`, { encoding: "utf8" });
+        return yaml.parseAllDocuments(yamlString, yamlOpts)
+            .map(document => {
+                if (document.errors.length)
+                    throw new Error(`YAML error in ${file}`, {cause: document.errors});
+                return document.toJS();
+            });
+    }
+
+    async load_dump (dump) {
+        const { fplus } = this;
+        const { service } = dump;
+
+        const url = Paths.get(service);
+        if (url == undefined)
+            throw new Error(`Unrecognised service UUID ${service}`);
+
+        /* The ConfigDB should accept this in the dump */
+        const query = service == UUIDs.Service.ConfigDB
+            ? { overwrite: dump.overwrite ? "true" : "false" }
+            : {};
+        const res = await fplus.Fetch.fetch({
+            service, url, query,
+            method:         "POST",
+            body:           JSON.stringify(dump),
+            headers:        { "Content-Type": "application/json" },
+        });
+        return res.status;
+    }
+
+    async for_all_dumps (filter, next) {
+        const files = await fsp.readdir(this.dumps);
+        files.sort();
+
+        for (const file of files) {
+            if (!file.endsWith(".yaml")) continue;
+            this.log("== %s", file);
+            const documents = await this.load_yaml(file);
+            for (const document of documents) {
+                if (filter(document))
+                    await next(file, document);
+            }
+        }
+    }
+
+    load_dumps (early) {
+        const { Directory } = UUIDs.Service;
+
+        return this.for_all_dumps(
+            d => (d.service == Directory) == early,
+            async (file, document) => {
+                this.log("=== %s", document.service);
+                const status = await this.load_dump(document);
+                if (status > 300)
+                    throw new Error(`Service dump ${file} failed: ${status}`);
+            });
     }
 }

--- a/acs-service-setup/lib/service-setup.js
+++ b/acs-service-setup/lib/service-setup.js
@@ -6,7 +6,7 @@
 import { ServiceClient } from "@amrc-factoryplus/service-client";
 
 import { setup_clusters }       from "./clusters.js";
-import {load_dumps}             from "./dumps.js";
+import { DumpLoader }           from "./dumps.js";
 import { fixups }               from "./fixups.js";
 import { setup_helm }           from "./helm.js";
 import { setup_manager }        from "./manager.js";
@@ -19,6 +19,12 @@ export class ServiceSetup {
 
         this.fplus = new ServiceClient({ env: opts.env });
         this.log = this.fplus.debug.bound("setup");
+        this.dumps = new DumpLoader({
+            fplus:      this.fplus,
+            acs_config: this.acs_config,
+            dumps:      "dumps",
+            log:        this.fplus.debug.bound("dump"),
+        });
 
         this.log("Service setup config: %o", this.config);
         this.log("ACS config: %o", this.acs_config);
@@ -34,13 +40,13 @@ export class ServiceSetup {
 
     async run () {
         this.log("Loading directory dump");
-        await load_dumps(this, true);
+        await this.dumps.load_dumps(true);
 
         this.log("Running fixups");
         await fixups(this);
 
         this.log("Loading service dump files");
-        await load_dumps(this);
+        await this.dumps.load_dumps(false);
 
         this.log("Creating Helm chart templates");
         const helm = await setup_helm(this);

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -20,3 +20,7 @@ package:
 push:
 	helm push ${helm.package} oci://${registry}
 
+lint: helm.lint
+
+helm.lint:
+	helm lint .


### PR DESCRIPTION
The lint step now requires a valid ACS config. This means a fair amount of refactoring to allow the lint step to use a fake ACS config and get it into the loader configuration.

While we're here: create a top-level `lint` target, and include Helm chart linting. This could now reasonably by run before allowing a PR to be merged.