### PR TITLE
Fix bug preventing scrolling on the Admin UI

### DIFF
--- a/acs-admin/src/App.vue
+++ b/acs-admin/src/App.vue
@@ -68,7 +68,7 @@
         </div>
       </header>
 
-      <main class="flex flex-col max-h-[calc(100vh-4rem)] lg:gap-4 lg:pt-4 lg:px-4 flex-grow-0">
+      <main class="flex flex-col max-h-[calc(100vh-4rem)] lg:gap-4 lg:pt-4 lg:px-4 flex-grow-0 overflow-y-auto pb-4">
         <NewClusterDialog/>
         <NewNodeDialog/>
         <NewDeviceDialog/>

--- a/acs-admin/src/components/EdgeManager/Devices/OriginMapEditor/OriginMapEditor.vue
+++ b/acs-admin/src/components/EdgeManager/Devices/OriginMapEditor/OriginMapEditor.vue
@@ -6,22 +6,22 @@
   <!-- Wrapper div with fixed height and no scrolling -->
   <div class="w-full overflow-hidden flex-1">
     <SidebarProvider class="overflow-hidden">
-    <Dialog :open="!!newObjectContext" @update:open="(open) => { if (!open) newObjectContext = null }">
-      <DialogContent class="sm:max-w-[425px]">
-        <DialogHeader>
-          <DialogTitle v-if="newObjectContext && newObjectContext.length">
-            Add a new entry to {{ newObjectContext[0].key }}
-          </DialogTitle>
-          <DialogDescription>Create a new item in this section</DialogDescription>
-        </DialogHeader>
-        <NewObjectOverlayForm
-            @create="createObject"
-            @close="newObjectContext = null"
-            v-if="newObjectContext && newObjectContext[newObjectContext.length-1]?.value?.patternProperties"
-            :object-type="newObjectContext && newObjectContext.length ? newObjectContext[0].key : 'Object'"
-            :regex="Object.keys(newObjectContext[newObjectContext.length-1]?.value?.patternProperties || {})[0] || '.*'"></NewObjectOverlayForm>
-      </DialogContent>
-    </Dialog>
+      <Dialog :open="!!newObjectContext" @update:open="(open) => { if (!open) newObjectContext = null }">
+        <DialogContent class="sm:max-w-[425px]">
+          <DialogHeader>
+            <DialogTitle v-if="newObjectContext && newObjectContext.length">
+              Add a new entry to {{ newObjectContext[0].key }}
+            </DialogTitle>
+            <DialogDescription>Create a new item in this section</DialogDescription>
+          </DialogHeader>
+          <NewObjectOverlayForm
+              @create="createObject"
+              @close="newObjectContext = null"
+              v-if="newObjectContext && newObjectContext[newObjectContext.length-1]?.value?.patternProperties"
+              :object-type="newObjectContext && newObjectContext.length ? newObjectContext[0].key : 'Object'"
+              :regex="Object.keys(newObjectContext[newObjectContext.length-1]?.value?.patternProperties || {})[0] || '.*'"></NewObjectOverlayForm>
+        </DialogContent>
+      </Dialog>
       <!-- Sidebar with fixed height and independent scrolling -->
       <Sidebar collapsible="none" class="flex flex-col ml-3 my-3 bg-gray-100/50 border rounded-lg">
         <SidebarContent class="flex flex-col h-auto">

--- a/acs-admin/src/components/EdgeManager/Devices/OriginMapEditor/OriginMapEditor.vue
+++ b/acs-admin/src/components/EdgeManager/Devices/OriginMapEditor/OriginMapEditor.vue
@@ -58,7 +58,7 @@
         <SidebarRail/>
       </Sidebar>
       <!-- Main content with fixed height and independent scrolling -->
-      <SidebarInset class="flex flex-col flex-1 overflow-hidden px-6 pt-4 h-full">
+      <SidebarInset class="flex flex-col flex-1 overflow-auto px-6 py-4 h-full">
         <!-- Fixed header -->
         <header class="flex shrink-0 items-center justify-between gap-2 px-1 mb-3">
             <Breadcrumb>

--- a/acs-admin/src/components/EdgeManager/Devices/OriginMapEditor/OriginMapEditor.vue
+++ b/acs-admin/src/components/EdgeManager/Devices/OriginMapEditor/OriginMapEditor.vue
@@ -41,45 +41,45 @@
                     :show-only-populated="showOnlyPopulated">
                 </SchemaGroup>
               </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
