### PR TITLE
Fix cluster-manager

### DIFF
--- a/acs-auth/lib/api_v2.js
+++ b/acs-auth/lib/api_v2.js
@@ -129,10 +129,10 @@ export class APIv2 {
 
         const permitted = await this.data.check_targ(req.auth, Perm.WriteACL, true);
         const rv = await this.data.request({ type: "grant", grant, permitted });
-        if (rv.status != 201)
+        if (rv.status > 299)
             fail(rv.status);
 
-        return res.status(201).json({ uuid: rv.uuid });
+        return res.status(rv.status).json({ uuid: rv.uuid });
     }
 
     async grant_put (req, res) {

--- a/acs-auth/lib/api_v2.js
+++ b/acs-auth/lib/api_v2.js
@@ -141,7 +141,7 @@ export class APIv2 {
         if (!valid_uuid(uuid)) fail(410);
 
         const grant = req.method == "PUT" ? req.body : null;
-        if (!valid_grant(grant)) fail(422);
+        if (grant && !valid_grant(grant)) fail(422);
         const permitted = await this.data.check_targ(req.auth, Perm.WriteACL, true);
 
         const rv = await this.data.request({ type: "grant", uuid, grant, permitted });

--- a/acs-auth/lib/authz.js
+++ b/acs-auth/lib/authz.js
@@ -113,7 +113,7 @@ export default class AuthZ {
      * before but this is meant to be an admin-only interface now. */
     async group_all(req, res) {
         const tok = await this.data.check_targ(req.auth, Perm.ManageGroup, false);
-        if (tok?.(Special.Wildcard))
+        if (!tok?.(Special.Wildcard))
             return res.status(403).end();
 
         const groups = await this.model.group_all();
@@ -122,7 +122,7 @@ export default class AuthZ {
 
     async group_get (req, res) {
         const tok = await this.data.check_targ(req.auth, Perm.ManageGroup, false);
-        if (tok?.(Special.Wildcard))
+        if (!tok?.(Special.Wildcard))
             return res.status(403).end();
 
         const { group } = req.params;
@@ -135,7 +135,7 @@ export default class AuthZ {
 
     async group_delete(req, res) {
         const tok = await this.data.check_targ(req.auth, Perm.ManageGroup, false);
-        if (tok?.(Special.Wildcard))
+        if (!tok?.(Special.Wildcard))
             return res.status(403).end();
 
         const {group, member} = req.params;

--- a/acs-auth/lib/queries.js
+++ b/acs-auth/lib/queries.js
@@ -104,8 +104,10 @@ export default class Queries {
         const uuid = await this.q_single(`
             insert into ace (principal, permission, target, plural)
             values ($1, $2, $3, $4)
+            on conflict do nothing
             returning uuid
         `, [...ids, g.plural]);
+        if (!uuid) return { status: 409 };
         return { status: 201, uuid };
     }
 

--- a/acs-cluster-manager/lib/actions.js
+++ b/acs-cluster-manager/lib/actions.js
@@ -110,10 +110,17 @@ export class Update extends Action {
 
         if (!status.flux) {
             const flux = await cdb.create_object(Edge.Class.Account);
+            /* XXX We should record this UUID at this point, but we need
+             * to know we haven't finished with it. */
             this.log("Creating op1flux/%s as %s", name, flux);
             await cdb.put_config(UUIDs.App.Info, flux, 
                 { name: `Edge flux: ${name}` });
-            await auth.add_ace(flux, Git.Perm.Pull, uuid);
+            await auth.add_grant({
+                principal:  flux,
+                permission: Git.Perm.Pull,
+                target:     uuid,
+                plural:     false,
+            });
             await auth.add_to_group(group.flux.uuid, flux);
             await auth.add_principal(flux, this.principal("op1flux"));
             this.update({ flux });

--- a/acs-cluster-manager/lib/actions.js
+++ b/acs-cluster-manager/lib/actions.js
@@ -250,8 +250,11 @@ export class Delete extends Action {
             await auth.delete_identity(st.uuid, "kerberos")
                 .catch(svc_catch(404));
             await cdb.class_remove_member(group[key].uuid, st.uuid);
+            /* I haven't worked out how to grant permission for this
+             * yet. Currently this is a PATCH to Registration, and we
+             * don't have support for fine-grained ACLs. */
             await cdb.mark_object_deleted(st.uuid)
-                .catch(svc_catch(404));
+                .catch(svc_catch(403, 404));
             this.update({ [key]: null });
         };
 

--- a/acs-cluster-manager/lib/actions.js
+++ b/acs-cluster-manager/lib/actions.js
@@ -75,11 +75,14 @@ export class Update extends Action {
     async apply () {
         const { cdb, status, uuid } = this;
 
+        this.fixup_account_status();
+
         this.spec = await cdb.get_config(Edge.App.Cluster, uuid);
         if (!this.spec) {
             this.log("Cluster %s has disappeared!", uuid);
             return;
         }
+
         if (status.ready) {
             this.log("Cluster %s is already set up", uuid);
             return;
@@ -94,6 +97,25 @@ export class Update extends Action {
         this.log("Cluster %s is ready", this.name());
     }
 
+    fixup_account_status () {
+        const { status } = this;
+
+        const changes = new Map();
+
+        for (const acc of ["flux", "krbkeys"]) {
+            const uuid = status[acc];
+            if (typeof uuid != "string") continue;
+            changes.set("ready", false);
+            changes.set(acc, { uuid });
+        }
+
+        if (!changes.size) return;
+        const patch = Object.fromEntries(m.entries());
+        this.update(patch);
+        /* this.status is not live */
+        jmp.apply(status, patch);
+    }
+
     async address () {
         const { cdb, uuid, spec, prefix } = this;
         const name = this.name();
@@ -104,36 +126,41 @@ export class Update extends Action {
     }
 
     async accounts () {
-        const { auth, cdb, uuid, spec, status } = this;
+        const { auth, cdb, uuid: cluster, spec, status } = this;
         const group = this.config.group;
         const name = this.name();
 
-        if (!status.flux) {
-            const flux = await cdb.create_object(Edge.Class.Account);
-            /* XXX We should record this UUID at this point, but we need
-             * to know we haven't finished with it. */
-            this.log("Creating op1flux/%s as %s", name, flux);
-            await cdb.put_config(UUIDs.App.Info, flux, 
-                { name: `Edge flux: ${name}` });
-            await auth.add_grant({
-                principal:  flux,
-                permission: Git.Perm.Pull,
-                target:     uuid,
-                plural:     false,
-            });
-            await auth.add_to_group(group.flux.uuid, flux);
-            await auth.add_principal(flux, this.principal("op1flux"));
-            this.update({ flux });
-        }
-        if (!status.krbkeys) {
-            const krbkeys = await cdb.create_object(Edge.Class.Account);
-            this.log("Creating op1krbkeys/%s as %s", name, krbkeys);
-            await cdb.put_config(UUIDs.App.Info, krbkeys,
-                { name: `Edge krbkeys: ${name}` });
-            await auth.add_to_group(group.krbkeys.uuid, krbkeys);
-            await auth.add_principal(krbkeys, this.principal("op1krbkeys"));
-            this.update({ krbkeys });
-        }
+        const do_acc = async (role, perm) => {
+            if (status[role]?.done) return;
+
+            const upn = `op1${role}`;
+
+            const uuid = await cdb.create_object(Edge.Class.Account);
+            this.update({ [role]: { uuid } });
+            this.log("Created %s/%s as %s", upn, name, uuid);
+
+            await cdb.put_config(UUIDs.App.Info, uuid,
+                { name: `Edge ${role}: ${name}` });
+
+            if (perm) {
+                /* This will succeed if we add a duplicate. This is
+                 * important for migration. */
+                const grant = await auth.add_grant({
+                    principal:  uuid,
+                    permission: perm,
+                    target:     cluster,
+                    plural:     false,
+                });
+                this.update({ [role]: { grant } });
+            }
+
+            await cdb.class_add_member(group[role].uuid, uuid);
+            await auth.add_identity(uuid, "kerberos", this.principal(upn));
+            this.update({ [role]: { done: true } });
+        };
+
+        await do_acc("flux", Git.Perm.Pull);
+        await do_acc("krbkeys");
     }
 
     async repo () {
@@ -144,7 +171,7 @@ export class Update extends Action {
 
         this.log("Creating repo for %s", name);
         await this.cdb.put_config(Git.App.Config, uuid, { path });
-        await this.auth.add_to_group(group.uuid, uuid);
+        await this.cdb.class_add_member(group.uuid, uuid);
 
         const flux = await this.flux();
 
@@ -206,24 +233,25 @@ export class Delete extends Action {
 
         this.log("Removing cluster %s", name);
 
-        const { flux, krbkeys } = status;
-        if (flux) {
-            this.log("Removing op1flux/%s (%s)", name, flux);
-            await auth.delete_principal(flux)
+        const rm_acc = async key => {
+            const st = status[key];
+            if (!st) return;
+
+            this.log("Removing op1%s/%s (%s)", key, name, st.uuid);
+            if (st.grant) {
+                await auth.delete_grant(st.grant);
+                this.update({ [key]: { grant: null } });
+            }
+            await auth.delete_identity(st.uuid, "kerberos")
                 .catch(svc_catch(404));
-            await auth.remove_from_group(group.flux.uuid, flux);
-            await auth.delete_ace(flux, Git.Perm.Pull, uuid);
-            await cdb.mark_object_deleted(flux)
+            await cdb.class_remove_member(group[key].uuid, st.uuid);
+            await cdb.mark_object_deleted(st.uuid)
                 .catch(svc_catch(404));
-        }
-        if (krbkeys) {
-            this.log("Removing op1krbkeys/%s (%s)", name, krbkeys);
-            await auth.delete_principal(krbkeys)
-                .catch(svc_catch(404));
-            await auth.remove_from_group(group.krbkeys.uuid, krbkeys);
-            await cdb.mark_object_deleted(krbkeys)
-                .catch(svc_catch(404));
-        }
+            this.update({ [key]: null });
+        };
+
+        await rm_acc("flux");
+        await rm_acc("krbkeys");
 
         this.log("Removing repo for %s", name);
         await cdb.delete_config(Git.App.Config, uuid)

--- a/acs-cluster-manager/lib/actions.js
+++ b/acs-cluster-manager/lib/actions.js
@@ -131,12 +131,16 @@ export class Update extends Action {
         const name = this.name();
 
         const do_acc = async (role, perm) => {
-            if (status[role]?.done) return;
+            const st = status[role];
+            if (st?.done) return;
 
             const upn = `op1${role}`;
 
-            const uuid = await cdb.create_object(Edge.Class.Account);
-            this.update({ [role]: { uuid } });
+            let uuid = st?.uuid;
+            if (!uuid) {
+                uuid = await cdb.create_object(Edge.Class.Account);
+                this.update({ [role]: { uuid } });
+            }
             this.log("Created %s/%s as %s", upn, name, uuid);
 
             await cdb.put_config(UUIDs.App.Info, uuid,

--- a/acs-service-setup/dumps/clusters.yaml
+++ b/acs-service-setup/dumps/clusters.yaml
@@ -353,14 +353,6 @@ grants:
     # XXX This is nearly root-equivalent.
     !u UUIDs.Permission.Auth.ManageKerberos: null
 
-    # XXX This is a very broad grant; it is very nearly root-equivalent.
-    # But currently any grant of ManageGroup will be equivalent to this,
-    # as groups are expanded recursively and we can just add a victim
-    # group to one of our target groups. We have an Clusters.Requirement.Groups,
-    # but it is not set up properly by service-setup, and using it won't
-    # improve security until the Auth groups are fixed.
-    !u UUIDs.Permission.Auth.ManageGroup: null
-
     !u UUIDs.Permission.Auth.ManageACL:
       !u Git.Perm.Pull: false
 
@@ -391,6 +383,7 @@ grants:
 
     !u UUIDs.Permission.ConfigDB.ManageObjects:
       !u Clusters.Class.Account: false
+      !u Clusters.Class.ClusterGroups: true
 
     !u Git.Perm.Pull:
       !u Clusters.Requirement.EdgeRepos: true

--- a/acs-service-setup/lib/clusters.js
+++ b/acs-service-setup/lib/clusters.js
@@ -95,25 +95,31 @@ async function setup_perms (auth, group) {
     const ReadKerberos = "e8c9c0f7-0d54-4db2-b8d6-cd80c45f6a5c";
 
     const aces = [
-        [account_req,           Git.Perm.Pull,      group.shared.uuid],
-        [account_req,           Git.Perm.Pull,      group.cluster.uuid],
-        [account_req,           Git.Perm.Push,      group.cluster.uuid],
-        [group.flux.uuid,       Git.Perm.Pull,      group.shared.uuid],
-        [group.krbkeys.uuid,    ManageObjects,      Auth.Class.EdgeService],
-        [group.krbkeys.uuid,    ReadConfig,         UUIDs.App.Info],
-        [group.krbkeys.uuid,    WriteConfig,        UUIDs.App.Info],
-        [group.krbkeys.uuid,    ReadConfig,         UUIDs.App.SparkplugAddress],
-        [group.krbkeys.uuid,    WriteConfig,        UUIDs.App.SparkplugAddress],
+        [account_req,           Git.Perm.Pull,      group.shared.uuid,          true],
+        [account_req,           Git.Perm.Pull,      group.cluster.uuid,         true],
+        [account_req,           Git.Perm.Push,      group.cluster.uuid,         true],
+        [group.flux.uuid,       Git.Perm.Pull,      group.shared.uuid,          true],
+        [group.krbkeys.uuid,    ManageObjects,      Auth.Class.EdgeService,     false],
+        [group.krbkeys.uuid,    ReadConfig,         UUIDs.App.Info,             false],
+        [group.krbkeys.uuid,    WriteConfig,        UUIDs.App.Info,             false],
+        [group.krbkeys.uuid,    ReadConfig,         UUIDs.App.SparkplugAddress, false],
+        [group.krbkeys.uuid,    WriteConfig,        UUIDs.App.SparkplugAddress, false],
         /* XXX This is root-equivalent */
-        [group.krbkeys.uuid,    ManageKerberos,     UUIDs.Special.Null],
-        [group.krbkeys.uuid,    ReadKerberos,       UUIDs.Special.Null],
-        /* XXX This is root-equivalent due to lack of group member quoting */
-        [group.krbkeys.uuid,    ManageGroup,        Edge.Group.EdgeGroup],
-        [group.krbkeys.uuid,    ManageACL,          Edge.Group.EdgePermission],
+        [group.krbkeys.uuid,    ManageKerberos,     UUIDs.Special.Null,         false],
+        [group.krbkeys.uuid,    ReadKerberos,       UUIDs.Special.Null,         false],
+        [group.krbkeys.uuid,    ManageGroup,        Edge.Group.EdgeGroup,       true],
+        /* XXX Not much use at present due to pure ranks. Composite
+         * perms are a rank higher than ordinary perms. Unused. */
+        [group.krbkeys.uuid,    ManageACL,          Edge.Group.EdgePermission,  true],
     ];
     for (const ace of aces) {
         auth.fplus.debug.log("clusters", "Adding %o", ace);
-        await auth.add_ace(...ace);
+        await auth.add_grant({
+            principal:  ace[0],
+            permission: ace[1],
+            target:     ace[2],
+            plural:     ace[3],
+        });
     }
 }
 

--- a/acs-service-setup/lib/helm.js
+++ b/acs-service-setup/lib/helm.js
@@ -68,8 +68,8 @@ async function setup_perms (auth, group) {
         [group.monitor.uuid,    ReloadConfig,   UUIDs.Special.Null,         false],
     ];
 
-    for (const a of aces) {
-        auth.fplus.debug.log("helm", "Adding ACE %s", a.join(", "));
+    for (const ace of aces) {
+        auth.fplus.debug.log("helm", "Adding ACE %s", ace.join(", "));
         await auth.add_grant({
             principal:  ace[0],
             permission: ace[1],

--- a/acs-service-setup/lib/helm.js
+++ b/acs-service-setup/lib/helm.js
@@ -56,21 +56,26 @@ async function setup_perms (auth, group) {
      * UUID for group access. */
 
     const aces = [
-        [group.agent.uuid,      ReadConfig,     Edge.App.AgentConfig],
-        [group.sync.uuid,       ReadConfig,     Clusters.App.HelmRelease],
-        [group.sync.uuid,       ReadConfig,     Clusters.App.HelmTemplate],
-        [group.sync.uuid,       ReadConfig,     Edge.App.Deployment],
-        [group.sync.uuid,       ReadConfig,     Edge.App.ClusterStatus],
-        [group.sync.uuid,       WriteConfig,    Edge.App.ClusterStatus],
-        [group.sync.uuid,       EdgeNodeConsumer, ACS.Device.ConfigDB],
-        [group.monitor.uuid,    ReadConfig,     Edge.App.AgentConfig],
-        [group.monitor.uuid,    EdgeNodeConsumer, ACS.Device.ConfigDB],
-        [group.monitor.uuid,    ReloadConfig,   UUIDs.Special.Null],
+        [group.agent.uuid,      ReadConfig,     Edge.App.AgentConfig,       false],
+        [group.sync.uuid,       ReadConfig,     Clusters.App.HelmRelease,   false],
+        [group.sync.uuid,       ReadConfig,     Clusters.App.HelmTemplate,  false],
+        [group.sync.uuid,       ReadConfig,     Edge.App.Deployment,        false],
+        [group.sync.uuid,       ReadConfig,     Edge.App.ClusterStatus,     false],
+        [group.sync.uuid,       WriteConfig,    Edge.App.ClusterStatus,     false],
+        [group.sync.uuid,       EdgeNodeConsumer, ACS.Device.ConfigDB,      false],
+        [group.monitor.uuid,    ReadConfig,     Edge.App.AgentConfig,       false],
+        [group.monitor.uuid,    EdgeNodeConsumer, ACS.Device.ConfigDB,      false],
+        [group.monitor.uuid,    ReloadConfig,   UUIDs.Special.Null,         false],
     ];
 
     for (const a of aces) {
         auth.fplus.debug.log("helm", "Adding ACE %s", a.join(", "));
-        await auth.add_ace(...a);
+        await auth.add_grant({
+            principal:  ace[0],
+            permission: ace[1],
+            target:     ace[2],
+            plural:     ace[3],
+        });
     }
 }
 

--- a/deploy/templates/configdb/configdb.yaml
+++ b/deploy/templates/configdb/configdb.yaml
@@ -131,8 +131,6 @@ spec:
               value: configdb
             - name: VERBOSE
               value: "1"
-            - name: MQTT_DISABLE
-              value: "1"
 {{ include "amrc-connectivity-stack.cache-max-age" (list . "configdb") | indent 12 }}
             - name: BODY_LIMIT
               value: "{{ .Values.configdb.bodyLimit }}"

--- a/lib/js-service-client/lib/service/auth.js
+++ b/lib/js-service-client/lib/service/auth.js
@@ -181,7 +181,7 @@ export class Auth extends ServiceInterface {
                 "Failed to resolve %s identity %s: %s", type, name, st);
             return null;
         }
-        this.debug.log("princ", "Resolved %o to %s", query, uuid);
+        this.debug.log("princ", "Resolved %s/%s to %s", type, name, uuid);
         return uuid;
     }
 

--- a/lib/js-service-client/lib/service/auth.js
+++ b/lib/js-service-client/lib/service/auth.js
@@ -384,7 +384,8 @@ export class Auth extends ServiceInterface {
             url:        "v2/grant",
             body:       grant,
         });
-        if (st == 204) return json.uuid;
+        /* 200 indicates we have attempted to add a duplicate */
+        if (st == 201 || st == 200) return json.uuid;
         this.throw("Failed to add grant", st);
     }
 

--- a/lib/js-service-client/lib/service/auth.js
+++ b/lib/js-service-client/lib/service/auth.js
@@ -370,8 +370,25 @@ export class Auth extends ServiceInterface {
      * @returns A list of grant objects.
      */
     async get_all_grants () {
-        const uuids = this.list_grants();
+        const uuids = await this.list_grants();
         return Promise.all(uuids.map(u => this.get_grant(u)));
+    }
+
+    /** Search for a grant.
+     * Finds all grants we have access to read which match the pattern
+     * provided. Unspecified fields are wildcard.
+     * @param pattern A grant object pattern.
+     * @returns A list of grant UUIDs.
+     */
+    async find_grants (pattern) {
+        const [st, json] = await this.fetch({
+            method:     "POST",
+            url:        "v2/grant/find",
+            body:       pattern,
+        });
+        if (st == 200)
+            return json;
+        this.throw("Failed to search grants", st);
     }
 
     /** Create a new grant.

--- a/lib/js-service-client/lib/service/auth.js
+++ b/lib/js-service-client/lib/service/auth.js
@@ -249,7 +249,7 @@ export class Auth extends ServiceInterface {
      *  resolve the principal (no permission or doesn't exist).
      */
     async find_principal (kind, identifier) {
-        const uuid = this.resolve_principal([kind, identifier]);
+        const uuid = await this.resolve_principal([kind, identifier]);
         if (uuid == undefined) return;
 
         const [st, ids] = await this.fetch(`v2/principal/${uuid}`);

--- a/lib/js-service-client/lib/service/auth.js
+++ b/lib/js-service-client/lib/service/auth.js
@@ -4,6 +4,8 @@
  * Copyright 2022 AMRC.
  */
 
+import util from "util";
+
 import { Address } from "../sparkplug/util.js";
 
 import { App, Service, Null as Null_UUID }  from "../uuids.js";
@@ -17,7 +19,6 @@ export class Auth extends ServiceInterface {
 
         this.service = Service.Authentication;
         this.root_principal = fplus.opts.root_principal;
-        this.permission_group = fplus.opts.permission_group;
 
         this.bootstrap_acl = this._build_bs_acl(fplus.opts);
     }
@@ -52,27 +53,58 @@ export class Auth extends ServiceInterface {
         return acl;
     }
     
-    /* Verifies if principal has permission on target. If 'wild' is true
-     * then the null UUID in an ACE will match any target. */
+    /** Checks if a principal has a given permission.
+     * The principal may be in any form accepted by `decode_principal`.
+     *
+     * @param principal The principal to check.
+     * @param permission The permission UUID to check.
+     * @param target The target UUID to check.
+     * @param wild A boolean: whether to accept Wildcard targets.
+     * @returns A boolean: permitted or not.
+     */
     async check_acl (principal, permission, target, wild) {
-        const acl = await this.fetch_acl(principal, this.permission_group);
+        const acl = await this.fetch_acl(principal);
         return acl(permission, target, wild);
     }
 
-    /* Takes a principal and a permission group. Returns a function
-     * which checks a particular permission and target against the
-     * returned ACL. */
+    /** Normalises different principal formats.
+     * Accepted formats are
+     * - A plain string, interpreted as a `kerberos` UPN.
+     * - A pair [type, name].
+     * - An object with a single key.
+     * The type is an identity type known to the Auth service, or `uuid`
+     * for a principal UUID.
+     *
+     * @returns A pair [type, name].
+     */
+    /* XXX This all need refactoring. Probably I want an Identity class
+     * which is (type, name) (including `uuid`) and then a Principal
+     * which has a list of Identities. */
+    decode_principal (req) {
+        if (req == null)                return [null, null];
+        if (Array.isArray(req))         return req.slice(0, 2);
+        if (typeof req == "string")     return ["kerberos", req];
+        
+        if (typeof req != "object")
+            this.throw("Can't decode as identity: %o", req);
+        const entries = Object.entries(req);
+        if (entries.length != 1)
+            this.throw("Can't decode as identity: %o", req);
+        return entries[0];
+    }
+
+    /* Fetch the ACL for a principal.
+     * Returns the ACL in the form of a function accepting (permission,
+     * target, wild) and returning boolean. See `check_acl`.
+     *
+     * @param princ_req Passed to `decode_principal`.
+     * @param group Ignored (for compatibility).
+     * @returns A function for checking the ACL.
+     */
     async fetch_acl (princ_req, group) {
-        const [type, principal] =
-            typeof(princ_req) == "string"   ? ["kerberos", princ_req]
-            : "kerberos" in princ_req       ? ["kerberos", princ_req.kerberos]
-            : "uuid" in princ_req           ? ["uuid", princ_req.uuid]
-            : [null, null];
-        if (type == null) {
-            this.debug.log("acl", 
-                "Unrecognised principal request: %o", princ_req);
-            return () => false;
-        }
+        const [type, principal] = this.decode_principal(princ_req);
+        if (type == null)
+            this.throw(util.format("Unrecognised principal request: %o", princ_req));
 
         if (this.root_principal 
             && type == "kerberos" 
@@ -84,9 +116,8 @@ export class Auth extends ServiceInterface {
 
         const acl = (type == "kerberos" && this.bootstrap_acl.has(principal))
             ? this.bootstrap_acl.get(principal)
-            : await this._fetch_acl(principal, group, type == "uuid");
+            : await this._fetch_acl(type, principal);
 
-        if (!acl) return () => false;
         this.debug.log("acl", "Got ACL for %s: %o", principal, acl);
 
         return (permission, target, wild) => 
@@ -96,34 +127,60 @@ export class Auth extends ServiceInterface {
                     || (wild && ace.target == Null_UUID)));
     }
 
-    async _fetch_acl (principal, group, by_uuid) {
-        const res = await this.fplus.fetch({
-            service:    Service.Authentication,
-            url:        "/authz/acl",
-            query:      { principal, permission: group, "by-uuid": by_uuid },
-        });
-        if (!res.ok) {
-            this.debug.log("acl", `Failed to read ACL for ${principal}: ${res.status}`);
-            return;
+    async _fetch_acl (type, principal) {
+        const url = type == "uuid" ? `v2/acl/${principal}`
+            : `v2/acl/${type}/${principal}`;
+        const [st, json] = await this.fetch(url);
+        if (st != 200) {
+            /* XXX I'm not sure what's best to do here. ServiceError has
+             * a `status` property holding the status from the failed
+             * request; this is obviously useful. But express will now
+             * interpret the `status` of an exception as the status to
+             * return to the client. I need to separate these two uses
+             * somehow. Maybe service-api needs to translate all Auth
+             * errors (or all ServiceErrors?) to 503 on principle? */
+            this.debug.log("acl", "Failed to read ACL for %s: %s",
+                principal, st);
+            this.throw(`Failed to read ACL for ${principal}`, 503);
         }
-        return res.json();
+        return json;
     }
 
-    /* Resolve a principal to a UUID. Query is an object with a single
-     * key; currently this must be 'kerberos' to search for principals
-     * by Kerberos principal name. */
+    /** Resolve a principal identity to a UUID.
+     * This method calls `resolve_identity`, except for:
+     * - Type `null` calls `whoami_uuid`.
+     * - Type `uuid` is returned unchanged.
+     * - Type `sparkplug` goes to the ConfigDB.
+     *
+     * @param query Passed to `decode_principal`.
+     * @returns A UUID.
+     */
     async resolve_principal (query) {
-        const res = await this.fplus.fetch({
-            service:    Service.Authentication,
-            url:        "/authz/principal/find",
-            query,
-        });
-        if (!res.ok) {
+        const [type, name] = this.decode_principal(query);
+        if (type == null) return this.whoami_uuid();
+        if (type == "uuid") return name;
+        if (type == "sparkplug") return this._resolve_by_addr(name);
+
+        return this.resolve_identity(type, name);
+    }
+
+    /** Look up an identity.
+     * This only supports name types supported directly by the Auth
+     * service. Currently this means Kerberos only.
+     *
+     * @param type The type of name `name` is.
+     * @param name The name to look up.
+     * @returns A UUID, or `null`.
+     */
+    async resolve_identity (type, name) {
+        const url = util.format("v2/identity/%s/%s",
+            encodeURIComponent(type), encodeURIComponent(name));
+        const [st, uuid] = await this.fetch(url);
+        if (st != 200) {
             this.debug.log("princ", 
-                "Failed to resolve %o: %s", query, res.status);
+                "Failed to resolve %s identity %s: %s", type, name, st);
             return null;
         }
-        const uuid = await res.json();
         this.debug.log("princ", "Resolved %o to %s", query, uuid);
         return uuid;
     }
@@ -131,26 +188,48 @@ export class Auth extends ServiceInterface {
     async _resolve_by_addr (address) {
         const cdb = this.fplus.ConfigDB;
 
+        const addr = Address.from(address);
+        if (addr.isDevice())
+            this.throw("${addr} is a Device address");
+
         /* Check for a version of the ConfigDB that can search for
          * not-existing keys. Otherwise we will get false results. */
+        /* XXX We should cache this. */
         if (!await cdb.version_satisfies(">=1.7")) {
             this.debug.log("princ", `ConfigDB is too old to search for addresses`);
             return;
         }
 
-        const uuids = await cdb.search({
+        return cdb.resolve({
             app:    App.SparkplugAddress,
             query:  {
-                group_id:   address.group,
-                node_id:    address.node,
+                group_id:   addr.group,
+                node_id:    addr.node,
                 device_id:  undefined,
             }});
-        if (uuids.length == 1) return uuids;
-        if (uuids.length)
-            this.debug.log("princ",
-                "Multiple results resolving Sparkplug address %s",
-                address);
-        return;
+    }
+
+    /** Fetch all my identities.
+     * Call the Auth service to find all my identities, based on my
+     * Kerberos UPN.
+     *
+     * @returns An object keyed by identity type.
+     */
+    async whoami () {
+        const [st, json] = await this.fetch("v2/whoami");
+        if (st == 200) return json;
+        this.throw("Can't fetch my identities", st);
+    }
+
+    /** Fetch my principal UUID.
+     * Look up my principal UUID in the Auth service.
+     *
+     * @returns A UUID.
+     */
+    async whoami_uuid () {
+        const [st, json] = await this.fetch("v2/whoami/uuid");
+        if (st == 200) return json;
+        this.throw("Can't fetch my identity", st);
     }
 
     /** Fetch the different identities for a principal. 
@@ -170,18 +249,10 @@ export class Auth extends ServiceInterface {
      *  resolve the principal (no permission or doesn't exist).
      */
     async find_principal (kind, identifier) {
-        const uuid = 
-            kind == undefined ? await this.resolve_principal()
-            : kind == "uuid" ? identifier
-            : kind == "kerberos"
-                ? await this.resolve_principal({kerberos: identifier})
-            : kind == "sparkplug"
-                ? await this._resolve_by_addr(identifier)
-            : undefined;
-
+        const uuid = this.resolve_principal([kind, identifier]);
         if (uuid == undefined) return;
 
-        const [st, ids] = await this.fetch(`/authz/principal/${uuid}`);
+        const [st, ids] = await this.fetch(`v2/principal/${uuid}`);
         if (st != 200) {
             this.debug.log("princ", "Failed to fetch principal %s: %s",
                 uuid, st);
@@ -196,98 +267,162 @@ export class Auth extends ServiceInterface {
         return ids;
     }
 
-    async add_principal (uuid, kerberos) {
+    /** Add an identity for a principal.
+     * This will silently succeed if there is an existing record which
+     * matches, and fail with 409 if there is a conflict.
+     *
+     * @param uuid The principal UUID.
+     * @param type The identity type.
+     * @param name The identity name.
+     */
+    async add_identity (uuid, type, name) {
         const [st] = await this.fetch({
-            method:     "POST",
-            url:        "authz/principal",
-            body:       { uuid, kerberos },
+            method:     "PUT",
+            url:        `v2/principal/${uuid}/${type}`,
+            body:       name,
         });
         if (st != 204)
-            this.throw(`Can't create principal ${kerberos}`, st);
+            this.throw(`Can't add ${type} identity ${name} for ${uuid}`, st);
     }
 
-    /* Returns true if we deleted a principal, false if the principal
-     * didn't exist. */
-    async delete_principal (uuid) {
+    add_principal (uuid, kerberos) {
+        return this.add_identity(uuid, "kerberos", kerberos);
+    }
+
+    /** Delete an identity.
+     * Returns true if we deleted an identity, false if the identity
+     * already didn't exist.
+     *
+     * @param uuid The principal UUID.
+     * @param type The type of identity to delete.
+     */
+    async delete_identity (uuid, type) {
         const [st] = await this.fetch({
             method:     "DELETE",
-            url:        `authz/principal/${uuid}`,
+            url:        `v2/principal/${uuid}/${type}`
         });
         switch (st) {
             case 204:   return true;
             case 404:   return false;
             default:
-                this.throw(`Can't delete principal ${uuid}`, st);
+                this.throw(`Can't delete ${type} identity for ${uuid}`, st);
         }
     }
 
+    delete_principal (uuid) {
+        return this.delete_identity(uuid, "kerberos");
+    }
+
+    /** Create a principal and set a Kerberos UPN.
+     * This creates the principal in the ConfigDB and sets the identity
+     * in the Auth service.
+     *
+     * @param klass The class UUID to use when creating the principal.
+     * @param kerberos The Kerberos UPN to set.
+     * @param name The _General Info_ name of the principal.
+     */
+    /* XXX There is a problem here: if we don't have permission to add
+     * identities we create an object we can't clean up. */
     async create_principal (klass, kerberos, name) {
         const cdb = this.fplus.ConfigDB;
         const uuid = await cdb.create_object(klass);
-        try {
+        //try {
             await this.add_principal(uuid, kerberos);
-        }
-        catch (e) {
-            await cdb.put_config(App.Info, uuid, {
-                name, deleted: true,
-            });
-            throw e;
-        }
+        //}
+        /* XXX This `deleted` field has moved to _Object
+         * Registration_ but in general we are not likely to have
+         * permission to PATCH that. */
+        //catch (e) {
+            //await cdb.put_config(App.Info, uuid, {
+            //    name, deleted: true,
+            //});
+            //throw e;
+        //}
         if (name)
             await cdb.put_config(App.Info, uuid, { name });
         return uuid;
     }
 
-    /* This is of limited use; you can only call it if you have wildcard
-     * Manage_ACL permission. So a root-equivalent administrator. */
-    async get_all_ace () {
-        const [st, aces] = await this.fetch("authz/ace");
-        if (st != 200)
-            this.throw(`Can't read ACEs`, st);
-        return aces;
+    /** List the current permission grants.
+     * The returned list will be filtered and will only include grants
+     * we have permission to edit.
+     * @returns A list of grant UUIDs.
+     */
+    async list_grants () {
+        const [st, uuids] = await this.fetch("v2/grant");
+        if (st == 200) return uuids;
+        this.throw("Can't list grants", st);
     }
 
-    async _edit_ace (spec) {
-        const [st] = await this.fetch({
+    /** Fetch a single grant by UUID.
+     * @param uuid A grant UUID.
+     * @returns A grant object.
+     */
+    async get_grant (uuid) {
+        const [st, grant] = await this.fetch(`v2/grant/${uuid}`);
+        if (st == 200) return grant;
+        this.throw(`Can't read grant ${uuid}`, st);
+    }
+
+    /** Fetch all grants.
+     * Fetches all grants we have access to read. This makes a large
+     * number of HTTP requests and should not be called frequently.
+     * @returns A list of grant objects.
+     */
+    async get_all_grants () {
+        const uuids = this.list_grants();
+        return Promise.all(uuids.map(u => this.get_grant(u)));
+    }
+
+    /** Create a new grant.
+     * @param grant A grant object.
+     * @returns the UUID of the new grant.
+     */
+    async add_grant (grant) {
+        const [st, json] = await this.fetch({
             method:     "POST",
-            url:        "authz/ace",
-            body:       spec,
+            url:        "v2/grant",
+            body:       grant,
         });
-        if (st != 204)
-            this.throw(`Can't ${spec.action} ACE`, st);
+        if (st == 204) return json.uuid;
+        this.throw("Failed to add grant", st);
     }
 
-    /* XXX This is a bad API. These should be HTTP methods rather than a
-     * generic POST request. */
-    async add_ace (principal, permission, target) {
-        await this._edit_ace({
-            action: "add", 
-            principal, permission, target,
-        });
-    }
-
-    async delete_ace (principal, permission, target) {
-        await this._edit_ace({
-            action: "delete",
-            principal, permission, target,
-        });
-    }
-
-    async add_to_group (group, member) {
+    /** Update a grant.
+     * This replaces given grant with a new one.
+     * @param uuid The UUID of the grant to replace.
+     * @param grant The new grant object.
+     */
+    async set_grant (uuid, grant) {
         const [st] = await this.fetch({
             method:     "PUT",
-            url:        `authz/group/${group}/${member}`,
+            url:        `v2/grant/${uuid}`,
+            body:       grant,
         });
-        if (st != 204)
-            this.throw(`Can't add ${member} to group ${group}`, st);
+        if (st == 204) return;
+        this.throw(`Can't update grant ${uuid}`, st);
     }
 
-    async remove_from_group (group, member) {
+    /** Delete a grant.
+     * @param uuid The grant to delete.
+     */
+    async delete_grant (uuid) {
         const [st] = await this.fetch({
             method:     "DELETE",
-            url:        `authz/group/${group}/${member}`,
+            url:        `v2/grant/${uuid}`,
         });
-        if (st != 204)
-            this.throw(`Can't remove ${member} from group ${group}`, st);
+        if (st == 204) return;
+        this.throw(`Can't delete grant ${uuid}`, st);
     }
+
+    /* These are deliberately not implemented; the grant format has
+     * changed and old clients won't set the correct information. */
+    _authv2 () { this.throw("Please update to support Auth v2"); }
+    get_all_ace () { this._authv2(); }
+    add_ace () { this._authv2(); }
+    delete_ace () { this._authv2(); }
+
+    /* XXX These could just forward to the ConfigDB? */
+    add_to_group () { this._authv2(); }
+    remove_from_group () { this._authv2(); }
 }

--- a/lib/js-service-client/lib/service/configdb.js
+++ b/lib/js-service-client/lib/service/configdb.js
@@ -120,12 +120,10 @@ export class ConfigDB extends ServiceInterface {
 
     /* This is currently the recommended way to 'delete' an object. This
      * will NOT delete any config entries, the caller will have to
-     * handle that.
-     *
-     * This flag is advisory and for human consumption only. Don't
-     * attempt to read it from services. */
+     * handle that. This requires permission to PATCH Registration.
+     */
     mark_object_deleted (obj) {
-        return this.patch_config(App.Info, obj, "merge",
+        return this.patch_config(App.Registration, obj, "merge",
             { deleted: true });
     }
 

--- a/lib/js-service-client/lib/sparkplug/util.js
+++ b/lib/js-service-client/lib/sparkplug/util.js
@@ -12,6 +12,12 @@ export class Address {
         this.device = device;
     }
 
+    static from (any) {
+        if (any instanceof Address) return any;
+        if (typeof any == "string") return Address.parse(any);
+        throw new Error("Can't interpret ${any} as an Address");
+    }
+
     static parse (addr) {
         return new Address(...addr.split("/"));
     }

--- a/mk/acs.k8s.mk
+++ b/mk/acs.k8s.mk
@@ -33,7 +33,7 @@ restart:
 	sleep 2
 
 logs:
-	${_kubectl} logs -f ${_cont} ${_dep}
+	${_kubectl} logs --since=5m -f ${_cont} ${_dep}
 
 alllogs:
 	${_kubectl} logs -f --all-containers --ignore-errors ${_dep}


### PR DESCRIPTION
Services which edit the auth information must be updated to use the new APIs.

* Update cluster-manger to the Auth v2 API.
* Change the POST v2/grant endpoint to allow exact duplicates and return 200.
* Create an endpoint to search for grants.
* Adjust ACLs to allow for groups being in the ConfigDB.
* Reenable the ConfigDB MQTT interface, cluster-manager relies on it for now.
* Allow the ConfigDB to start without MQTT, this is now important for bootstrapping.

The cluster-manager no longer has permission to mark objects deleted; this is now a PATCH to the _Registration_ entries and granting that would allow very broad changes. We need a ConfigDB change to allow ACLs to be applied to the individual changes made to the _Registration_ entry, but that is not straighforward to implement.
