### PR TITLE
Manager migration from ConfigDB

### DIFF
--- a/acs-service-setup/lib/manager-devices.js
+++ b/acs-service-setup/lib/manager-devices.js
@@ -1,0 +1,78 @@
+/*
+ * ACS service setup
+ * Migrate Manager edge agent config to devices and connections in the ConfigDB
+ * Copyright 2025 University of Sheffield AMRC
+ */
+
+import {UUIDs} from "@amrc-factoryplus/service-client";
+
+export async function migrate_edge_agent_config(ss) {
+    const {fplus} = ss;
+    const cdb = fplus.ConfigDB;
+    const log = fplus.debug.bound("manager");
+
+    const edgeAgentConfigUUIDs = await cdb.list_configs(UUIDs.App.EdgeAgentConfig);
+    const driverUUIDs = await cdb.list_configs(UUIDs.App.DriverDefinition);
+    const drivers = {};
+    log(JSON.stringify(driverUUIDs));
+    // Find and build driver name lookup.
+    for (const driverUUID of driverUUIDs){
+        const driverInfo = await cdb.get_config(UUIDs.App.Info, driverUUID);
+        drivers[driverInfo.name] = driverUUID;
+    }
+
+    for (const uuid of edgeAgentConfigUUIDs) {
+        const edgeAgentConfig = await cdb.get_config(UUIDs.App.EdgeAgentConfig, uuid);
+        const edgeDeploymentConfig = await cdb.get_config(UUIDs.App.EdgeAgentDeployment, uuid);
+        // TODO: add a check to skip config if it already exists in the new apps
+        for (const connection of edgeAgentConfig.deviceConnections) {
+            const connectionObjectUUID = await cdb.create_object(UUIDs.Class.EdgeAgentConnection);
+            await cdb.put_config(UUIDs.App.Info, connectionObjectUUID, {
+                name: connection.name
+            });
+            // Remove any special characters.
+            const connectionConfigKey = (connection.connType).replace(/[^a-zA-Z0-9]/g, '');
+            // Insert into connection config
+            const connectionConfig = {
+                config: connection[(connectionConfigKey + "ConnDetails")],
+                createdAt: new Date().toISOString(),
+                deployment: {},
+                driver: drivers[connectionConfigKey],
+                edgeAgent: uuid,
+                source: {
+                    payloadFormat: connection.payloadFormat
+                },
+                topology: {
+                    cluster: edgeDeploymentConfig.cluster,
+                    host: edgeDeploymentConfig.hostname,
+                    node: uuid,
+                }
+            }
+            await cdb.put_config(UUIDs.App.ConnectionConfiguration, connectionObjectUUID, connectionConfig);
+            // Migrate device information
+            for (const device of connection.devices){
+                // create object
+                const deviceObjectUUID = await cdb.create_object(UUIDs.Class.Device);
+                // create object information
+                await cdb.put_config(UUIDs.App.Info, deviceObjectUUID, {
+                    name: device.deviceId
+                });
+                // Find the schema uuid tag.
+                const schemaTag = device.tags.find(t => t.Name === "Value/Schema_UUID");
+
+                const deviceInformationPayload = {
+                    connection: connectionObjectUUID,
+                    createdAt: new Date().toISOString(),
+                    node: uuid,
+                    originMap: device.tags,
+                    schema: schemaTag.value,
+                    sparkplugName: device.deviceId,
+                };
+                // Insert the config.
+                await cdb.put_config(UUIDs.App.DeviceInformation, deviceObjectUUID, deviceInformationPayload);
+            }
+
+        }
+    }
+}
+

--- a/acs-service-setup/lib/manager-devices.js
+++ b/acs-service-setup/lib/manager-devices.js
@@ -21,7 +21,7 @@ export async function migrate_edge_agent_config(ss) {
         log("Nothing to migrate.")
         return;
     }
-
+    log("Migrating Edge Agent Config.")
     const edgeAgentConfigUUIDs = await cdb.list_configs(UUIDs.App.EdgeAgentConfig);
     const driverUUIDs = await cdb.list_configs(UUIDs.App.DriverDefinition);
     const drivers = {};