+            </SidebarGroupContent>
+          </SidebarGroup>
           <!-- Save button fixed at the bottom -->
           <Button variant="destructive" :disabled="loading" @click="save()" class="mt-2 shrink-0 m-3">
-          <div v-if="!loading" class="flex items-center justify-center gap-1">
-            <span>Save Changes</span>
-            <i class="fa-sharp fa-solid fa-save ml-2"></i>
-          </div>
-          <div v-else class="flex items-center justify-center gap-1">
-            <span>Saving</span>
-            <i class="fa-sharp fa-solid fa-circle-notch fa-spin ml-2"></i>
-          </div>
-        </Button>
-      </SidebarContent>
-      <SidebarRail/>
-    </Sidebar>
+            <div v-if="!loading" class="flex items-center justify-center gap-1">
+              <span>Save Changes</span>
+              <i class="fa-sharp fa-solid fa-save ml-2"></i>
+            </div>
+            <div v-else class="flex items-center justify-center gap-1">
+              <span>Saving</span>
+              <i class="fa-sharp fa-solid fa-circle-notch fa-spin ml-2"></i>
+            </div>
+          </Button>
+        </SidebarContent>
+        <SidebarRail/>
+      </Sidebar>
       <!-- Main content with fixed height and independent scrolling -->
       <SidebarInset class="flex flex-col flex-1 overflow-hidden px-6 pt-4 h-full">
         <!-- Fixed header -->
-      <header class="flex shrink-0 items-center justify-between gap-2 px-1 mb-3">
-          <Breadcrumb>
-            <BreadcrumbList>
-              <template v-if="selectedMetric">
-                <template v-for="(segment, index) in selectedMetric.path.slice(0, -1)" :key="index">
-                  <BreadcrumbItem class="hidden md:block">
-                    <BreadcrumbLink>
-                      {{segment}}
-                    </BreadcrumbLink>
+        <header class="flex shrink-0 items-center justify-between gap-2 px-1 mb-3">
+            <Breadcrumb>
+              <BreadcrumbList>
+                <template v-if="selectedMetric">
+                  <template v-for="(segment, index) in selectedMetric.path.slice(0, -1)" :key="index">
+                    <BreadcrumbItem class="hidden md:block">
+                      <BreadcrumbLink>
+                        {{segment}}
+                      </BreadcrumbLink>
+                    </BreadcrumbItem>
+                    <BreadcrumbSeparator class="hidden md:block"/>
+                  </template>
+                  <BreadcrumbItem>
+                    <BreadcrumbPage>{{selectedMetric.path.slice(-1)[0]}}</BreadcrumbPage>
                   </BreadcrumbItem>
-                  <BreadcrumbSeparator class="hidden md:block"/>
                 </template>
-                <BreadcrumbItem>
-                  <BreadcrumbPage>{{selectedMetric.path.slice(-1)[0]}}</BreadcrumbPage>
-                </BreadcrumbItem>
-              </template>
-            </BreadcrumbList>
-          </Breadcrumb>
-        <div class="text-xs text-gray-400/90">{{selectedMetric?.model.Documentation}}</div>
-      </header>
+              </BreadcrumbList>
+            </Breadcrumb>
+          <div class="text-xs text-gray-400/90">{{selectedMetric?.model.Documentation}}</div>
+        </header>
         <!-- Scrollable content area -->
         <div class="flex-1 content-scroll">
         <div v-if="selectedMetric">

--- a/acs-admin/src/pages/EdgeManager/Devices/Device.vue
+++ b/acs-admin/src/pages/EdgeManager/Devices/Device.vue
@@ -65,74 +65,76 @@
       </div>
 
       <!-- Sidebar -->
