### PR TITLE
Fix sealed secret Content-Type

### DIFF
--- a/acs-admin/Makefile
+++ b/acs-admin/Makefile
@@ -4,4 +4,4 @@ include ${top}/mk/acs.init.mk
 repo?=acs-admin
 k8s.deployment?=admin
 
-include ${mk}/acs.js.mk
+include ${mk}/acs.docker.mk

--- a/acs-admin/src/components/EdgeManager/Connections/NewConnectionDialog.vue
+++ b/acs-admin/src/components/EdgeManager/Connections/NewConnectionDialog.vue
@@ -429,8 +429,10 @@ export default {
         // url: `v1/cluster/${this.node.cluster}/secret/${this.node.namespace}/edge-agent-sensitive-information-${this.node.uuid}/${key}`,
         url: `v1/cluster/${cluster}/secret/${namespace}/${name}/${key}`,
         method: 'PUT',
-        contentType: 'application/octet-stream',
-        body: value
+        body: value,
+        headers: {
+          'Content-Type': 'application/octet-stream',
+        },
       })
 
       return key


### PR DESCRIPTION
This pull request includes updates to `acs-admin`, focusing on build configuration and API request handling. The most notable changes involve switching to a different makefile for Docker builds and modifying HTTP request headers in the `NewConnectionDialog` component.

### Build configuration updates:
* [`acs-admin/Makefile`](diffhunk://#diff-a1524d6df5de19432e44ba241fd422dc99921c343ee7c2904d4a48e12f5896dfL7-R7): Replaced the inclusion of `acs.js.mk` with `acs.docker.mk` as the admin app uses `bun` and doesn't make use of the local build at all (and it was erroring).

### API request handling improvements:
* [`acs-admin/src/components/EdgeManager/Connections/NewConnectionDialog.vue`](diffhunk://#diff-8057c0cf5be2e3aaab1b826d5bf4d7d9801bcfa16bf23eff8bce8390d6a94c23L432-R435): Updated the HTTP request configuration to move the `Content-Type` definition from the non-existing `contentType` property to the `headers` object.