### PR TITLE
Support multiple chart sources for edge helm charts

### DIFF
--- a/deploy/templates/service-setup.yaml
+++ b/deploy/templates/service-setup.yaml
@@ -48,7 +48,7 @@ spec:
                   "secure"          (.Values.acs.secure | ternary "s" "")
                   "realm"           .Values.identity.realm
                   "directory"
-                    (include "amrc-connectivity-stack.external-url" 
+                    (include "amrc-connectivity-stack.external-url"
                       (list . "directory"))
                 | toRawJson | quote }}
           volumeMounts:
@@ -70,6 +70,8 @@ spec:
               value: ALL,!token,!service
             - name: GIT_REPO_PATH
               value: {{ .Values.edgeHelm.repoPath }}
+            - name: CHART_SOURCES
+              value: {{ .Values.edgeHelm.chartSources | toJson | quote }}
 {{ if .Values.acs.schemas.load }}
         - name: load-schemas
 {{ include "amrc-connectivity-stack.image" (list . .Values.acs.schemas) | indent 10 }}

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -149,6 +149,18 @@ edgeHelm:
   image:
     repository: edge-helm-charts
   repoPath: shared/helm
+  # Chart sources configuration
+  chartSources: []
+  # Example chart sources configuration:
+  # chartSources:
+  #   - name: "Custom Charts"
+  #     enabled: true
+  #     url: "https://github.com/example/custom-helm-charts.git"
+  #     branch: "main"
+  #     auth:
+  #       type: "basic"
+  #       username: "username"
+  #       # Password is provided via SOURCE_0_PASSWORD environment variable
 
 mqtt:
   # -- Whether or not to enable the MQTT component
@@ -236,7 +248,7 @@ shell:
     repository: acs-krb-utils
 
 # XXX This should probably be included in acs-krb-utils
-curl: 
+curl:
   image:
     registry: docker.io
     repository: appropriate/curl

--- a/edge-helm-charts/bin/update.js
+++ b/edge-helm-charts/bin/update.js
@@ -1,28 +1,102 @@
 /*
- * AMRC Connectivity Stack Edge Helm charts
- * Script to update an on-prem git repo
- * Copyright 2024 AMRC
+ * Copyright (c) University of Sheffield AMRC 2025.
  */
 
-import fs       from "fs";
+import fs from "fs";
+import path from "path";
 
-import git      from "isomorphic-git";
-import http     from "isomorphic-git/http/node/index.js";
+import git from "isomorphic-git";
+import http from "isomorphic-git/http/node/index.js";
 
 import { ServiceClient } from "@amrc-factoryplus/service-client";
 
 import { GIT_VERSION } from "../lib/git-version.js";
 
-const path = process.env.GIT_REPO_PATH;
+const repoPath = process.env.GIT_REPO_PATH;
+const chartSources = JSON.parse(process.env.CHART_SOURCES || "[]");
 
 const fplus = await new ServiceClient({ env: process.env }).init();
-const repo = await fplus.Git.remote({ path });
+const repo = await fplus.Git.remote({ path: repoPath });
 const princ = await fplus.Auth.find_principal();
 
