### PR TITLE
Fix connection selector

### DIFF
--- a/acs-admin/src/components/EdgeManager/Connections/NewConnectionDialog.vue
+++ b/acs-admin/src/components/EdgeManager/Connections/NewConnectionDialog.vue
@@ -584,8 +584,7 @@ export default {
               },
               topology: {
                 cluster: this.node.cluster,
-                host: this.node.hostname,
-                node: this.node.uuid,
+                hostname: this.node.hostname,
               },
             })
           ])
@@ -627,8 +626,7 @@ export default {
             },
             topology: {
               cluster: this.node.cluster,
-              host: this.node.hostname,
-              node: this.node.uuid,
+              hostname: this.node.hostname,
             },
           }
 

--- a/acs-admin/src/components/EdgeManager/Devices/ChangeConnectionDialog.vue
+++ b/acs-admin/src/components/EdgeManager/Devices/ChangeConnectionDialog.vue
@@ -102,7 +102,7 @@ export default {
 
   computed: {
     nodeConnections() {
-      return this.conn.data.filter(conn => conn.configuration?.topology?.node === this.nodeUuid)
+      return this.conn.data.filter(conn => conn.configuration?.edgeAgent === this.nodeUuid)
     },
   },
 


### PR DESCRIPTION
Make the connection selector use the `edgeAgent` UUID instead of mis-matched topology key from migration/connection creation.