### PR TITLE
Fix incorrect acs config name

### DIFF
--- a/acs-service-setup/dumps/service-urls.yaml
+++ b/acs-service-setup/dumps/service-urls.yaml
@@ -17,7 +17,7 @@ advertisements:
     #The Git repository is configured with an external URL. We need to use the appropriate
     #protocol (HTTP/HTTPS) based on whether the application is running in a secure or
     #insecure deployment.
-    url: !url "${PROTOCOL}://git.${BASE_URL}"
+    url: !url "${PROTOCOL}://git.${DOMAIN}"
     device: !u ACS.Device.Git
   - service: !u UUIDs.Service.MQTT
     url: !url "mqtt://mqtt.${NAMESPACE}.svc.cluster.local"

--- a/acs-service-setup/lib/dumps.js
+++ b/acs-service-setup/lib/dumps.js
@@ -28,7 +28,7 @@ export class DumpLoader {
         const acs = opts.acs_config;
         this.url_replacements = {
             NAMESPACE: acs.namespace,
-            BASE_URL: acs.base_url,
+            DOMAIN: acs.domain,
             PROTOCOL: acs.url_protocol,
         };
 

--- a/deploy/templates/service-setup.yaml
+++ b/deploy/templates/service-setup.yaml
@@ -48,7 +48,7 @@ spec:
                 dict
                   "organisation"    .Values.acs.organisation
                   "namespace"       .Release.Namespace
-                  "base_url"        .Values.acs.baseUrl
+                  "domain"          .Values.acs.baseUrl
                   "url_protocol"    (.Values.acs.secure | ternary "https" "http")
                   "realm"           .Values.identity.realm
                   "directory"


### PR DESCRIPTION
"domain" was renamed to "base_url", this caused the edge charts to have an undefined domain. Changing the name back to "domain" fixes the issue.