### PR TITLE
Support notify for direct class relations

### DIFF
--- a/acs-configdb/lib/model.js
+++ b/acs-configdb/lib/model.js
@@ -378,7 +378,6 @@ export default class Model extends EventEmitter {
             return [st, info];
         });
 
-        this.log("OBJECT CREATE: %s", st);
         if (st < 299) {
             this.updates.next({
                 type:   "config",
@@ -386,7 +385,6 @@ export default class Model extends EventEmitter {
                 object: config.uuid,
                 config,
             });
-            this.log("SENDING class UPDATE");
             this.updates.next({ type: "class" });
         }
         return [st, config];
@@ -468,6 +466,7 @@ export default class Model extends EventEmitter {
         for (const app of body)
             this.updates.next({ type: "config", app, object });
         this.updates.next({ type: "config", app: App.Registration, object });
+        this.updates.next({ type: "class" });
         return [st];
     }
 

--- a/acs-configdb/lib/notify.js
+++ b/acs-configdb/lib/notify.js
@@ -245,6 +245,14 @@ export class CDBNotify extends Notify {
                 path:       "v2/class/:class/subclass/",
                 handler:    class_watch.bind(null, "all_subclass"),
             }),
+            new WatchFilter({
+                path:       "v2/class/:class/direct/member/",
+                handler:    class_watch.bind(null, "membership"),
+            }),
+            new WatchFilter({
+                path:       "v2/class/:class/direct/subclass/",
+                handler:    class_watch.bind(null, "subclass"),
+            }),
         ];
     }
     

--- a/lib/js-rx-client/lib/configdb.js
+++ b/lib/js-rx-client/lib/configdb.js
@@ -48,21 +48,33 @@ export class ConfigDB extends Interfaces.ConfigDB {
             rx.distinctUntilChanged(imm.is));
     }
 
+    /* Watch a class relation */
+    _watch_relation (rel) {
+        return rxx.cacheSeq({
+            factory:    klass => this._watch_set(`v2/class/${klass}/${rel}/`),
+            replay:     true,
+        });
+    }
+
     /** Watch the members of a class.
      * @param klass A class UUID.
      */
-    watch_members = rxx.cacheSeq({
-        factory:    klass => this._watch_set(`v2/class/${klass}/member/`),
-        replay:     true,
-    });
+    watch_members = this._watch_relation("member");
 
     /** Watch the subclasses of a class.
      * @param klass A class UUID.
      */
-    watch_subclasses = rxx.cacheSeq({
-        factory:    klass => this._watch_set(`v2/class/${klass}/subclass/`),
-        replay:     true,
-    });
+    watch_subclasses = this._watch_relation("subclass");
+
+    /** Watch the direct members of a class.
+     * @param klass A class UUID.
+     */
+    watch_direct_members = this._watch_relation("direct/member");
+
+    /** Watch the direct subclasses of a class.
+     * @param klass A class UUID.
+     */
+    watch_direct_subclasses = this._watch_relation("direct/subclass");
 
     /** Track the members of a sequence of classes.
      *

--- a/lib/js-rx-client/lib/notify-v2.js
+++ b/lib/js-rx-client/lib/notify-v2.js
@@ -16,6 +16,14 @@ function st_ok (res) {
     return res.status < 300;
 }
 
+class NotifyError extends Error {
+    constructor (status, request) {
+        super("Notify request failed");
+        this.status = status;
+        this.request = request;
+    }
+}
+
 /** Provides access to the `notify/v2` API. */
 export class NotifyV2 {
     /** Build a notify/v2 connection.
@@ -119,14 +127,15 @@ export class NotifyV2 {
                 return rxx.rx(
                     updates,
                     rx.filter(u => u.uuid == uuid),
-                    rx.tap(u => st_ok(u) || u.status == 410
-                        || this.log("Notify error: %s", u.status)),
-                    rx.takeWhile(st_ok),
                     rx.tap({
                         subscribe:      () => send({ ...req, uuid }),
                         unsubscribe:    () => send({ method: "CLOSE", uuid }),
                     }));
-            }));
+            }),
+            rx.takeWhile(u => u.status != 410),
+            rx.tap(u => st_ok(u) || this.log("Notify error: %s", u.status)),
+            rx.mergeMap(u => st_ok(u) ? rx.of(u) 
+                : rx.throwError(() => new NotifyError(u.status, req))));
     }
 
     /** Make a WATCH notify request and return a sequence of the HTTP

--- a/lib/js-rx-util/lib/util.js
+++ b/lib/js-rx-util/lib/util.js
@@ -125,7 +125,9 @@ export function cacheSeq (opts) {
             rx.finalize(() => cache.delete(arg)),
             rx.share({
                 connector,
-                resetOnRefCountZero: () => rx.timer(timeout),
+                resetOnError:           true,           
+                resetOnComplete:        true,
+                resetOnRefCountZero:    () => rx.timer(timeout),
             }));
         cache.set(arg, seq);
         return seq;


### PR DESCRIPTION
* Support notify for `v2/class/:class/direct/*/`.
* Support this in RxClient.
* Fix a bug in RxClient when a notify request returns an error.
* Send a class update when we delete an object.