### PR TITLE
Fix Monaco editor in acs-admin build

### DIFF
--- a/acs-admin/vite.config.js
+++ b/acs-admin/vite.config.js
@@ -30,6 +30,10 @@ export default defineConfig({
     rollupOptions: {
       treeshake: 'safest'
     },
+    commonjsOptions: {
+      strictRequires: true,
+      transformMixedEsModules: true,
+    },
   },
   optimizeDeps: {
     include: ['buffer'],


### PR DESCRIPTION
For some reason this is not sufficient to make `json-schema-ref-parser` bundle correctly, so we still need the in-tree copy. Probably with more tweaking we could fix this.