### PR TITLE
Fix YAML syntax in service setup configuration

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - testing/v4
 
 jobs:
   lint:

--- a/deploy/templates/service-setup.yaml
+++ b/deploy/templates/service-setup.yaml
@@ -138,7 +138,7 @@ spec:
                   key: password
             - name: VERBOSE
               value: ALL,!token,!service
-{{- end -}}
+{{ end }}
       containers:
         - name: restart-mqtt
           image: bitnami/kubectl:latest


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow and a Kubernetes YAML template. The most important changes are:

Workflow updates:
* [`.github/workflows/helm-lint.yml`](diffhunk://#diff-fb24acb876b6bfe365bb467eeb6196229cdc85ac6ea056eade9032f4b51e9baeR7): Added the `testing/v4` branch to the list of branches that trigger the `pull_request` event.

Kubernetes template adjustments:
* [`deploy/templates/service-setup.yaml`](diffhunk://#diff-9ce0a162b5f64bc5b7f641da3e8ec49cdd2f354d03b6cf8cc8718195a3c95f24L141-R141): Corrected the syntax by changing `{{- end -}}` to `{{ end }}` in the `VERBOSE` environment variable section.