+const log = fplus.debug.bound("charts");
+log("ACS Edge Helm Charts update rev %s", GIT_VERSION);
+
+// Create merged directory
+const mergedDir = "/tmp/merged-charts";
+fs.mkdirSync(mergedDir, { recursive: true });
+fs.mkdirSync(path.join(mergedDir, "charts"), { recursive: true });
+
+// Always copy the local charts directory first
+log("Copying local charts directory");
+if (fs.existsSync("charts")) {
+    fs.cpSync("charts", path.join(mergedDir, "charts"), { recursive: true });
+} else {
+    log("Warning: Local charts directory not found");
+}
+
+// Process additional chart sources
+for (const [index, source] of chartSources.entries()) {
+    if (!source.enabled) continue;
+
+    log(`Processing chart source: ${source.name}`);
+
+    // Require source URL to be specified
+    if (!source.url) {
+        log(`Error: No URL specified for chart source ${source.name}, skipping`);
+        continue;
+    }
+
+    const sourceUrl = source.url;
+    const sourceBranch = source.branch || "main";
+
+    // Set up auth if provided
+    const auth = {};
+    if (source.auth) {
+        if (source.auth.type === "basic") {
+            const password = process.env[`SOURCE_${index}_PASSWORD`];
+            if (password) {
+                auth.onAuth = () => ({ username: source.auth.username, password });
+            }
+        }
+        // Add other auth types as needed
+    }
+
+    // Clone source to temp directory
+    const sourceDir = `/tmp/source-${index}`;
+    log(`Cloning ${sourceUrl} (${sourceBranch}) to ${sourceDir}`);
+
+    try {
+        await git.clone({
+            fs, http,
+            dir: sourceDir,
+            url: sourceUrl,
+            ref: sourceBranch,
+            depth: 1,
+            ...auth
+        });
+
+        // Copy charts from this source
+        if (fs.existsSync(path.join(sourceDir, "charts"))) {
+            log(`Copying charts from ${source.name}`);
+            fs.cpSync(
+                path.join(sourceDir, "charts"),
+                path.join(mergedDir, "charts"),
+                { recursive: true }
+            );
+        } else {
+            log(`No charts directory found in ${source.name}`);
+        }
+    } catch (error) {
+        log(`Error processing source ${source.name}: ${error.message}`);
+    }
+}
+
+// Now push the merged charts to the internal Git repo
 const opts = {
     fs, http,
     ...repo,
-    dir: "charts",
+    dir: mergedDir,
     remote: "origin",
     author: {
         name: "ACS installer",
@@ -30,45 +104,42 @@ const opts = {
     },
 };
 
-const log = fplus.debug.bound("charts");
-log("ACS Edge Helm Charts update rev %s", GIT_VERSION);
-
-const get_ref = ref => git.resolveRef({...opts, ref})
+const get_ref = ref => git.resolveRef({ ...opts, ref })
     .catch(e => e instanceof git.Errors.NotFoundError
         ? null : Promise.reject(e));
 
-const set_branch = (ref, sha1) => {
-    log("Updating %s branch %s to %s", path, ref, sha1);
-    return git.branch({ ...opts, ref, object: sha1, force: true });
-};
+// Initialize the repo
+await git.init({ ...opts, defaultBranch: "main" });
+await git.addRemote(opts);
 
+// Fetch existing repo
+log("Fetching from %s", repoPath);
+await git.fetch(opts);
+
+// Get existing refs
+const main = await get_ref("origin/main");
+const acs = (await get_ref("origin/acs")) ?? main;
+
+// Add all files and commit
+await git.add({ ...opts, filepath: "." });
+const sha1 = await git.commit({
+    ...opts,
+    ref: "acs",
+    parent: (acs ? [acs] : []),
+    message: "ACS install with merged charts",
+});
+log("Committed %s to branch acs", sha1);
+
+// Push to the repo
 const push_ref = async ref => {
-    log("Pushing branch %s to %s", ref, path);
+    log("Pushing branch %s to %s", ref, repoPath);
     await git.push({ ...opts, ref, remoteRef: ref });
 };
 
-await git.init({...opts, defaultBranch: "main"});
-await git.addRemote(opts);
-
-log("Fetching from %s", path);
-const mirror = await git.fetch(opts);
-
-const main = await get_ref("origin/main");
-const acs = (await get_ref("origin/acs")) ?? main;
-const update = (!main || main == acs);
-
-await git.add({...opts, filepath:"."});
-const sha1 = await git.commit({
-    ...opts,
-    ref:        "acs",
-    parent:     (acs ? [acs] : []),
-    message:    "ACS install",
-});
-log("Committed %s to branch acs", sha1);
 await push_ref("acs");
 
 if (!main || main == acs) {
-    await set_branch("main", "acs");
+    await git.branch({ ...opts, ref: "main", object: "acs", force: true });
     await push_ref("main");
 }
 


### PR DESCRIPTION
This pull request introduces the capability to merge edge Helm charts from multiple Git repository sources, in addition to the local charts.

**Key Changes:**

* **Multiple Chart Source Configuration:**
    * A new `CHART_SOURCES` environment variable is introduced in `deploy/templates/service-setup.yaml` to pass the chart source configuration to the `update.js` script.
    * The `deploy/values.yaml` file now includes a `edgeHelm.chartSources` section, allowing users to define a list of external chart repositories. Each source can be configured with:
        * `name`: A descriptive name.
        * `enabled`: A boolean to enable/disable the source.
        * `url`: The Git repository URL (mandatory).
        * `branch`: The Git branch to use (defaults to "main").
        * `auth`: Authentication details (e.g., "basic" with username, password via `SOURCE_<index>_PASSWORD` environment variable).
* **Chart Merging Logic (in `edge-helm-charts/bin/update.js`):**
    * The `update.js` script now first copies the local charts from the `charts` directory.
    * It then iterates through the configured `chartSources`. For each enabled source with a valid URL:
        * It clones the specified repository and branch.
        * Authentication (currently basic auth) is handled if configured.
        * Charts from the `charts` directory of the external repository are copied into a merged directory.
    * If a chart exists in multiple sources, the version from the last processed source (including local charts as the first source) will take precedence.
    * The script then commits and pushes the contents of this merged directory to the internal Git server.
    * Improved logging and error handling have been added for the chart source processing.
* **Documentation Updates (`edge-helm-charts/README.md`):**
    * The README has been updated to explain the new multiple chart sources feature.
    * It includes an example configuration for `edgeHelm.chartSources`.
    * The chart deployment process section now recommends using this feature for managing custom charts.
* **Minor Adjustments:**
    * The commit message for the automated update now reflects that charts may be merged from multiple sources.
    * Copyright year updated in `update.js`.

**Benefits:**

* **Enhanced Flexibility:** Users can now easily incorporate their own custom Helm charts or charts from third-party repositories without directly modifying the core ACS chart set.
* **Better Modularity:** Promotes a cleaner separation between base ACS charts and user-specific or project-specific charts.
* **Simplified Custom Chart Management:** Simplifies the process of keeping custom charts up-to-date and version-controlled independently.

This change maintains backward compatibility for existing setups that do not use the new chart sources feature.