@@ -36,6 +36,7 @@ export async function migrate_edge_agent_config(ss) {
         const edgeAgentConfig = await cdb.get_config(UUIDs.App.EdgeAgentConfig, uuid);
         const edgeDeploymentConfig = await cdb.get_config(UUIDs.App.EdgeAgentDeployment, uuid);
         for (const connection of edgeAgentConfig.deviceConnections) {
+            log(`Migrating connection ${connection.name}`);
             const connectionObjectUUID = await cdb.create_object(UUIDs.Class.EdgeAgentConnection);
             await cdb.put_config(UUIDs.App.Info, connectionObjectUUID, {
                 name: connection.name
@@ -61,6 +62,7 @@ export async function migrate_edge_agent_config(ss) {
             await cdb.put_config(UUIDs.App.ConnectionConfiguration, connectionObjectUUID, connectionConfig);
             // Migrate device information
             for (const device of connection.devices){
+                log(`Migrating device ${device.deviceId}`);
                 // create object
                 const deviceObjectUUID = await cdb.create_object(UUIDs.Class.Device);
                 // create object information
@@ -102,5 +104,6 @@ export async function migrate_edge_agent_config(ss) {
         timestamp: new Date().toISOString(),
         migrated: true,
     });
+    log("Migration completed.")
 }
 

--- a/acs-service-setup/lib/service-setup.js
+++ b/acs-service-setup/lib/service-setup.js
@@ -10,6 +10,7 @@ import { DumpLoader }           from "./dumps.js";
 import { fixups }               from "./fixups.js";
 import { setup_git_repos }      from "./git-repos.js";
 import { setup_local_uuids }    from "./local-uuids.js";
+import {migrate_edge_agent_config} from "./manager-devices.js";
 
 export class ServiceSetup {
     constructor (opts) {
@@ -54,6 +55,9 @@ export class ServiceSetup {
 
         this.log("Creating shared git repositories");
         await setup_git_repos(this, local);
+
+        this.log("Migrating managed edge agent config");
+        await migrate_edge_agent_config(this);
 
         this.log("Migrating legacy Auth groups");
         await migrate_auth_groups(this);

--- a/lib/js-service-client/lib/uuids.js
+++ b/lib/js-service-client/lib/uuids.js
@@ -17,7 +17,8 @@ export const Class = {
     Special: "ddb132e4-5cdd-49c8-b9b1-2f35879eab6d",
     EdgeCluster: "f24d354d-abc1-4e32-98e1-0667b3e40b61",
     EdgeAgentConnection: "f371cbfc-de3e-11ef-b361-7b31622bc42f",
-    EdgeAgentDriver: "3874e06c-de4a-11ef-a68c-0f1c2d4d555c"
+    EdgeAgentDriver: "3874e06c-de4a-11ef-a68c-0f1c2d4d555c",
+    Private: "eda329ca-4e55-4a92-812d-df74993c47e2",
 };
 
 export const Special = {
@@ -47,7 +48,8 @@ export const App = {
     DriverDefinition: "454e5bec-de4a-11ef-bfea-4bc400f636a5",
     ConnectionConfiguration: "fa8b429c-de3e-11ef-87fd-6382f0eac944",
     SchemaInformation: "32093857-9d29-470e-a897-d2b56d5aa978",
-    Schema: "b16e85fb-53c2-49f9-8d83-cdf6763304ba"
+    Schema: "b16e85fb-53c2-49f9-8d83-cdf6763304ba",
+    ServiceSetup: "5b47881c-b012-4040-945c-eacafca539b2",
 };
 
 export const Schema = {


### PR DESCRIPTION
This addition to service setup splits existing edge agent config into connection configuration and device information. The migration sets inserts the migration status into configDB to prevent the migration running after its initial run. 

- [x]  Implement migration.
- [x] Test migration from v3 to v4. 
- [x]  Remove existing connection config migration. 