### PR TITLE
Add generic store

### DIFF
--- a/acs-admin/src/store/useObjectStore.js
+++ b/acs-admin/src/store/useObjectStore.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) University of Sheffield AMRC 2024.
+ * Copyright (c) University of Sheffield AMRC 2025.
  */
 
 import * as imm from "immutable";
@@ -20,8 +20,10 @@ export const useObjectStore = defineStore('object', {
   }),
   actions: {
     async start () {
+
       if (this.rxsub)
-        throw new Error("Object store start() called twice!");
+        // Already started so just return
+        return;
 
       await serviceClientReady();
       const cdb = useServiceClientStore().client.ConfigDB;

--- a/acs-admin/src/store/useStore.js
+++ b/acs-admin/src/store/useStore.js
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) University of Sheffield AMRC 2025.
+ */
+
+import { defineStore } from 'pinia'
+import * as rx from 'rxjs'
+
+import * as rxu from '@amrc-factoryplus/rx-util'
+
+import { useObjectStore } from '@store/useObjectStore.js'
+import { useServiceClientStore } from '@/store/serviceClientStore.js'
+import { serviceClientReady } from '@store/useServiceClientReady.js'
+
+const stores = new Map()
+
+export const useStore = (name, classUUID, appBindings = {}) => {
+  if (stores.has(name)) {
+    return stores.get(name)
+  }
+
+  const store = defineStore(name, {
+    state: () => ({
+      data: [],
+      loading: true,
+      rxsub: null,
+    }),
+    actions: {
+      async start() {
+        this.loading = true
+        await useObjectStore().start()
+        await serviceClientReady()
+
+        const cdb = useServiceClientStore().client.ConfigDB
+        const objectsObservable = useObjectStore().maps
+
+        const uuidsObservable = cdb.watch_members(classUUID)
+
+        // Create observables for each app binding
+        const appObservables = Object.entries(appBindings).reduce((acc, [key, appUUID]) => {
+          acc[key] = cdb.search_app(appUUID)
+          return acc
+        }, {})
+
+        const details = rxu.rx(
+          rx.combineLatest({
+            objects: objectsObservable,
+            uuids: uuidsObservable,
+            ...appObservables,
+          }),
+
+          rx.map((v) => v.uuids.map(uuid => {
+            const baseObj = v.objects.get(uuid, {
+              name: 'UNKNOWN',
+              class: { name: 'UNKNOWN' },
+            })
+
+            // Merge in any bound app data
+            const boundData = Object.entries(appBindings).reduce((acc, [key]) => {
+              acc[key] = v[key].get(baseObj.uuid)
+              return acc
+            }, {})
+
+            return {
+              ...baseObj,
+              ...boundData,
+            }
+          }).toArray())
+        )
+
+        this.rxsub = details.subscribe(cs => {
+          console.log(`${name.toUpperCase()} UPDATE: %o`, cs)
+          this.data = cs
+          this.loading = false
+        })
+      },
+      stop() {
+        this.rxsub?.unsubscribe()
+        this.rxsub = null
+      },
+
+      async storeReady() {
+        await serviceClientReady()
+        while (this.loading) {
+          await new Promise(resolve => setTimeout(resolve, 100))
+        }
+      },
+    },
+  })
+
+  stores.set(name, store)
+  return store
+}


### PR DESCRIPTION
# Generic Store Implementation for Factory+ Admin UI

## Overview
This PR introduces a generic store implementation that replaces our individual store implementations, reducing code duplication and providing a more flexible approach to data binding.

## Key Changes
- Added new `useStore` factory function that creates reusable Pinia stores
- Stores are cached and reused across components
- Configurable class UUID watching
- Support for multiple app bindings with customizable keys
- Maintains all existing functionality of individual stores

## Usage Example
```js
// Old way - individual store implementation for each type
const driverStore = useDriverStore()

// New way - generic store with configuration
const driverStore = useStore(
  'driver',
  UUIDs.Class.EdgeAgentDriver,
  { definition: UUIDs.App.DriverDefinition }
)()
```

## Important Implementation Notes
- Always call the store function with `()` to initialize the Pinia store instance
- Store names must be unique across the application
- Stores are returned instead of recreated if the name matches an existing store