### PR TITLE
Add Schema_UUID and Instance_UUID tags for all nested objects in edge agent config

### DIFF
--- a/acs-admin/src/utils/edgeAgentConfigUpdater.js
+++ b/acs-admin/src/utils/edgeAgentConfigUpdater.js
@@ -97,8 +97,46 @@ function processOriginMapObject(obj, path, tags) {
             recordToDB: true
           })
         }
+
+        // Add Instance_UUID for this value if it exists
+        if (value.Instance_UUID) {
+          tags.push({
+            Name: `${newPath}/Instance_UUID`,
+            type: 'UUID',
+            method: 'GET',
+            value: value.Instance_UUID,
+            docs: 'A reference to the instance of this object.',
+            recordToDB: true
+          })
+        }
       } else {
         // This is an object, process it recursively
+
+        // First, check if this object has Schema_UUID and Instance_UUID
+        // and add them as tags before processing the rest of the object
+        if (value.Schema_UUID) {
+          tags.push({
+            Name: `${newPath}/Schema_UUID`,
+            type: 'UUID',
+            method: 'GET',
+            value: value.Schema_UUID,
+            docs: 'A reference to the schema used for this object.',
+            recordToDB: true
+          })
+        }
+
+        if (value.Instance_UUID) {
+          tags.push({
+            Name: `${newPath}/Instance_UUID`,
+            type: 'UUID',
+            method: 'GET',
+            value: value.Instance_UUID,
+            docs: 'A reference to the instance of this object.',
+            recordToDB: true
+          })
+        }
+
+        // Then process the rest of the object recursively
         processOriginMapObject(value, newPath, tags)
       }
     }
@@ -226,7 +264,7 @@ export async function updateEdgeAgentConfig({
   // Refresh all stores to ensure we have the latest data
   console.debug('Refreshing stores before updating edge agent config')
 
-  // Synchronise all stores 
+  // Synchronise all stores
   await Promise.all(
     [deviceStore, connectionStore, driverStore]
       .map(s => s.synchronise()))
@@ -249,7 +287,7 @@ export async function updateEdgeAgentConfig({
         return
       }
 
-      connections = connectionStore.data.filter(c => 
+      connections = connectionStore.data.filter(c =>
         c.uuid === devices[0].deviceInformation?.connection)
     }
 
@@ -315,7 +353,7 @@ export async function updateEdgeAgentConfig({
       // We can search by UUID; service-setup will have updated all EA
       // configs to have this uuid property.
       if (config.deviceConnections) {
-        connectionIndex = config.deviceConnections.findIndex(conn => 
+        connectionIndex = config.deviceConnections.findIndex(conn =>
           conn.uuid == connection.uuid);
       }
 

--- a/acs-admin/src/utils/edgeAgentConfigUpdater.js
+++ b/acs-admin/src/utils/edgeAgentConfigUpdater.js
@@ -55,8 +55,32 @@ function createTagsFromOriginMap(originMap) {
 function processOriginMapObject(obj, path, tags) {
   if (!obj || typeof obj !== 'object') return
 
-  // Skip Schema_UUID and Instance_UUID as they're handled separately
+  // Process Schema_UUID and Instance_UUID for the current object level
+  if (obj.Schema_UUID && path) {
+    tags.push({
+      Name: `${path}/Schema_UUID`,
+      type: 'UUID',
+      method: 'GET',
+      value: obj.Schema_UUID,
+      docs: 'A reference to the schema used for this object.',
+      recordToDB: true
+    })
+  }
+
+  if (obj.Instance_UUID && path) {
+    tags.push({
+      Name: `${path}/Instance_UUID`,
+      type: 'UUID',
+      method: 'GET',
+      value: obj.Instance_UUID,
+      docs: 'A reference to the instance of this object.',
+      recordToDB: true
+    })
+  }
+
+  // Process all other properties
   for (const key in obj) {
+    // Skip Schema_UUID and Instance_UUID as we've already handled them above
     if (key === 'Schema_UUID' || key === 'Instance_UUID') continue
 
     const value = obj[key]
@@ -111,32 +135,6 @@ function processOriginMapObject(obj, path, tags) {
         }
       } else {
         // This is an object, process it recursively
-
-        // First, check if this object has Schema_UUID and Instance_UUID
-        // and add them as tags before processing the rest of the object
-        if (value.Schema_UUID) {
-          tags.push({
-            Name: `${newPath}/Schema_UUID`,
-            type: 'UUID',
-            method: 'GET',
-            value: value.Schema_UUID,
-            docs: 'A reference to the schema used for this object.',
-            recordToDB: true
-          })
-        }
-
-        if (value.Instance_UUID) {
-          tags.push({
-            Name: `${newPath}/Instance_UUID`,
-            type: 'UUID',
-            method: 'GET',
-            value: value.Instance_UUID,
-            docs: 'A reference to the instance of this object.',
-            recordToDB: true
-          })
-        }
-
-        // Then process the rest of the object recursively
         processOriginMapObject(value, newPath, tags)
       }
     }


### PR DESCRIPTION
This commit fixes an issue where Schema_UUID and Instance_UUID entries for nested objects in the originMap were not being consistently included in the generated edge agent configuration.

Changes:
- Modified processOriginMapObject in edgeAgentConfigUpdater.js to add Instance_UUID tags for metric objects (with Sparkplug_Type)
- Added handling for both Schema_UUID and Instance_UUID in non-metric nested objects
- Ensures all levels of the originMap hierarchy properly include both Schema_UUID and Instance_UUID in the generated configuration

This ensures that device configurations correctly maintain object identity and type information through both Schema_UUID and Instance_UUID at all levels of nesting, not just at the root level.