### PR TITLE
Fix Helm Upgrade Failure

### DIFF
--- a/acs-directory/lib/queries.js
+++ b/acs-directory/lib/queries.js
@@ -28,7 +28,7 @@ function sym_diff(one, two) {
  * the database directly, and sometimes we need to query using a query
  * function for a transaction. The model inherits from this class. */
 export default class Queries {
-    static DBVersion = 11;
+    static DBVersion = 12;
 
     constructor(query) {
         this.query = query;
@@ -330,7 +330,7 @@ export default class Queries {
         const ins = await this.query(`
             insert into service_provider as prv (service, device, url)
             values ($1, $2, $3)
-            on conflict (service, device) do update 
+            on conflict (service) do update 
                 set url = $3
             where prv.device is distinct from $2
                 or prv.url is distinct from $3

--- a/acs-directory/sql/migrate.sql
+++ b/acs-directory/sql/migrate.sql
@@ -27,6 +27,7 @@ BEGIN;
 \ir v9.sql
 \ir v10.sql
 \ir v11.sql
+\ir v12.sql
 
 \ir permissions.sql
 

--- a/acs-directory/sql/v12.sql
+++ b/acs-directory/sql/v12.sql
@@ -1,0 +1,14 @@
+-- Factory+ / AMRC Connectivity Stack (ACS) Directory component
+-- Database creation/upgrade DDL.
+-- Copyright 2025 AMRC
+
+
+call migrate_to(12, $migrate$
+
+    -- Drop the existing unique constraint
+    ALTER TABLE service_provider DROP CONSTRAINT service_provider_service_device_key;
+
+    -- Add the new unique constraint
+    ALTER TABLE service_provider ADD CONSTRAINT service_provider_service_key UNIQUE (service);
+
+$migrate$);


### PR DESCRIPTION
Added a new SQL migration to the directory to make a services unique. This prevents multiple instances of the same service being registered.