### PR TITLE
More v3→v4 fixes

### DIFF
--- a/acs-admin/src/components/Nav/DeviceList.vue
+++ b/acs-admin/src/components/Nav/DeviceList.vue
@@ -57,7 +57,7 @@ export default {
 
   computed: {
     devices () {
-      return Array.isArray(this.d.data) ? this.d.data.filter(e => e.deviceInformation.node === this.node.uuid) : []
+      return Array.isArray(this.d.data) ? this.d.data.filter(e => e.deviceInformation?.node === this.node.uuid) : []
     },
 
     devicesLoading () {

--- a/acs-admin/src/components/Nav/EdgeBreadcrumbs.vue
+++ b/acs-admin/src/components/Nav/EdgeBreadcrumbs.vue
@@ -129,7 +129,7 @@ export default {
     // ║  Nodes  ║
     // ╚═════════╝
     nodes () {
-      return useNodeStore().data.filter((node) => node.deployment.cluster === this.$route.params.clusteruuid)
+      return useNodeStore().data.filter((node) => node.deployment?.cluster === this.$route.params.clusteruuid)
     },
     currentNode () {
       if (useNodeStore().data instanceof Array) {
@@ -140,7 +140,7 @@ export default {
     // ║  Devices  ║
     // ╚═══════════╝
     devices () {
-      return useDeviceStore().data.filter((device) => device.deviceInformation.node === this.$route.params.nodeuuid)
+      return useDeviceStore().data.filter((device) => device.deviceInformation?.node === this.$route.params.nodeuuid)
     },
     currentDevice () {
       if (useDeviceStore().data instanceof Array) {

--- a/acs-admin/src/components/Nav/NodeList.vue
+++ b/acs-admin/src/components/Nav/NodeList.vue
@@ -72,7 +72,7 @@ export default {
 
   computed: {
     nodes () {
-      return Array.isArray(this.s.data) ? this.s.data.filter(e => e.deployment.cluster === this.cluster.uuid) : []
+      return Array.isArray(this.s.data) ? this.s.data.filter(e => e.deployment?.cluster === this.cluster.uuid) : []
     },
 
   },

--- a/acs-admin/src/pages/EdgeManager/Nodes/Node.vue
+++ b/acs-admin/src/pages/EdgeManager/Nodes/Node.vue
@@ -202,7 +202,7 @@ export default {
     },
 
     cluster() {
-      return this.c.data.find(e => e.uuid === this.node.deployment.cluster)?.name
+      return this.c.data.find(e => e.uuid === this.node.deployment?.cluster)?.name
     },
 
     devices () {

--- a/acs-service-setup/lib/manager-devices.js
+++ b/acs-service-setup/lib/manager-devices.js
@@ -62,13 +62,13 @@ class MigrateAgents {
     }
 
     async register_drivers () {
-        const { cdb } = this;
+        const { cdb, drivers } = this;
 
         this.log("Locating/registering Drivers");
 
         const tags = this.driver_by_image = new Map();
         const internal = this.internal_drivers = new Map();
-        for (const [uuid, def] of this.drivers.entries()) {
+        for (const [uuid, def] of drivers.entries()) {
             if (def.internal) {
                 internal.set(def.internal.connType, [uuid, def.internal.details]);
                 continue;
@@ -92,6 +92,7 @@ class MigrateAgents {
                 const drv = await cdb.create_object(Edge.Class.Driver);
                 await cdb.put_config(App.Info, drv, { name });
                 await cdb.put_config(App.DriverDefinition, drv, { image });
+                drivers.set(drv, { image });
                 tags.set(tag, drv);
 
                 this.log("Registered driver %s as %s", tag, drv);

--- a/deploy/templates/files/files.yaml
+++ b/deploy/templates/files/files.yaml
@@ -93,6 +93,8 @@ apiVersion: v1
 metadata:
   name: files-storage
   namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/resource-policy": keep
   labels:
     component: files
 spec:

--- a/deploy/templates/git/git.yaml
+++ b/deploy/templates/git/git.yaml
@@ -125,6 +125,8 @@ kind: PersistentVolumeClaim
 metadata:
   name: git-storage
   namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/resource-policy": keep
   labels:
     component: git
 spec:

--- a/deploy/templates/identity/kdc.yaml
+++ b/deploy/templates/identity/kdc.yaml
@@ -235,6 +235,8 @@ apiVersion: v1
 metadata:
   name: kdc-storage
   namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/resource-policy": keep
   labels:
     component: kdc
 spec:


### PR DESCRIPTION
* Newly-registered drivers were not available to register connections.
* Admin interface didn't handle unavailable ConfigDB entries gracefully.
* Preserve all our PVCs on uninstall.