### PR TITLE
Add missing protocol option to modbus driver definition

### DIFF
--- a/acs-service-setup/dumps/edge.yaml
+++ b/acs-service-setup/dumps/edge.yaml
@@ -483,7 +483,9 @@ configs:
           icon: "server"
           placeholder: "e.g. 1,holding,0,1"
         path:
-          hidden: true
+          title: "Path"
+          description: "Set this to 0"
+          placeholder: "e.g. 0 (must be set to 0)"
       image:
         repository: edge-modbus
       schema:
@@ -500,6 +502,15 @@ configs:
             type: number
             options:
               order: 2
+          protocol:
+            default: tcp
+            enum:
+              - tcp
+            minLength: 1
+            title: Protocol
+            type: string
+            options:
+              order: 3
         required:
           - host
         title: Modbus Connection Details


### PR DESCRIPTION
This pull request makes updates to the `acs-service-setup/dumps/edge.yaml` file to fix the modbus driver.

### Modbus Driver Definition Changes

* Added path (which must be 0)
* Added the missing `protocol` field with a default value of `tcp`.