### PR TITLE
Sort all tables within the Admin Auth UI

### DIFF
--- a/acs-admin/src/pages/AccessControl/Groups/GroupList.vue
+++ b/acs-admin/src/pages/AccessControl/Groups/GroupList.vue
@@ -3,7 +3,7 @@
   -->
 <template>
   <Skeleton v-if="g.loading" v-for="i in 10" class="h-16 rounded-lg mb-2"/>
-  <DataTable v-else :data="g.data" :columns="columns" :filters="[{
+  <DataTable v-else :data="g.data" :default-sort="initialSort" :columns="columns" :filters="[{
         name: 'Name',
         property: 'name',
         options: filterOptions.names
@@ -30,8 +30,6 @@ import { useGroupStore } from '@store/useGroupStore.js'
 import { columns } from './groupListColumns.ts'
 
 export default {
-  name: 'GroupList',
-
   emits: ['rowClick'],
 
   setup () {
@@ -48,6 +46,12 @@ export default {
   },
 
   computed: {
+    initialSort () {
+      return [{
+        id: 'name',
+        desc: false
+      }]
+    },
     filterOptions () {
       return {
         names: this.g.data.map((g) => g.name).filter((v, i, a) => a.indexOf(v) === i).map((g) => {

--- a/acs-admin/src/pages/AccessControl/Groups/MembersTab.vue
+++ b/acs-admin/src/pages/AccessControl/Groups/MembersTab.vue
@@ -4,7 +4,7 @@
 
 <template>
   <Skeleton v-if="g.loading || ps.loading || p.loading || loading" v-for="i in 10" class="h-16 rounded-lg mb-2"/>
-  <DataTable v-else :data="this.members" :columns="columns" :filters="[]" @row-click="e => $emit('objectClick', e)">
+  <DataTable v-else :data="this.members" :default-sort="initialSort" :columns="columns" :filters="[]" @row-click="e => $emit('objectClick', e)">
     <template #toolbar-left>
       <Alert class="mr-6">
         <div class="flex items-start gap-3">
@@ -83,6 +83,12 @@ export default {
   },
 
   computed: {
+    initialSort () {
+      return [{
+        id: 'name',
+        desc: false
+      }]
+    },
     memberUuids () {
       if (this.g.loading || this.loading) {
         return []

--- a/acs-admin/src/pages/AccessControl/Groups/PermissionsTab.vue
+++ b/acs-admin/src/pages/AccessControl/Groups/PermissionsTab.vue
@@ -4,8 +4,7 @@
 
 <template>
   <Skeleton v-if="p.loading || grants.loading || loading" v-for="i in 10" class="h-16 rounded-lg mb-2"/>
-<!--  <DataTable v-else :data="this.permissions" :columns="columns" :filters="[]" @row-click="e => $emit('objectClick', e)">-->
-  <DataTable v-else :data="this.permissions" :columns="columns" :filters="[]">
+  <DataTable v-else :data="this.permissions" :default-sort="initialSort" :columns="columns" :filters="[]">
     <template #toolbar-left>
       <Alert class="mr-6">
         <div class="flex items-start gap-3">
@@ -144,6 +143,12 @@ export default {
   },
 
   computed: {
+    initialSort () {
+      return [{
+        id: 'permission',
+        desc: false
+      }]
+    },
     permissions () {
       this.loading = true
 

--- a/acs-admin/src/pages/AccessControl/Permissions/EntriesDropdown.vue
+++ b/acs-admin/src/pages/AccessControl/Permissions/EntriesDropdown.vue
@@ -4,7 +4,7 @@
 
 <script setup lang="ts">
 import type {Row} from '@tanstack/vue-table'
-import type {Permission} from './principalsColumns'
+import type {Permission} from './entriesColumns'
 
 import {Button} from '@/components/ui/button'
 import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger, DropdownMenuGroup} from '@/components/ui/dropdown-menu'

--- a/acs-admin/src/pages/AccessControl/Permissions/EntriesTab.vue
+++ b/acs-admin/src/pages/AccessControl/Permissions/EntriesTab.vue
@@ -24,7 +24,7 @@
 <script>
 import DataTable from '@components/ui/data-table/DataTable.vue'
 import {Skeleton} from '@components/ui/skeleton/index.js'
-import {columns} from './principalsColumns.ts'
+import {columns} from './entriesColumns.ts'
 import {Alert, AlertDescription, AlertTitle} from '@components/ui/alert/index.js'
 import {useGroupStore} from '@store/useGroupStore.js'
 import {usePrincipalStore} from "@store/usePrincipalStore.js";

--- a/acs-admin/src/pages/AccessControl/Permissions/GroupsTab.vue
+++ b/acs-admin/src/pages/AccessControl/Permissions/GroupsTab.vue
@@ -4,7 +4,7 @@
 
 <template>
   <Skeleton v-if="g.loading || loading" v-for="i in 10" class="h-16 rounded-lg mb-2"/>
-  <DataTable v-else :data="this.groups" :columns="columns" :filters="[]" @row-click="e => $emit('objectClick', e)">
+  <DataTable v-else :data="this.groups" :default-sort="initialSort" :columns="columns" :filters="[]" @row-click="e => $emit('objectClick', e)">
     <template #toolbar-left>
       <Alert class="mr-6">
         <div class="flex items-start gap-3">
@@ -54,6 +54,12 @@ export default {
   },
 
   computed: {
+    initialSort () {
+      return [{
+        id: 'name',
+        desc: false
+      }]
+    },
     groups () {
       if (this.g.loading) {
         return []

--- a/acs-admin/src/pages/AccessControl/Permissions/PermissionList.vue
+++ b/acs-admin/src/pages/AccessControl/Permissions/PermissionList.vue
@@ -3,7 +3,7 @@
   -->
 <template>
   <Skeleton v-if="p.loading" v-for="i in 10" class="h-16 rounded-lg mb-2"/>
-  <DataTable v-else :data="p.data" :columns="columns" :filters="filters" @row-click="e => $emit('rowClick', e)"/>
+  <DataTable v-else :data="p.data" :default-sort="initialSort" :columns="columns" :filters="filters" @row-click="e => $emit('rowClick', e)"/>
 </template>
 
 <script>
@@ -30,7 +30,12 @@ export default {
   },
 
   computed: {
-
+    initialSort () {
+      return [{
+        id: 'name',
+        desc: false
+      }]
+    },
     filters () {
       return [
         {

--- a/acs-admin/src/pages/AccessControl/Permissions/PermissionManagementSidebar.vue
+++ b/acs-admin/src/pages/AccessControl/Permissions/PermissionManagementSidebar.vue
@@ -70,7 +70,7 @@
 <script>
 import { SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@components/ui/sheet/index.js'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import PrincipalsTab from './PrincipalsTab.vue'
+import EntriesTab from './EntriesTab.vue'
 import GroupsTab from "./GroupsTab.vue";
 import {usePermissionStore} from "@store/usePermissionStore.js";
 import Copyable from "@components/Copyable.vue";
@@ -110,7 +110,7 @@ export default {
     TabsList,
     TabsTrigger,
     TabsContent,
-    PrincipalsTab,
+    PrincipalsTab: EntriesTab,
     GroupsTab,
     ObjectSelector: defineAsyncComponent(() => import('@components/ObjectSelector/ObjectSelector.vue')),
   },

--- a/acs-admin/src/pages/AccessControl/Permissions/PrincipalsTab.vue
+++ b/acs-admin/src/pages/AccessControl/Permissions/PrincipalsTab.vue
@@ -4,7 +4,7 @@
 
 <template>
   <Skeleton v-if="g.loading || p.loading || grants.loading || loading" v-for="i in 10" class="h-16 rounded-lg mb-2"/>
-  <DataTable v-else :data="this.entries" :columns="columns" :filters="[]">
+  <DataTable v-else :data="this.entries" :default-sort="initialSort" :columns="columns" :filters="[]">
     <template #toolbar-left>
       <Alert class="mr-6">
         <div class="flex items-start gap-3">
@@ -57,6 +57,12 @@ export default {
   },
 
   computed: {
+    initialSort () {
+      return [{
+        id: 'principal',
+        desc: false
+      }]
+    },
     entries() {
       this.loading = true
 

--- a/acs-admin/src/pages/AccessControl/Permissions/entriesColumns.ts
+++ b/acs-admin/src/pages/AccessControl/Permissions/entriesColumns.ts
@@ -7,7 +7,7 @@ import {h} from 'vue'
 import {Badge} from '@/components/ui/badge'
 
 import DataTableColumnHeader from '@/components/ui/data-table/DataTableColumnHeader.vue'
-import PrincipalDropdown from './PrincipalDropdown.vue'
+import EntriesDropdown from './EntriesDropdown.vue'
 
 export interface Permission {
     uuid: string
@@ -94,5 +94,5 @@ export const columns: ColumnDef<Permission>[] = [
     },
     {
         id: 'actions',
-        cell: ({row}) => h(PrincipalDropdown, {row}),
+        cell: ({row}) => h(EntriesDropdown, {row}),
     }]

--- a/acs-admin/src/pages/AccessControl/Principals/EffectivePermissionsTab.vue
+++ b/acs-admin/src/pages/AccessControl/Principals/EffectivePermissionsTab.vue
@@ -4,8 +4,7 @@
 
 <template>
   <Skeleton v-if="loading" v-for="i in 10" class="h-16 rounded-lg mb-2"/>
-<!--  <DataTable v-else :data="permissions" :columns="columns" :filters="[]" @row-click="e => $emit('objectClick', e)">-->
-  <DataTable v-else :data="permissions" :columns="columns" :filters="[]">
+  <DataTable v-else :data="permissions" :default-sort="initialSort" :columns="columns" :filters="[]">
     <template #toolbar-left>
       <Alert class="mr-6">
         <div class="flex items-start gap-3">
@@ -65,7 +64,17 @@ export default {
     },
   },
 
+  computed: {
+    initialSort() {
+      return [{
+        id: 'permission',
+        desc: false
+      }]
+    },
+  },
+
   watch: {
+    // TODO: When the Auth service has notify implemented, switch this to a computed property
     principal: {
       handler (val) {
         if (val == null) {

--- a/acs-admin/src/pages/AccessControl/Principals/GroupsTab.vue
+++ b/acs-admin/src/pages/AccessControl/Principals/GroupsTab.vue
@@ -4,7 +4,7 @@
 
 <template>
   <Skeleton v-if="g.loading || loading" v-for="i in 10" class="h-16 rounded-lg mb-2"/>
-  <DataTable v-else :data="this.groups" :columns="columns" :filters="[]" @row-click="e => $emit('objectClick', e)">
+  <DataTable v-else :data="this.groups" :default-sort="initialSort" :columns="columns" :filters="[]" @row-click="e => $emit('objectClick', e)">
     <template #toolbar-left>
       <Alert class="mr-6">
         <div class="flex items-start gap-3">
@@ -118,6 +118,12 @@ export default {
   },
 
   computed: {
+    initialSort () {
+      return [{
+        id: 'name',
+        desc: false
+      }]
+    },
     groups () {
       if (this.g.loading) {
         return []

--- a/acs-admin/src/pages/AccessControl/Principals/PermissionsTab.vue
+++ b/acs-admin/src/pages/AccessControl/Principals/PermissionsTab.vue
@@ -4,7 +4,7 @@
 
 <template>
   <Skeleton v-if="p.loading || pr.loading || grants.loading || loading" v-for="i in 10" class="h-16 rounded-lg mb-2"/>
-  <DataTable v-else :data="this.permissions" :columns="columns" :filters="[]">
+  <DataTable v-else :data="this.permissions" :default-sort="initialSort" :columns="columns" :filters="[]">
     <template #toolbar-left>
       <Alert class="mr-6">
         <div class="flex items-start gap-3">
@@ -143,6 +143,12 @@ export default {
   },
 
   computed: {
+    initialSort () {
+      return [{
+        id: 'permission',
+        desc: false
+      }]
+    },
     permissions () {
       this.loading = true
 

--- a/acs-admin/src/pages/AccessControl/Principals/PrincipalList.vue
+++ b/acs-admin/src/pages/AccessControl/Principals/PrincipalList.vue
@@ -3,7 +3,7 @@
   -->
 <template>
   <Skeleton v-if="p.loading" v-for="i in 10" class="h-16 rounded-lg mb-2"/>
-  <DataTable v-else :data="p.data" :columns="columns" :filters="[{
+  <DataTable v-else :data="p.data" :default-sort="initialSort" :columns="columns" :filters="[{
         name: 'Name',
         property: 'name',
         options: filterOptions.names,
@@ -46,7 +46,12 @@ export default {
   },
 
   computed: {
-
+    initialSort () {
+      return [{
+        id: 'name',
+        desc: false
+      }]
+    },
     filterOptions () {
       return {
         names: this.p.data.map((p) => p.name).filter((v, i, a) => a.indexOf(v) === i).map((p) => {


### PR DESCRIPTION
Minor tweaks to provide a base sort so that the UI is predictable to a human eye.

Each table is now sorted by the `name` column, where that exists. Otherwise, it will be sorted by the first column, such as the Permission name.