### PR TITLE
Fix sealed secret creation

### DIFF
--- a/acs-admin/src/components/EdgeManager/Connections/NewConnectionDialog.vue
+++ b/acs-admin/src/components/EdgeManager/Connections/NewConnectionDialog.vue
@@ -412,11 +412,20 @@ export default {
   },
 
   methods: {
+    random() {
+      if (crypto.randomUUID)
+        return crypto.randomUUID();
+
+      const buf = new Uint8Array(16);
+      crypto.getRandomValues(buf);
+      return buf.toHex();
+    },
+
     async encryptSensitiveInfo(value) {
       if (!this.node) throw new Error('No node selected')
 
       // Generate a unique identifier for this sensitive info
-      const key = '__FPSI__' + crypto.randomUUID()
+      const key = '__FPSI__' + this.random()
       const cluster = this.node.cluster;
       const namespace = this.c.data.find(c => c.uuid === cluster)?.namespace;
 

--- a/acs-admin/src/components/EdgeManager/Connections/NewConnectionDialog.vue
+++ b/acs-admin/src/components/EdgeManager/Connections/NewConnectionDialog.vue
@@ -427,7 +427,11 @@ export default {
       // Generate a unique identifier for this sensitive info
       const key = '__FPSI__' + this.random()
       const cluster = this.node.cluster;
-      const namespace = this.c.data.find(c => c.uuid === cluster)?.namespace;
+      const config = this.c.data.find(c => c.uuid === cluster)
+      const namespace = config?.configuration?.namespace;
+
+      console.debug("Node: %o, cluster: %o, config: %o, ns: %o",
+          this.node, cluster, config, namespace);
 
       if (!namespace) throw new Error('No namespace found for cluster')
 

--- a/acs-admin/src/components/EdgeManager/Connections/NewConnectionDialog.vue
+++ b/acs-admin/src/components/EdgeManager/Connections/NewConnectionDialog.vue
@@ -426,7 +426,7 @@ export default {
 
       // Generate a unique identifier for this sensitive info
       const key = '__FPSI__' + this.random()
-      const cluster = this.node.cluster;
+      const cluster = this.node.deployment.cluster;
       const config = this.c.data.find(c => c.uuid === cluster)
       const namespace = config?.configuration?.namespace;
 


### PR DESCRIPTION
* `crypto.randomUUID` is only available in secure contexts.
* Carry through the node store change.