### PR TITLE
Add support for loading schemas in service setup

### DIFF
--- a/deploy/templates/service-setup.yaml
+++ b/deploy/templates/service-setup.yaml
@@ -123,6 +123,22 @@ spec:
               name: krb5-conf
             - mountPath: /app/storage/ccache
               name: manager-ccache-storage
+{{ if .Values.acs.schemas.load }}
+        - name: load-schemas
+{{ include "amrc-connectivity-stack.image" (list . .Values.acs.schemas) | indent 10 }}
+          env:
+            - name: DIRECTORY_URL
+              value: http://directory.{{ $.Release.Namespace }}.svc.cluster.local
+            - name: SERVICE_USERNAME
+              value: admin
+            - name: SERVICE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: admin-password
+                  key: password
+            - name: VERBOSE
+              value: ALL,!token,!service
+{{- end -}}
       containers:
         - name: restart-mqtt
           image: bitnami/kubectl:latest

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -31,6 +31,14 @@ acs:
   # The default pullPolicy.
   defaultPullPolicy: IfNotPresent
 
+  # -- Configure which schemas are loaded into the ConfigDB
+  schemas:
+    load: true
+    image:
+      registry: gcr.io
+      repository: amrc-factoryplus/acs-schemas
+      tag: v1.0.0
+
 identity:
   # -- Whether or not to enable the Identity component
   enabled: true


### PR DESCRIPTION
This pull request includes changes to the deployment configuration to support loading schemas into the ConfigDB and to add environment variables for the new container. The most important changes include adding a new container configuration in the `service-setup.yaml` file and updating the `values.yaml` file to include schema loading settings.

### Deployment configuration updates:

* [`deploy/templates/service-setup.yaml`](diffhunk://#diff-9ce0a162b5f64bc5b7f641da3e8ec49cdd2f354d03b6cf8cc8718195a3c95f24R126-R141): Added a new container configuration for loading schemas, including environment variables such as `DIRECTORY_URL`, `SERVICE_USERNAME`, `SERVICE_PASSWORD`, and `VERBOSE`.

* [`deploy/values.yaml`](diffhunk://#diff-c59120ea9e7b09fe13ee02876552a043f9f0c4e058a7155f73bf362a7b1babf7R34-R41): Added settings to configure schema loading into the ConfigDB, including the `load` flag and image details (registry, repository, and tag).