### PR TITLE
Support custom drivers in the Manager

### DIFF
--- a/acs-admin/.dockerignore
+++ b/acs-admin/.dockerignore
@@ -1,3 +1,4 @@
 .env
+bun.lock
 dist
 node_modules

--- a/acs-admin/src/utils/edgeAgentConfigUpdater.js
+++ b/acs-admin/src/utils/edgeAgentConfigUpdater.js
@@ -113,8 +113,9 @@ function processOriginMapObject(obj, path, tags) {
  * @param {Array} deviceConnections - Array of device connection configurations from the Edge Agent config
  * @returns {Promise<void>}
  */
-async function updateEdgeAgentDeployment(nodeUuid, connections, deviceConnections) {
+async function updateEdgeAgentDeployment(nodeUuid, deviceConnections) {
   // Get the stores
+  const connectionStore = useConnectionStore()
   const driverStore = useDriverStore()
   const serviceClientStore = useServiceClientStore()
   const serviceClient = serviceClientStore.client
@@ -149,7 +150,7 @@ async function updateEdgeAgentDeployment(nodeUuid, connections, deviceConnection
     const driverMap = {}
 
     console.debug('Updating edge agent deployment for node:', nodeUuid)
-    console.debug('Connections:', connections)
+    console.debug('Connections:', connectionStore.data)
     console.debug('Device connections:', deviceConnections)
 
     // Process each device connection to find external drivers
@@ -157,8 +158,8 @@ async function updateEdgeAgentDeployment(nodeUuid, connections, deviceConnection
       // Find the corresponding connection in the connection store
       console.debug('Looking for connection matching device connection:', deviceConn.name, 'with uuid:', deviceConn.uuid)
 
-      // The s-s migration will have given every deviceConnections a uuid
-      const connection = connections.find(conn => conn.uuid == deviceConn.uuid)
+      // The s-s migration will have given every deviceConnection a uuid
+      const connection = connectionStore.data.find(conn => conn.uuid === deviceConn.uuid)
       if (!connection) {
         console.debug('No matching connection found for device connection:', deviceConn.name);
         continue;
@@ -529,7 +530,7 @@ export async function updateEdgeAgentConfig({
     await serviceClient.ConfigDB.put_config(UUIDs.App.EdgeAgentConfig, nodeUuid, config)
 
     // Update the Edge Agent Deployment configuration for external drivers
-    await updateEdgeAgentDeployment(nodeUuid, connections, config.deviceConnections)
+    await updateEdgeAgentDeployment(nodeUuid, config.deviceConnections)
   } catch (configErr) {
     console.error('Error updating edge agent config:', configErr)
   }

--- a/acs-admin/src/utils/edgeAgentConfigUpdater.js
+++ b/acs-admin/src/utils/edgeAgentConfigUpdater.js
@@ -155,7 +155,7 @@ async function updateEdgeAgentDeployment(nodeUuid, connections, deviceConnection
     // Process each device connection to find external drivers
     for (const deviceConn of deviceConnections) {
       // Find the corresponding connection in the connection store
-      console.debug('Looking for connection matching device connection:', deviceConn.name, 'with connType:', deviceConn.connType)
+      console.debug('Looking for connection matching device connection:', deviceConn.name, 'with uuid:', deviceConn.uuid)
 
       // The s-s migration will have given every deviceConnections a uuid
       const connection = connections.find(conn => conn.uuid == deviceConn.uuid)

--- a/acs-admin/src/utils/edgeAgentConfigUpdater.js
+++ b/acs-admin/src/utils/edgeAgentConfigUpdater.js
@@ -116,14 +116,13 @@ function processOriginMapObject(obj, path, tags) {
 async function updateEdgeAgentDeployment(nodeUuid, deviceConnections) {
   // Get the stores
   const connectionStore = useConnectionStore()
-  const driverStore = useDriverStore()
   const serviceClientStore = useServiceClientStore()
   const serviceClient = serviceClientStore.client
 
-  // The driver store should already be refreshed by the parent function, but let's make sure
-  if (!driverStore.ready) {
+  // The store should already be refreshed by the parent function, but let's make sure
+  if (!connectionStore.ready) {
     console.debug('Driver store not ready, waiting...')
-    await storeReady(driverStore)
+    await storeReady(connectionStore)
   }
   try {
 
@@ -166,26 +165,17 @@ async function updateEdgeAgentDeployment(nodeUuid, deviceConnections) {
       }
       console.debug('Found matching connection:', connection.name)
 
-      // Check if driver is a UUID that points to a driver definition
-      const driverUuid = connection.configuration?.driver;
-      if (!driverUuid) {
-        console.debug('No driver for connection:', deviceConn.name);
-        continue;
-      }
-      console.debug('Found driver UUID:', driverUuid);
-
-      // Look up the driver definition in the driver store
-      const driverDef = driverStore.data.find(d => d.uuid === driverUuid);
-      const image = driverDef?.definition?.image;
+      // Check if we have a driver image definition
+      const image = connection.configuration?.driver?.image;
       if (!image) {
-        console.debug('Driver definition not found in driver store or missing image');
-        console.debug('Driver definition', driverDef);
+        console.debug('Driver image not found in connection store');
+        console.debug('Connection', connection);
         continue;
       }
       console.debug('Found driver image from driver store', image);
 
       driverMap[deviceConn.name] = {
-        ...(connection.deployment ?? {}),
+        ...(connection.configuration.deployment ?? {}),
         image,
       };
     }

--- a/acs-service-setup/dumps/edge.yaml
+++ b/acs-service-setup/dumps/edge.yaml
@@ -463,7 +463,6 @@ configs:
       image:
         registry: ghcr.io/amrc-factoryplus
         repository: edge-bacnet
-        reference: bacnet
       schema:
         properties:
           host:
@@ -489,7 +488,6 @@ configs:
       image:
         registry: ghcr.io/amrc-factoryplus
         repository: edge-modbus
-        reference: modbus
       schema:
         properties:
           host:
@@ -523,7 +521,6 @@ configs:
       image:
         registry: ghcr.io/amrc-factoryplus
         repository: edge-test
-        reference: test
       schema:
         properties: null
         title: Test Connection Details
@@ -541,7 +538,6 @@ configs:
       image:
         registry: ghcr.io/amrc-factoryplus
         repository: edge-tplink-smartplug
-        reference: tplink-smartplug
       schema:
         properties:
           host:

--- a/acs-service-setup/lib/manager-devices.js
+++ b/acs-service-setup/lib/manager-devices.js
@@ -58,7 +58,7 @@ class MigrateAgents {
         const agents = await cdb.class_members(Class.EdgeAgent);
         this.deployments = await Promise.all(
             agents.map(o =>
-                cdb.get_config(App.EdgeDeployment, o)
+                cdb.get_config(Edge.App.Deployment, o)
                     .then(c => [o, c])))
             .then(es => new Map(es));
     }
@@ -160,7 +160,7 @@ class MigrateAgents {
         this.log("Registering connection %s of Edge Agent %s", conn.name, agent);
 
         const cconf = this.connection_config(agent, conn);
-        const cobj = await cdb.create_object(Class.Connection);
+        const cobj = await cdb.create_object(Class.EdgeAgentConnection);
         await cdb.put_config(App.Info, cobj, { name: conn.name });
         await cdb.put_config(App.ConnectionConfiguration, cobj, cconf);
 

--- a/acs-service-setup/lib/manager-devices.js
+++ b/acs-service-setup/lib/manager-devices.js
@@ -4,106 +4,235 @@
  * Copyright 2025 University of Sheffield AMRC
  */
 
+import util from "util";
+
 import {UUIDs} from "@amrc-factoryplus/service-client";
 
-export async function migrate_edge_agent_config(ss) {
+import { ACS, Edge } from "./uuids.js";
 
-    const {fplus} = ss;
-    const cdb = fplus.ConfigDB;
-    const log = fplus.debug.bound("manager");
-    const MIGRATION_OBJECT_UUID = "d0208d04-a17d-4281-94ef-496b9f6aeede";
+const { App, Class } = UUIDs;
+const { Driver } = ACS;
 
-    // Check the migration status.
-    const privateConfig = await cdb.get_config(UUIDs.App.ServiceSetup, MIGRATION_OBJECT_UUID);
-    if(
-        privateConfig && privateConfig.migrated === true
-    ){
-        log("Nothing to migrate.")
-        return;
+/* Stock drivers with image definitions in the edge-agent Helm chart.
+ * This is only for migrating existing deployments so this does not need
+ * to be kept up to date as the Helm chart changes. */
+const StockDriver = new Map([
+    ["bacnet",              Driver.Bacnet],
+    ["modbus",              Driver.Modbus],
+    ["test",                Driver.Test],
+    ["tplink-smartplug",    Driver.TPlinkSmartPlug],
+]);
+
+function image_tag (img) {
+    return util.format("%s/%s:%s",
+        img?.registry ?? "",
+        img?.repository ?? "",
+        img?.tag ?? "");
+}
+
+class MigrateAgents {
+    constructor (ss) {
+        const { fplus } = ss;
+
+        this.cdb = fplus.ConfigDB;
+        this.log = fplus.debug.bound("manager");
     }
-    log("Migrating Edge Agent Config.")
-    const edgeAgentConfigUUIDs = await cdb.list_configs(UUIDs.App.EdgeAgentConfig);
-    const driverUUIDs = await cdb.list_configs(UUIDs.App.DriverDefinition);
-    const drivers = {};
-    log(JSON.stringify(driverUUIDs));
-    // Find and build driver name lookup.
-    for (const driverUUID of driverUUIDs){
-        const driverInfo = await cdb.get_config(UUIDs.App.Info, driverUUID);
-        drivers[driverInfo.name] = driverUUID;
+
+    async run () {
+        await this.fetch_existing_configs();
+        await this.register_drivers();
+        await this.migrate_agents();
+        this.log("Manager migration complete");
     }
 
-    for (const uuid of edgeAgentConfigUUIDs) {
-        const edgeAgentConfig = await cdb.get_config(UUIDs.App.EdgeAgentConfig, uuid);
-        const edgeDeploymentConfig = await cdb.get_config(UUIDs.App.EdgeAgentDeployment, uuid);
-        for (const connection of edgeAgentConfig.deviceConnections) {
-            log(`Migrating connection ${connection.name}`);
-            const connectionObjectUUID = await cdb.create_object(UUIDs.Class.EdgeAgentConnection);
-            await cdb.put_config(UUIDs.App.Info, connectionObjectUUID, {
-                name: connection.name
-            });
-            // Remove any special characters.
-            const connectionConfigKey = (connection.connType).replace(/[^a-zA-Z0-9]/g, '');
-            // Insert into connection config
-            const connectionConfig = {
-                config: connection[(connectionConfigKey + "ConnDetails")],
-                createdAt: new Date().toISOString(),
-                deployment: {},
-                driver: drivers[connectionConfigKey],
-                edgeAgent: uuid,
-                source: {
-                    payloadFormat: connection.payloadFormat
-                },
-                topology: {
-                    cluster: edgeDeploymentConfig.cluster,
-                    host: edgeDeploymentConfig.hostname,
-                    node: uuid,
-                }
-            }
-            await cdb.put_config(UUIDs.App.ConnectionConfiguration, connectionObjectUUID, connectionConfig);
-            // Migrate device information
-            for (const device of connection.devices){
-                log(`Migrating device ${device.deviceId}`);
-                // create object
-                const deviceObjectUUID = await cdb.create_object(UUIDs.Class.Device);
-                // create object information
-                await cdb.put_config(UUIDs.App.Info, deviceObjectUUID, {
-                    name: device.deviceId
-                });
-                // Find the schema uuid tag.
-                const schemaTag = device.tags.find(t => t.Name === "Value/Schema_UUID");
+    async fetch_existing_configs () {
+        const { cdb } = this;
 
-                const deviceInformationPayload = {
-                    connection: connectionObjectUUID,
-                    createdAt: new Date().toISOString(),
-                    node: uuid,
-                    originMap: device.tags,
-                    schema: schemaTag.value,
-                    sparkplugName: device.deviceId,
-                };
-                // Insert the config.
-                await cdb.put_config(UUIDs.App.DeviceInformation, deviceObjectUUID, deviceInformationPayload);
-            }
+        this.log("Fetching existing configs");
 
+        this.eaconfigs = await cdb.get_all_configs(App.EdgeAgentConfig);
+        this.connections = await cdb.get_all_configs(App.ConnectionConfiguration);
+        this.drivers = await cdb.get_all_configs(App.DriverDefinition);
+
+        /* We don't want all Deployments, only the Edge Agents */
+        const agents = await cdb.class_members(Class.EdgeAgent);
+        this.deployments = await Promise.all(
+            agents.map(o =>
+                cdb.get_config(App.EdgeDeployment, o)
+                    .then(c => [o, c])))
+            .then(es => new Map(es));
+    }
+
+    async register_drivers () {
+        const { cdb } = this;
+
+        this.log("Locating/registering Drivers");
+
+        const tags = this.driver_by_image = new Map();
+        const internal = this.internal_drivers = new Map();
+        for (const [uuid, def] of this.drivers.entries()) {
+            if (def.internal) {
+                internal.set(def.internal.connType, [uuid, def.internal.details]);
+                continue;
+            }
+            if (!def.image) continue;
+            const tag = image_tag(def.image);
+            tags.set(tag, uuid);
+        }
+
+        /* Find custom drivers not deployed with ACS. We assume all
+         * these deployments are using some variation on the edge-agent
+         * Helm chart. */
+        for (const dep of this.deployments.values()) {
+            if (!dep?.values?.image)
+                continue;
+            for (const image of Object.values(dep.values.image)) {
+                const tag = image_tag(image);
+                if (tags.has(tag)) continue;
+
+                const name = image.repository ?? "(unknown driver)";
+                const drv = await cdb.create_object(Edge.Class.Driver);
+                await cdb.put_config(App.Info, drv, { name });
+                await cdb.put_config(App.DriverDefinition, drv, { image });
+                tags.set(tag, drv);
+
+                this.log("Registered driver %s as %s", tag, drv);
+            }
         }
     }
 
-    // Set migration status
-    log("Creating required Classes");
-    // Make sure the class exists.
-    await cdb.create_object(UUIDs.Class.Class, UUIDs.Class.Private);
-    await cdb.put_config(UUIDs.App.Info, UUIDs.Class.Private,
-        { name: "Private configuration" });
+    find_driver (conn, values, dvals) {
+        if (conn.connType != "Driver")
+            return this.internal_drivers.get(conn.connType);
 
-    // create an instance of the private class.
-    await cdb.create_object(UUIDs.Class.Private, MIGRATION_OBJECT_UUID);
-    await cdb.put_config(UUIDs.App.Info, MIGRATION_OBJECT_UUID, { name: "Migration Information" });
+        const driver = (() => {
+            const img = dvals?.image;
+            if (!img) return;
 
-    // Insert the migration config.
-    await cdb.put_config(UUIDs.App.ServiceSetup, MIGRATION_OBJECT_UUID, {
-        name: "v4-Migration",
-        timestamp: new Date().toISOString(),
-        migrated: true,
-    });
-    log("Migration completed.")
+            const image = values?.image?.[img];
+            if (!image)
+                return StockDriver.get(img);
+
+            const tag = image_tag(image);
+            return this.driver_by_image.get(tag);
+        })();
+
+        /* Fallback if we can't find deployment info */
+        return [driver ?? Driver.External, "DriverDetails"];
+    }
+
+    async migrate_agents () {
+        const { cdb, connections } = this;
+
+        this.log("Registering Connections");
+
+        for (const [agent, config] of this.eaconfigs.entries()) {
+            let dirty = false;
+            for (const conn of config.deviceConnections) {
+                /* Assume if a connection has a UUID in the config it
+                 * has been wholly migrated. */
+                if (conn.uuid && connections.has(conn.uuid))
+                    continue;
+
+                dirty = true;
+
+                /* XXX This is now the authoritative link between the EA
+                 * and the Connection. This is incorrect; the EA config
+                 * is a generated file and should not include any
+                 * authoritative information. We need some sort of _Edge
+                 * Agent request_ entry from which Deployment and Config
+                 * are both derived. */
+                conn.uuid = await this.register_connection(agent, conn);
+
+                for (const device of conn.devices)
+                    await this.register_device(agent, conn.uuid, device);
+            }
+            if (dirty) {
+                this.log("Updating config for Edge Agent %s", agent);
+                await cdb.put_config(App.EdgeAgentConfig, agent, config);
+            }
+        }
+    }
+
+    async register_connection (agent, conn) {
+        const { cdb } = this;
+
+        this.log("Registering connection %s of Edge Agent %s", conn.name, agent);
+
+        const cconf = this.connection_config(agent, conn);
+        const cobj = await cdb.create_object(Class.Connection);
+        await cdb.put_config(App.Info, cobj, { name: conn.name });
+        await cdb.put_config(App.ConnectionConfiguration, cobj, cconf);
+
+        this.log("Registered as %s", cobj);
+        return cobj;
+    }
+
+    deployment_config (values, dvals) {
+        const ddevs = values?.driverDevices;
+        const dmnts = dvals?.deviceMounts;
+        
+        if (ddevs && dmnts) {
+            const hps = [];
+            for (const [tag, mountPath] of Object.entries(dmnts)) {
+                const hostPath = ddevs[tag];
+                if (!hostPath) continue;
+                hps.push({ hostPath, mountPath });
+            }
+            if (hps.length)
+                dvals.hostPaths = hps;
+        }
+        delete dvals.deviceMounts;
+
+        return dvals;
+    }
+
+    connection_config (edgeAgent, conn) {
+        const dep = this.deployments.get(edgeAgent);
+
+        const values = dep?.values;
+        const dvals = values?.drivers?.[conn.name];
+
+        const [driver, details] = this.find_driver(conn, values, dvals);
+        const deployment = this.deployment_config(values, dvals);
+
+        return {
+            driver, edgeAgent, deployment,
+            createdAt:  new Date().toISOString(),
+            config:     conn[details] ?? {},
+            source:     {
+                payloadFormat:  conn.payloadFormat,
+            },
+            topology:   {
+                cluster:        deployment?.cluster,
+                hostname:       deployment?.hostname,
+            },
+        };
+    }
+
+    async register_device (node, connection, device) {
+        const { cdb } = this;
+
+        this.log("Registering device %s of Edge Agent %s", device.deviceId, node);
+
+        const dobj = await cdb.create_object(Class.Device);
+        await cdb.put_config(App.Info, dobj, { name: device.deviceId });
+        const schemaTag = device.tags.find(t => t.Name === "Schema_UUID");
+
+        const dconf = {
+            connection, node,
+            createdAt:      new Date().toISOString(),
+            originMap:      device.tags,
+            schema:         schemaTag.value,
+            sparkplugName:  device.deviceId,
+        };
+        await cdb.put_config(App.DeviceInformation, dobj, dconf);
+
+        this.log("Registered as %s", dobj);
+    }
+}
+            
+export function migrate_edge_agent_config(ss) {
+    return new MigrateAgents(ss).run();
 }
 

--- a/acs-service-setup/lib/manager-devices.js
+++ b/acs-service-setup/lib/manager-devices.js
@@ -183,6 +183,7 @@ class MigrateAgents {
                 dvals.hostPaths = hps;
         }
         delete dvals.deviceMounts;
+        delete dvals.image;
 
         return dvals;
     }
@@ -204,8 +205,8 @@ class MigrateAgents {
                 payloadFormat:  conn.payloadFormat,
             },
             topology:   {
-                cluster:        deployment?.cluster,
-                hostname:       deployment?.hostname,
+                cluster:        dep?.cluster,
+                hostname:       dep?.hostname,
             },
         };
     }

--- a/edge-helm-charts/charts/edge-agent/templates/_helpers.tpl
+++ b/edge-helm-charts/charts/edge-agent/templates/_helpers.tpl
@@ -15,5 +15,7 @@ imagePullPolicy: {{ $spec.pullPolicy }}
 {{- end }}
 
 {{- define "edge-agent.sanitize-name" -}}
-{{- . | lower | replace " " "-" | replace "_" "-" | regexFind "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*" -}}
+{{- . | lower | replace " " "-" | replace "_" "-" 
+    | regexFind "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
+-}}
 {{- end -}}

--- a/edge-helm-charts/charts/edge-agent/templates/_helpers.tpl
+++ b/edge-helm-charts/charts/edge-agent/templates/_helpers.tpl
@@ -1,21 +1,27 @@
-{{- define "edge-agent.image" -}}
-{{- $root := index . 0 -}}
-{{- $key := index . 1 -}}
-{{- $image := $root.Values.image -}}
-{{- $spec := merge 
-        (ternary (get $image $key) $key (kindIs "string" $key))
-        $image.default
--}}
-image: "{{ $spec.registry }}/{{ $spec.repository }}:{{ $spec.tag }}"
-imagePullPolicy: {{ $spec.pullPolicy }}
+{{- define "edge-agent._image" -}}
+image: "{{ .registry }}/{{ .repository }}:{{ .tag }}"
+imagePullPolicy: {{ .pullPolicy }}
+{{- end }}
+
+{{- define "edge-agent.image" }}
+    {{- $root := index . 0 }}
+    {{- $image := index . 1 }}
+    {{- $images := $root.Values.image }}
+    {{- if kindIs "string" $image }}
+        {{- include "edge-agent._image" 
+            (merge (get $images $image) $images.default) }}
+    {{- else }}
+        {{- include "edge-agent._image"
+            (merge $image $images.default) }}
+    {{- end }}
 {{- end }}
 
 {{- define "edge-agent.k8sname" }}
-{{- .Values.name | lower | replace "_" "-" }}
+    {{- .Values.name | lower | replace "_" "-" }}
 {{- end }}
 
 {{- define "edge-agent.sanitize-name" -}}
-{{- . | lower | replace " " "-" | replace "_" "-" 
-    | regexFind "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
--}}
+    {{- . | lower | replace " " "-" | replace "_" "-" 
+        | regexFind "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
+    }}
 {{- end -}}

--- a/edge-helm-charts/charts/edge-agent/templates/_helpers.tpl
+++ b/edge-helm-charts/charts/edge-agent/templates/_helpers.tpl
@@ -1,6 +1,6 @@
 {{- define "edge-agent._image" -}}
 image: "{{ .registry }}/{{ .repository }}:{{ .tag }}"
-imagePullPolicy: {{ .pullPolicy }}
+imagePullPolicy: "{{ .pullPolicy }}"
 {{- end }}
 
 {{- define "edge-agent.image" }}
@@ -16,9 +16,9 @@ imagePullPolicy: {{ .pullPolicy }}
     {{- end }}
 {{- end }}
 
+{{/* Grr this wretched language is awful */}}
 {{- define "edge-agent.k8sname" }}
-    {{- . | lower 
-        | regexReplaceAllLiteral "[^-a-z0-9]+" "-"
-        | trimAll "-"
-    }}
+    {{- $lc := . | lower }}
+    {{- $rp := regexReplaceAllLiteral "[^a-z0-9-]+" $lc "-" }}
+    {{- $rp | trimAll "-" }}
 {{- end }}

--- a/edge-helm-charts/charts/edge-agent/templates/_helpers.tpl
+++ b/edge-helm-charts/charts/edge-agent/templates/_helpers.tpl
@@ -2,7 +2,10 @@
 {{- $root := index . 0 -}}
 {{- $key := index . 1 -}}
 {{- $image := $root.Values.image -}}
-{{- $spec := merge (get $image $key) $image.default -}}
+{{- $spec := merge 
+        (ternary (get $image $key) $key (kindIs "string" $key))
+        $image.default
+-}}
 image: "{{ $spec.registry }}/{{ $spec.repository }}:{{ $spec.tag }}"
 imagePullPolicy: {{ $spec.pullPolicy }}
 {{- end }}

--- a/edge-helm-charts/charts/edge-agent/templates/_helpers.tpl
+++ b/edge-helm-charts/charts/edge-agent/templates/_helpers.tpl
@@ -17,11 +17,8 @@ imagePullPolicy: {{ .pullPolicy }}
 {{- end }}
 
 {{- define "edge-agent.k8sname" }}
-    {{- .Values.name | lower | replace "_" "-" }}
-{{- end }}
-
-{{- define "edge-agent.sanitize-name" -}}
-    {{- . | lower | replace " " "-" | replace "_" "-" 
-        | regexFind "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
+    {{- . | lower 
+        | regexReplaceAllLiteral "[^-a-z0-9]+" "-"
+        | trimAll "-"
     }}
-{{- end -}}
+{{- end }}

--- a/edge-helm-charts/charts/edge-agent/templates/edge-agent-key.yaml
+++ b/edge-helm-charts/charts/edge-agent/templates/edge-agent-key.yaml
@@ -1,4 +1,4 @@
-{{- $k8sname := include "edge-agent.k8sname" . }}
+{{- $k8sname := include "edge-agent.k8sname" .Values.name }}
 apiVersion: factoryplus.app.amrc.co.uk/v1
 kind: KerberosKey
 metadata:

--- a/edge-helm-charts/charts/edge-agent/templates/edge-agent.yaml
+++ b/edge-helm-charts/charts/edge-agent/templates/edge-agent.yaml
@@ -1,4 +1,15 @@
 {{- $k8sname := include "edge-agent.k8sname" . }}
+
+{{- $driverMounts := dict "volumes" dict "mounts" dict }}
+{{- range $name, $driver := coalesce .Values.drivers dict }}
+  {{- $_ := set $driverMounts.mounts $name dict }}
+  {{- range $ix, $hp := coalesce $driver.hostPaths list }}
+    {{- $vn := printf "hp-%s-%d" $name $ix }}
+    {{- $_ := set $driverMounts.volumes $vn $hp.hostPath }}
+    {{- $_ := set (get $driverMounts.mounts $name) $vn $hp.mountPoint }}
+  {{- end }}
+{{- end -}}
+
 # This deployment is configured to completely disable Kubernetes
 # back-offs for edge agents. This ensures that when an edge agent fails,
 # it will be restarted immediately without any exponential back-off
@@ -167,12 +178,13 @@ spec:
                   key: "{{ $name }}"
             - name: VERBOSE
               value: "{{ $.Values.verbosity }}"
-    {{- if $driver.deviceMounts }}
+    {{- $hp := get $driverMounts.mounts $name }}
+    {{- if $hp }}
           volumeMounts:
-      {{- range $name, $path := coalesce $driver.deviceMounts dict }}
-            - mountPath: "{{ $path }}"
-              name: "driver-dev-{{ $name }}"
-      {{- end }}
+    {{- end }}
+    {{- range $n, $m := $hp }}
+            - mountPoint: "{{ $m }}"
+              name: "{{ $n }}"
     {{- end }}
   {{- end }}
 {{- end }}
@@ -187,10 +199,10 @@ spec:
           secret:
             optional: true
             secretName: driver-passwords.{{ $k8sname }}
-{{- range $name, $path := coalesce .Values.driverDevices dict }}
-        - name: "driver-dev-{{ $name }}"
+{{- range $n, $p := $driverMounts.volumes }}
+        - name: "{{ $n }}"
           hostPath:
-            path: "{{ $path }}"
+            path: "{{ $p }}"
 {{- end }}
 ---
 apiVersion: factoryplus.app.amrc.co.uk/v1

--- a/edge-helm-charts/charts/edge-agent/templates/edge-agent.yaml
+++ b/edge-helm-charts/charts/edge-agent/templates/edge-agent.yaml
@@ -6,7 +6,7 @@
   {{- range $ix, $hp := coalesce $driver.hostPaths list }}
     {{- $vn := printf "hp-%s-%d" (include "edge-agent.k8sname" $name) $ix }}
     {{- $_ := set $driverMounts.volumes $vn $hp.hostPath }}
-    {{- $_ := set (get $driverMounts.mounts $name) $vn $hp.mountPoint }}
+    {{- $_ := set (get $driverMounts.mounts $name) $vn $hp.mountPath }}
   {{- end }}
 {{- end -}}
 
@@ -183,7 +183,7 @@ spec:
           volumeMounts:
     {{- end }}
     {{- range $n, $m := $hp }}
-            - mountPoint: "{{ $m }}"
+            - mountPath: "{{ $m }}"
               name: "{{ $n }}"
     {{- end }}
   {{- end }}

--- a/edge-helm-charts/charts/edge-agent/templates/edge-agent.yaml
+++ b/edge-helm-charts/charts/edge-agent/templates/edge-agent.yaml
@@ -1,10 +1,10 @@
-{{- $k8sname := include "edge-agent.k8sname" . }}
+{{- $k8sname := include "edge-agent.k8sname" .Values.name }}
 
 {{- $driverMounts := dict "volumes" dict "mounts" dict }}
 {{- range $name, $driver := coalesce .Values.drivers dict }}
   {{- $_ := set $driverMounts.mounts $name dict }}
   {{- range $ix, $hp := coalesce $driver.hostPaths list }}
-    {{- $vn := printf "hp-%s-%d" $name $ix }}
+    {{- $vn := printf "hp-%s-%d" (include "edge-agent.k8sname" $name) $ix }}
     {{- $_ := set $driverMounts.volumes $vn $hp.hostPath }}
     {{- $_ := set (get $driverMounts.mounts $name) $vn $hp.mountPoint }}
   {{- end }}

--- a/edge-helm-charts/charts/edge-agent/templates/local-secrets.yaml
+++ b/edge-helm-charts/charts/edge-agent/templates/local-secrets.yaml
@@ -1,14 +1,15 @@
-{{- $k8sname := include "edge-agent.k8sname" . }}
+{{- $k8sname := include "edge-agent.k8sname" .Values.name }}
+{{- $secret := printf "driver-passwords.%s" $k8sname }}
 {{ range $name, $image := .Values.drivers }}
 ---
 apiVersion: factoryplus.app.amrc.co.uk/v1
 kind: LocalSecret
 metadata:
   namespace: {{ $.Release.Namespace }}
-  name: "driver-passwords.{{ $k8sname }}.{{ include "edge-agent.sanitize-name" $name }}"
+  name: "{{ $secret }}.{{ include "edge-agent.k8sname" $name }}"
 spec:
   format: Password
-  secret: "driver-passwords.{{ $k8sname }}"
+  secret: "{{ $secret }}"
   key: "{{ $name }}"
 {{- end }}
 {{- if .Values.driverDebugUser }}
@@ -17,9 +18,9 @@ apiVersion: factoryplus.app.amrc.co.uk/v1
 kind: LocalSecret
 metadata:
   namespace: {{ $.Release.Namespace }}
-  name: "driver-passwords.{{ $k8sname }}.{{ include "edge-agent.sanitize-name" .Values.driverDebugUser }}"
+  name: "{{ $secret }}.{{ include "edge-agent.k8sname" .Values.driverDebugUser }}"
 spec:
   format: Password
-  secret: "driver-passwords.{{ $k8sname }}"
+  secret: "{{ $secret }}"
   key: "{{ .Values.driverDebugUser }}"
 {{- end }}

--- a/edge-helm-charts/charts/edge-agent/templates/service.yaml
+++ b/edge-helm-charts/charts/edge-agent/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- $k8sname := include "edge-agent.k8sname" . }}
+{{- $k8sname := include "edge-agent.k8sname" .Values.name }}
 {{- if .Values.externalIPs }}
 apiVersion: v1
 kind: Service

--- a/edge-helm-charts/charts/edge-agent/values.yaml
+++ b/edge-helm-charts/charts/edge-agent/values.yaml
@@ -1,9 +1,9 @@
 image:
   # Default image parameters. These can be overidden per-image.
   default:
-    registry: %%REGISTRY%%
-    tag: %%TAG%%
-    pullPolicy: %%PULLPOLICY%%
+    registry: "%%REGISTRY%%"
+    tag: "%%TAG%%"
+    pullPolicy: "%%PULLPOLICY%%"
   # Edge Agent image to pull
   edgeAgent:
     repository: acs-edge

--- a/edge-helm-charts/charts/edge-agent/values.yaml
+++ b/edge-helm-charts/charts/edge-agent/values.yaml
@@ -38,7 +38,7 @@ drivers: {}
     # A list of host paths to mount into the driver container.
     #hostPaths:
     #  - hostPath: /dev/ttyUSB0
-    #    mountPoint: /dev/arduino
+    #    mountPath: /dev/arduino
 
 # Make the driver interface available externally.
 #externalIPs: []

--- a/edge-helm-charts/charts/edge-agent/values.yaml
+++ b/edge-helm-charts/charts/edge-agent/values.yaml
@@ -23,20 +23,22 @@ drivers: {}
   #Test:
     # An image name from the image list above.
     #image: test
+
+    # OR: a full image specification, with defaults from image.default.
+    #image:
+    #  repository: edge-test
+
     # OR: this driver is deployed externally
     #external: false
+
     # Run this driver as a privileged container. This removes a k8s
     # security feature but is necessary to allow access to hardware.
     #privileged: true
-    # An object mapping mount names from driverDevices to mount points
-    # in the driver container.
-    #deviceMounts:
-      #arduino: /dev/arduino
 
-# Host paths which may be mounted into drivers. This is to make host
-# devices available inside the driver containers.
-#driverDevices:
-  #arduino: /dev/ttyUSB0
+    # A list of host paths to mount into the driver container.
+    #hostPaths:
+    #  - hostPath: /dev/ttyUSB0
+    #    mountPoint: /dev/arduino
 
 # Make the driver interface available externally.
 #externalIPs: []

--- a/lib/js-service-client/lib/service/configdb.js
+++ b/lib/js-service-client/lib/service/configdb.js
@@ -121,6 +121,18 @@ export class ConfigDB extends ServiceInterface {
         return json;
     }
 
+    /** Get all configs for an application.
+     * @arg app The application UUID
+     * @returns A Map from UUID to config entry
+     */
+    async get_all_configs (app) {
+        const objs = await this.list_configs(app);
+        return Promise.all(objs.map(o => 
+                this.get_config(app, o)
+                    .then(c => [o, c])))
+            .then(es => new Map(es));
+    }
+
     /** Create a new object.
      *
      * The class named here will be set as the primary class of the new


### PR DESCRIPTION
The Manager migration code was not correctly supporting custom drivers.

In the `edge-agent` Helm chart:
* Allow drivers to specify a full image reference explicitly.
* Move hostPath mount information entirely under the `drivers` property.

In the service-setup step:
* Locate and register and custom driver images already deployed.
* Include Connection UUIDs in the Edge Agent config.
* Map connTypes to drivers using the registration information rather than making assumptions about naming.
* Update Deployment `values` to be compatible with the updated Helm chart.

In the Manager code itself:
* Include Connection UUIDs in the Edge Agent config.
* Deploy drivers using full image specs rather than image references.
* Include the `deployment` information from the driver registration.
* When recreating a Deployment, include all Connections.

Remove the `reference` property from the driver registrations altogether as it's now redundant.