-      <div class="w-96 border-l border-border hidden xl:block">
-        <div class="flex items-center justify-start gap-2 p-4 border-b">
-          <i :class="`fa-fw fa-solid fa-microchip`"></i>
-          <div class="font-semibold text-xl">{{device.name}}</div>
-        </div>
-        <div class="space-y-4 p-4">
-          <SidebarDetail
-              icon="fas fa-key"
-              label="Device UUID"
-              :value="device.uuid"
-          />
-          <SidebarDetail
-              icon="fas fa-bolt-lightning"
-              label="Sparkplug Device ID"
-              :value="device.deviceInformation.sparkplugName"
-          />
-          <SidebarDetail
-              v-if="device.createdAt"
-              :title="device.createdAt"
-              icon="clock"
-              label="Created"
-              :value="moment(device.createdAt).fromNow()"
-          />
-        </div>
-        <!-- Schema section -->
-        <div class="flex items-center justify-between gap-2 p-4 border-b">
-          <div class="font-semibold text-lg">Schema</div>
-          <Button
-              v-if="device.deviceInformation?.schema"
-              @click="changeSchema"
-              size="sm"
-              variant="ghost"
-              class="flex items-center justify-center gap-2"
-          >
+      <div class="w-96 border-l border-border hidden xl:block overflow-y-auto">
+        <div>
+          <div class="flex items-center justify-start gap-2 p-4 border-b">
+            <i :class="`fa-fw fa-solid fa-microchip`"></i>
+            <div class="font-semibold text-xl">{{device.name}}</div>
+          </div>
+          <div class="space-y-4 p-4">
+            <SidebarDetail
+                icon="fas fa-key"
+                label="Device UUID"
+                :value="device.uuid"
+            />
+            <SidebarDetail
+                icon="fas fa-bolt-lightning"
+                label="Sparkplug Device ID"
+                :value="device.deviceInformation.sparkplugName"
+            />
+            <SidebarDetail
+                v-if="device.createdAt"
+                :title="device.createdAt"
+                icon="clock"
+                label="Created"
+                :value="moment(device.createdAt).fromNow()"
+            />
+          </div>
+          <!-- Schema section -->
+          <div class="flex items-center justify-between gap-2 p-4 border-b">
+            <div class="font-semibold text-lg">Schema</div>
+            <Button
+                v-if="device.deviceInformation?.schema"
+                @click="changeSchema"
+                size="sm"
+                variant="ghost"
+                class="flex items-center justify-center gap-2"
+            >
               <i class="fa-solid fa-sync text-sm"></i>
-          </Button>
-        </div>
-        <div class="space-y-4 p-4">
-          <SidebarDetail
-              icon="fas fa-code"
-              label="Schema Type"
-              :value="schema?.schemaInformation?.name"
-          />
-          <SidebarDetail
-              icon="fas fa-square-v"
-              label="Schema Version"
-              :value="schema?.schemaInformation?.version"
-          />
-        </div>
-        <!-- Connection section -->
-        <div class="flex items-center justify-between gap-2 p-4 border-b">
-          <div class="font-semibold text-lg">Connection</div>
-          <Button
-              v-if="device.deviceInformation?.connection"
-              @click="changeConnection"
-              size="sm"
-              variant="ghost"
-              class="flex items-center justify-center gap-2"
-          >
+            </Button>
+          </div>
+          <div class="space-y-4 p-4">
+            <SidebarDetail
+                icon="fas fa-code"
+                label="Schema Type"
+                :value="schema?.schemaInformation?.name"
+            />
+            <SidebarDetail
+                icon="fas fa-square-v"
+                label="Schema Version"
+                :value="schema?.schemaInformation?.version"
+            />
+          </div>
+          <!-- Connection section -->
+          <div class="flex items-center justify-between gap-2 p-4 border-b">
+            <div class="font-semibold text-lg">Connection</div>
+            <Button
+                v-if="device.deviceInformation?.connection"
+                @click="changeConnection"
+                size="sm"
+                variant="ghost"
+                class="flex items-center justify-center gap-2"
+            >
               <i class="fa-solid fa-sync text-sm"></i>
-          </Button>
-        </div>
-        <div class="space-y-4 p-4">
-          <SidebarDetail
-              icon="fas fa-plug"
-              label="Connection"
-              :value="connection?.name"
-          />
+            </Button>
+          </div>
+          <div class="space-y-4 p-4">
+            <SidebarDetail
+                icon="fas fa-plug"
+                label="Connection"
+                :value="connection?.name"
+            />
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Minor tweaks within the Admin UI that allow for scrolling on long pages.
There are some whitespace changes (in individual commits) which I included as it helped me locate the right DOM node.

It's basically just a few `overflow-y-auto` added in with some `padding-bottom` to help complete it.