### PR TITLE
Fix high memory usage when writing large files

### DIFF
--- a/acs-files/bin/api.js
+++ b/acs-files/bin/api.js
@@ -29,8 +29,7 @@ const api = await new WebAPI({
   http_port: env.PORT,
   max_age: env.CACHE_MAX_AGE,
   routes: routes({
-    auth: fplus.Auth,
-    configDb: fplus.ConfigDB,
+    fplus: fplus,
     uploadPath: uploadPath,
   }),
 }).init();

--- a/acs-files/bin/api.js
+++ b/acs-files/bin/api.js
@@ -29,7 +29,8 @@ const api = await new WebAPI({
   http_port: env.PORT,
   max_age: env.CACHE_MAX_AGE,
   routes: routes({
-    fplus: fplus,
+    auth: fplus.Auth,
+    configDb: fplus.ConfigDB,
     uploadPath: uploadPath,
   }),
 }).init();

--- a/acs-files/bin/api.js
+++ b/acs-files/bin/api.js
@@ -28,7 +28,6 @@ const api = await new WebAPI({
   keytab: env.SERVER_KEYTAB,
   http_port: env.PORT,
   max_age: env.CACHE_MAX_AGE,
-  body_limit: env.BODY_LIMIT,
   routes: routes({
     auth: fplus.Auth,
     configDb: fplus.ConfigDB,

--- a/acs-files/bin/api.js
+++ b/acs-files/bin/api.js
@@ -29,8 +29,6 @@ const api = await new WebAPI({
   http_port: env.PORT,
   max_age: env.CACHE_MAX_AGE,
   body_limit: env.BODY_LIMIT,
-  body_type: 'raw',
-
   routes: routes({
     auth: fplus.Auth,
     configDb: fplus.ConfigDB,

--- a/acs-files/bin/api.js
+++ b/acs-files/bin/api.js
@@ -4,6 +4,7 @@ import { ServiceClient } from '@amrc-factoryplus/service-client';
 import { WebAPI } from '@amrc-factoryplus/service-api';
 import { routes } from '../lib/routes.js';
 import { Version, Service } from '../lib/constants.js';
+import {clean_up} from "../lib/startup.js";
 
 const { env } = process;
 
@@ -12,6 +13,11 @@ const fplus = await new ServiceClient({
 }).init();
 
 const uploadPath = env.FILES_STORAGE;
+
+await clean_up({
+  path : uploadPath,
+  fplus
+});
 
 const api = await new WebAPI({
   ping: {

--- a/acs-files/bin/api.js
+++ b/acs-files/bin/api.js
@@ -35,8 +35,7 @@ const api = await new WebAPI({
   http_port: env.PORT,
   max_age: env.CACHE_MAX_AGE,
   routes: routes({
-    auth: fplus.Auth,
-    configDb: fplus.ConfigDB,
+    fplus,
     uploadPath: uploadPath,
   }),
 }).init();

--- a/acs-files/lib/api-v1.js
+++ b/acs-files/lib/api-v1.js
@@ -107,7 +107,6 @@ export class APIv1 {
     let aborted = false;
 
     req.pipe(file_stream);
-    console.log(`Max file size:${MAX_FILE_SIZE}`);
     req.on('data', (chunk) => {
       total_bytes += chunk.length;
       if (total_bytes > MAX_FILE_SIZE) {
@@ -120,7 +119,6 @@ export class APIv1 {
         fs.unlink(file_path, () => {});
         return;
       }
-
       file_stream.write(chunk);
     });
 

--- a/acs-files/lib/api-v1.js
+++ b/acs-files/lib/api-v1.js
@@ -110,11 +110,8 @@ export class APIv1 {
     }
 
     // check the file object uuid exists.
-    const r = await this.fplus.fetch({
-      service: UUIDs.Service.ConfigDB,
-      url: `v1/class/${file_uuid}`,
-    });
-    if(!r.ok){
+    const exists = await this.configDb.class_has_member(Class.File, file_uuid);
+    if(!exists){
       return res.status(404).json({ message: 'FAILED: File object not found.' });
     }
 
@@ -210,6 +207,7 @@ export class APIv1 {
     write_stream.on('error', (err) => {
       aborted = true;
       fs.unlink(file_path, () => {});
+      fs.unlink(temp_path, () => {});
       return res.status(500).send('Error uploading file: ' + err.message);
     });
   }

--- a/acs-files/lib/api-v1.js
+++ b/acs-files/lib/api-v1.js
@@ -13,9 +13,8 @@ const MAX_FILE_SIZE = parseSize(process.env.BODY_LIMIT || '10GB');
 
 export class APIv1 {
   constructor(opts) {
-    this.configDb = opts.fplus.ConfigDB;
-    this.auth = opts.fplus.Auth;
-    this.fplus = opts.fplus;
+    this.configDb = opts.configDb;
+    this.auth = opts.auth;
     this.uploadPath = opts.uploadPath;
     this.routes = express.Router();
     this.setup_routes();

--- a/acs-files/lib/parseSize.js
+++ b/acs-files/lib/parseSize.js
@@ -1,0 +1,18 @@
+export function parseSize(sizeStr) {
+    if (typeof sizeStr !== 'string') return 0;
+
+    const match = sizeStr.trim().toUpperCase().match(/^(\d+(?:\.\d+)?)(KB|MB|GB|B)?$/);
+    if (!match) throw new Error(`Invalid size format: ${sizeStr}`);
+
+    const value = parseFloat(match[1]);
+    const unit = match[2] || 'B';
+
+    const unitMap = {
+        B: 1,
+        KB: 1024,
+        MB: 1024 ** 2,
+        GB: 1024 ** 3,
+    };
+
+    return value * unitMap[unit];
+}

--- a/acs-files/lib/startup.js
+++ b/acs-files/lib/startup.js
@@ -1,0 +1,48 @@
+import fs from "fs";
+import {App} from "./constants.js";
+import path from 'path';
+/**
+ *
+ * @param opts
+ * @returns {Promise<void>}
+ */
+export async function clean_up(opts) {
+    const uploadPath = opts.path;
+    const fplus = opts.fplus;
+    const log = fplus.debug.bound("clean_up");
+    const exists = await fs.promises.access(uploadPath)
+        .then(() => true, () => false);
+    if (!exists){
+        log("Start path doesn't exist");
+        return;
+    }
+    // search for existing temporary files
+    const files = await fs.promises.readdir(uploadPath);
+    log("Reading files. Found " + files.length + " files...");
+    log(JSON.stringify(files));
+    // check for a file configuration entry
+    for (const file of files){
+        log("Reading " + file);
+        const test = file.match(/^.*\.(temp)$/);
+        log("Result " + JSON.stringify(test));
+        if(!file.match(/^.*\.(temp)$/g)){
+            log("No match found for " + file);
+            continue;
+        }
+        const tempPath = path.resolve(uploadPath, file);
+        const fileUUID = file.split('.')[0];
+        log("file matched regex " + file);
+        log("Getting config entry for file.")
+        const config = await fplus.ConfigDB.get_config(App.Config, fileUUID);
+        // If we have config, the upload succeeded so rename the temporary file.
+        if (config){
+            log("Config found, renaming file.")
+            const newPath = path.resolve(uploadPath, fileUUID)
+            await fs.promises.rename(tempPath, newPath);
+        }else{
+            log("No config found, deleting file.");
+            // If not config has been found, delete the file.
+            await fs.promises.unlink(tempPath);
+        }
+    }
+}

--- a/acs-files/lib/startup.js
+++ b/acs-files/lib/startup.js
@@ -26,7 +26,7 @@ export async function clean_up(opts) {
     // check for a file configuration entry
     for (const file of files){
         log("Checking " + file);
-        if(!file.match(/^.*\.(temp)$/g)){
+        if(!file.match(/^.*\.(temp)$/)){
             continue;
         }
         const tempPath = path.resolve(uploadPath, file);

--- a/acs-files/package-lock.json
+++ b/acs-files/package-lock.json
@@ -13,6 +13,7 @@
         "@amrc-factoryplus/service-client": "file:../lib/js-service-client",
         "@dotenvx/dotenvx": "^1.39.0",
         "express": "^4.21.2",
+        "stream-size": "^0.0.6",
         "uuid": "^11.0.5"
       },
       "devDependencies": {
@@ -1989,6 +1990,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/stream-size": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/stream-size/-/stream-size-0.0.6.tgz",
+      "integrity": "sha512-TZsxxZzKPkiD7fxcKx0Ze9s0+WnGGbX1yWZNoXXmN6YjyEu/62pYkLKo7P627N27BT9kI93ZfZAx38brr/hq+Q==",
+      "license": "MIT"
     },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",

--- a/acs-files/package.json
+++ b/acs-files/package.json
@@ -14,6 +14,7 @@
     "@amrc-factoryplus/service-client": "file:../lib/js-service-client",
     "@dotenvx/dotenvx": "^1.39.0",
     "express": "^4.21.2",
+    "stream-size": "^0.0.6",
     "uuid": "^11.0.5"
   },
   "devDependencies": {

--- a/acs-service-setup/dumps/files.yaml
+++ b/acs-service-setup/dumps/files.yaml
@@ -59,6 +59,8 @@ grants:
   !u Files.Requirement.ServiceAccount:
     !u Auth.Perm.ReadACL:
       !u Files.Perm.All: true
+    !u ConfigDB.Perm.ReadConfig:
+      !u Files.App.Config: false
     !u ConfigDB.Perm.WriteConfig:
       !u Files.App.Config: false
     !u ConfigDB.Perm.ManageObjects:

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -102,7 +102,7 @@ files:
   enabled: true
   image:
     repository: acs-files
-  bodyLimit: 10GB
+  bodyLimit: 500kb
   storage: 20Gi
 
 monitor:

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -102,7 +102,7 @@ files:
   enabled: true
   image:
     repository: acs-files
-  bodyLimit: 500kb
+  bodyLimit: 10GB
   storage: 20Gi
 
 monitor:


### PR DESCRIPTION
ACS File Service used fs.writeFile to write files which buffers them to memory before writing. The file service now uses fs.createWriteStream to write the file to the Kubernetes volume. 

- [x] Add stream writing.
- [x] Add file limit checking.
- [x] Add uuid to file POST response.
- [x] Remove body parsing.
- [x] Increase default file limit.  
- [x] Delete the created file class if the file fails to write to disk.