### PR TITLE
Fix Manager Auth Page Refresh

### DIFF
--- a/acs-admin/src/main.js
+++ b/acs-admin/src/main.js
@@ -103,10 +103,10 @@ const router = createRouter({
 
 // Setup auth guard.
 router.beforeEach((to, from, next) => {
-  const s = useServiceClientStore();
-  if(!s.loaded && to.path !== "/login"){
+  const loaded = localStorage.getItem('loaded');
+  if(!loaded && to.path !== "/login"){
     next({path: "/login"})
-  }else if(s.loaded && to.path === "/login"){
+  }else if(loaded && to.path === "/login"){
     next({path: "/"})
   }
   else{

--- a/acs-admin/src/main.js
+++ b/acs-admin/src/main.js
@@ -103,10 +103,10 @@ const router = createRouter({
 
 // Setup auth guard.
 router.beforeEach((to, from, next) => {
-  const loaded = localStorage.getItem('loaded');
-  if(!loaded && to.path !== "/login"){
+  const clientLoaded = localStorage.getItem('clientLoaded');
+  if(!clientLoaded && to.path !== "/login"){
     next({path: "/login"})
-  }else if(loaded && to.path === "/login"){
+  }else if(clientLoaded && to.path === "/login"){
     next({path: "/"})
   }
   else{

--- a/acs-admin/src/store/serviceClientStore.js
+++ b/acs-admin/src/store/serviceClientStore.js
@@ -26,7 +26,7 @@ export const useServiceClientStore = defineStore('service-client', {
         this.urls.MQTT = await client.service_urls(UUIDs.Service.MQTT);
         // save opts to local storage
         localStorage.setItem('opts', JSON.stringify(opts))
-        localStorage.setItem('loaded', JSON.stringify(true));
+        localStorage.setItem('clientLoaded', JSON.stringify(true));
         this.username = opts.username;
         this.client  = client;
         this.loaded = true;
@@ -34,7 +34,7 @@ export const useServiceClientStore = defineStore('service-client', {
         this.baseUrl = import.meta.env.BASEURL;
       }catch (e) {
         this.$reset();
-        localStorage.removeItem('loaded')
+        localStorage.removeItem('clientLoaded')
         throw e;
       }
     },
@@ -42,7 +42,7 @@ export const useServiceClientStore = defineStore('service-client', {
     logout () {
       // Delete the opts local storage item
       localStorage.removeItem('opts');
-      localStorage.removeItem('loaded')
+      localStorage.removeItem('clientLoaded')
       // Reset the local state
       this.$reset();
     },

--- a/acs-admin/src/store/serviceClientStore.js
+++ b/acs-admin/src/store/serviceClientStore.js
@@ -21,26 +21,28 @@ export const useServiceClientStore = defineStore('service-client', {
     async login (opts) {
 
       const client = new RxClient(opts);
-
       // Try an auth lookup to check client authentication.
       try{
         this.urls.MQTT = await client.service_urls(UUIDs.Service.MQTT);
         // save opts to local storage
         localStorage.setItem('opts', JSON.stringify(opts))
-        this.username = opts.username
-        this.client  = client
-        this.loaded  = true
-        this.scheme  = import.meta.env.SCHEME
-        this.baseUrl = import.meta.env.BASEURL
+        localStorage.setItem('loaded', JSON.stringify(true));
+        this.username = opts.username;
+        this.client  = client;
+        this.loaded = true;
+        this.scheme  = import.meta.env.SCHEME;
+        this.baseUrl = import.meta.env.BASEURL;
       }catch (e) {
         this.$reset();
+        localStorage.removeItem('loaded')
         throw e;
       }
     },
 
     logout () {
       // Delete the opts local storage item
-      localStorage.removeItem('opts')
+      localStorage.removeItem('opts');
+      localStorage.removeItem('loaded')
       // Reset the local state
       this.$reset();
     },


### PR DESCRIPTION
The connection state of the client was stored in the Pina state. On page refresh, this state was reset causing a redirect to login because of a race condition between mounted() and router.beforeEach(). The client connection state is now stored in session storage to prevent this. 