### PR TITLE
Refactor Metric* imports to come from service-client

### DIFF
--- a/acs-cmdesc/lib/mqttcli.js
+++ b/acs-cmdesc/lib/mqttcli.js
@@ -1,10 +1,9 @@
 /*
- * Factory+ / AMRC Connectivity Stack (ACS) Command Escalation component
- * MQTT client
- * Copyright 2022 AMRC
+ * Copyright (c) University of Sheffield AMRC 2025.
  */
 
-import {Address, MetricBuilder, SpB, Topic, UUIDs} from "@amrc-factoryplus/utilities";
+import { Address, SpB, Topic, UUIDs } from '@amrc-factoryplus/utilities'
+import { MetricBuilder } from '@amrc-factoryplus/service-client'
 
 const Valid = {
     Name: /^[A-Za-z0-9_-]+$/,

--- a/acs-cmdesc/package.json
+++ b/acs-cmdesc/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@amrc-factoryplus/utilities": "2.0.0",
+    "@amrc-factoryplus/service-client": "^1.5.0",
     "@isaacs/ttlcache": "^1.2.0",
     "express": "^4.18.1",
     "express-basic-auth": "^1.2.1",

--- a/acs-configdb/lib/mqttcli.js
+++ b/acs-configdb/lib/mqttcli.js
@@ -1,12 +1,11 @@
 /*
- * Factory+ / AMRC Connectivity Stack (ACS) Config Store component
- * MQTT client connection
- * Copyright 2022 AMRC
+ * Copyright (c) University of Sheffield AMRC 2025.
  */
 
-import {Address, Debug, MetricBuilder, SpB, Topic, UUIDs} from "@amrc-factoryplus/utilities";
+import { Address, Debug, SpB, Topic, UUIDs } from '@amrc-factoryplus/utilities'
+import { MetricBuilder } from '@amrc-factoryplus/service-client'
 
-import {Device_Info, Schema, Service} from "./constants.js";
+import { Device_Info, Schema, Service } from './constants.js'
 
 const Changed = {
     app: "Application",

--- a/acs-configdb/package.json
+++ b/acs-configdb/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@amrc-factoryplus/rx-util": "^0.0.3",
     "@amrc-factoryplus/service-api": "^0.0.2",
+    "@amrc-factoryplus/service-client": "^1.5.0",
     "@amrc-factoryplus/utilities": "2.0.0",
     "ajv": "^8.10.0",
     "ajv-formats": "^2.1.1",

--- a/acs-directory/lib/mqttcli.js
+++ b/acs-directory/lib/mqttcli.js
@@ -1,20 +1,16 @@
 /*
- * Factory+ / AMRC Connectivity Stack (ACS) Directory component service
- * MQTT client connection
- * Copyright 2021 AMRC
+ * Copyright (c) University of Sheffield AMRC 2025.
  */
 
-import timers from "timers/promises";
-import async from "async";
-import Long from "long";
+import timers from 'timers/promises'
+import async from 'async'
+import Long from 'long'
 
-import {
-    Address, Debug, 
-    MetricBranch, MetricBuilder, MetricTree, 
-    SpB, Topic, UUIDs
-} from "@amrc-factoryplus/utilities";
-import { Device_Info } from "./constants.js";
-import { Schema } from "./uuids.js";
+import { Address, SpB, Topic, UUIDs } from '@amrc-factoryplus/utilities'
+import { MetricBranch, MetricBuilder } from '@amrc-factoryplus/service-client'
+
+import { Device_Info } from './constants.js'
+import { Schema } from './uuids.js'
 
 function sym_diff(one, two) {
     const diff = new Set(one);


### PR DESCRIPTION
There were duplicates being exported from v2.0.0 of @amrc-factoryplus/utilities.