### PR TITLE
Add support for multiple Helm chart sources in edge deployments

### DIFF
--- a/acs-edge-sync/lib/deployments.js
+++ b/acs-edge-sync/lib/deployments.js
@@ -12,13 +12,18 @@ import template         from "json-templates";
 import { Edge }             from "./uuids.js";
 import { LABELS }           from "./metadata.js";
 
+// Define a record type for Kubernetes resources to help with grouping
 const Resource = imm.Record({ apiVersion: null, kind: null });
 Resource.prototype.toString = function () {
     return `${this.apiVersion}/${this.kind}`;
 };
 
+/**
+ * Base class for reconciling Kubernetes resources
+ * Handles comparing existing resources with desired state and making necessary changes
+ */
 class Reconciliation {
-    constructor (deploy, manifests, resource) {
+    constructor(deploy, manifests, resource) {
         this.deploy = deploy;
         this.manifests = manifests;
         this.resource = resource;
@@ -29,6 +34,7 @@ class Reconciliation {
     async prepare () {
         this.objs = k8s.KubernetesObjectApi.makeApiClient(this.deploy.kc);
 
+        // Helper function to convert a list of resources to a Map keyed by name
         const named = l => (l ?? imm.List())
             .map(m => [m.metadata.name, m])
             .fromEntrySeq().toMap();
@@ -40,6 +46,7 @@ class Reconciliation {
     }
 
     async apply () {
+        // Create or update resources that we want
         for (const [name, man] of this.want) {
             const old = this.have.get(name);
             if (old) {
@@ -75,6 +82,8 @@ class Reconciliation {
                 this.log("Finished create");
             }
         }
+
+        // Delete resources that we no longer want
         for (const [name, man] of this.have) {
             if (this.want.has(name))
                 continue;
@@ -106,6 +115,127 @@ class Reconciliation {
     }
 }
 
+/**
+ * Specialized class for reconciling GitRepository resources
+ * Creates and manages Flux GitRepository resources for Helm chart sources
+ */
+class GitRepoReconciliation {
+    constructor(deploy, sources) {
+        this.deploy = deploy;
+        this.sources = sources; // Map of source name to repo URL
+        this.log = deploy.log;
+    }
+
+    async prepare() {
+        this.objs = k8s.KubernetesObjectApi.makeApiClient(this.deploy.kc);
+
+        // Get existing GitRepository resources with our managed-by label
+        const { response, body } = await this.objs.list(
+            "source.toolkit.fluxcd.io/v1", "GitRepository",
+            this.deploy.namespace,
+            /*pretty*/null, /*exact*/null, /*exportt*/null,
+            /*fieldSelector*/null,
+            /*labelSelector*/`${LABELS.managed}=${LABELS.sync}`,
+        );
+
+        if (response.statusCode != 200)
+            throw `Can't list GitRepositories: ${response.statusCode}`;
+
+        // Convert to a map of name -> resource
+        this.have = imm.Map(body.items.map(m => [m.metadata.name, m]));
+
+        // Create map of desired GitRepository resources
+        this.want = this.createGitRepoResources();
+
+        this.log("Have GitRepos: %o", this.have.toJS());
+        this.log("Want GitRepos: %o", this.want.toJS());
+    }
+
+    /**
+     * Create GitRepository resources for each source
+     * @returns {Map} Map of name -> GitRepository resource
+     */
+    createGitRepoResources() {
+        return imm.Map(this.sources).map((url, name) => ({
+            apiVersion: "source.toolkit.fluxcd.io/v1",
+            kind: "GitRepository",
+            metadata: {
+                name,
+                namespace: this.deploy.namespace,
+                labels: {
+                    [LABELS.managed]: LABELS.sync,
+                }
+            },
+            spec: {
+                interval: "3m",
+                ref: {
+                    branch: "main"
+                },
+                secretRef: {
+                    name: "flux-secrets"
+                },
+                url
+            }
+        }));
+    }
+
+    async apply() {
+        // Create or update resources that we want
+        for (const [name, man] of this.want) {
+            const old = this.have.get(name);
+            if (old) {
+                // Only compare and update the spec
+                if (!deep_equal(old.spec, man.spec)) {
+                    // Create a patch that only updates the spec
+                    const patch = {
+                        apiVersion: "source.toolkit.fluxcd.io/v1",
+                        kind: "GitRepository",
+                        spec: man.spec,
+                        metadata: {
+                            name,
+                            namespace: this.deploy.namespace
+                        }
+                    };
+                    this.log("PATCH GitRepo: %o", patch);
+                    await this.check(this.objs.patch(
+                        patch,
+                        undefined,
+                        undefined,
+                        undefined,
+                        undefined,
+                        { headers: { 'Content-Type': 'application/merge-patch+json' } }
+                    ));
+                    this.log("Finished patch GitRepo");
+                }
+            }
+            else {
+                this.log("CREATE GitRepo: %o", man);
+                const pr = this.objs.create(man);
+                this.log("Create GitRepo promise: %o", pr);
+                await this.check(pr);
+                this.log("Finished create GitRepo");
+            }
+        }
+
+        // Delete resources that we no longer want
+        for (const [name, man] of this.have) {
+            if (this.want.has(name))
+                continue;
+            this.log("DELETE GitRepo: %s", name);
+            await this.check(this.objs.delete(man));
+            this.log("Finished delete GitRepo");
+        }
+    }
+
+    async check(pr) {
+        const { response, body } = await pr;
+        const st = response.statusCode;
+        this.log("K8s status: %s", st);
+        if (st < 200 || st > 299)
+            throw `Can't update GitRepository: ${st}`;
+    }
+}
+
 export class Deployments {
     constructor (opts) {
         this.fplus = opts.fplus;
@@ -126,6 +256,7 @@ export class Deployments {
     }
 
     run () {
+        // Subscribe to manifest changes and reconcile when they change
         this.manifests.subscribe(ms =>
             this.reconcile_manifests(ms));
     }
@@ -137,9 +268,13 @@ export class Deployments {
         /* XXX Also watch our config (app, cluster) and merge onto the
          * global config? */
         return watcher.watch_config(app, app).pipe(
+            // Only emit when the config changes
             rx.distinctUntilChanged(deep_equal),
             rx.map(conf => {
+                // Extract the resource types we need to reconcile
                 const resources = imm.Set(conf.resources.map(r => Resource(r)));
+
+                // Add our namespace and labels to the template
                 const labelled = jmp.merge(conf.template, {
                     metadata: {
                         namespace: this.namespace,
@@ -166,23 +301,30 @@ export class Deployments {
          * Returns an array of individual charts which need to be
          * deployed. */
         const lookup = list => rx.from(list).pipe(
+            // For each deployment UUID, get the deployment config
             rx.mergeMap(agent => cdb.get_config(Deployments, agent)
                 .then(spec => ({ uuid: agent, spec }))),
+            // Extract the chart UUIDs and source from the deployment
             rx.map(dep => {
                 const { spec } = dep;
+                // Extract source field (default to "helm-charts" if not specified)
+                const source = spec.source || "helm-charts";
+                // Handle both single chart and multiple charts
                 const charts =
                     spec.chart ? rx.of(spec.chart) : rx.from(spec.charts);
-                return [dep, charts];
+                return [dep, charts, source];
             }),
-            rx.mergeMap(([deployment, charts]) => charts.pipe(
+            // For each chart UUID, get the chart template and include the source
+            rx.mergeMap(([deployment, charts, source]) => charts.pipe(
                 rx.mergeMap(ch => cdb.get_config(HelmChart, ch)),
                 /* XXX We could cache (against an etag) to avoid
                  * recompiling every time... */
                 rx.map(tmpl => template(tmpl)),
-                rx.map(chart => ({ ...deployment, chart })))),
+                rx.map(chart => ({ ...deployment, chart, source })))),
             rx.toArray(),
         );
 
+        // Watch for deployments targeting this cluster
         return watcher
             .watch_search(Deployments, { cluster: this.cluster })
             .pipe(rx.switchMap(lookup));
@@ -194,6 +336,8 @@ export class Deployments {
             rx.map(opts => ({
                 resources: opts.config.resources,
                 manifests: this.create_manifests(opts),
+                // Pass the original deployments for source extraction
+                deployments: opts.deployments,
             })),
             rx.tap(o => this.log("Resources: %s, Manifests: %o",
                 o.resources.toJS(), o.manifests.toJS())),
@@ -205,7 +349,7 @@ export class Deployments {
     create_manifests ({ config, deployments }) {
         return imm.List(deployments)
             .map(deployment => {
-                const { uuid, spec } = deployment;
+                const { uuid, spec, source } = deployment;
                 const chart = deployment.chart({
                     uuid,
                     name:       spec.name,
@@ -213,19 +357,75 @@ export class Deployments {
                 });
                 const values = [this.values, chart.values, spec.values]
                     .map(v => v ?? {}).reduce(jmp.merge);
+
+                // Include the source in the template data
                 return config.template({
                     uuid, values,
                     chart:  chart.chart,
+                    source: source || "helm-charts", // Default to helm-charts if not specified
                 });
             })
             .groupBy(Resource);
     }
 
-    async reconcile_manifests ({ resources, manifests }) {
+    /**
+     * Collect all unique sources from deployments and look up their repository URLs
+     * Only collects sources that are explicitly specified in the deployment entries
+     * @param {Array} deployments - List of deployment objects
+     * @returns {Promise<Object>} - Map of source name to repository URL
+     */
+    async collectSources(deployments) {
+        // Extract unique sources from deployments
+        // Only include sources that are explicitly specified in the spec (not defaulted)
+        const sources = imm.Set(
+            deployments
+                .filter(d => {
+                    // Check if the source is explicitly specified in the spec
+                    return d.spec?.source
+                })
+                .map(d => d.spec.source)
+        ).toJS();
+
+        this.log("Unique explicitly specified sources found: %o", sources);
+
+        // Look up repository URLs for each source
+        const sourceMap = {};
+        for (const source of sources) {
+            try {
+                // Look up URL for the source
+                const repoUrl = await this.fplus.Git.repo_by_uuid(source);
+                if (repoUrl) {
+                    this.log("Found URL for source %s: %s", source, repoUrl);
+                    sourceMap[source] = repoUrl;
+                } else {
+                    this.log("Warning: Could not find URL for source %s", source);
+                }
+            } catch (err) {
+                this.log("Error looking up URL for source %s: %s", source, err);
+            }
+        }
+
+        return sourceMap;
+    }
+
+    async reconcile_manifests({ resources, manifests, deployments }) {
+        // Skip resource kinds that aren't in our config
         imm.Set.fromKeys(manifests)
             .subtract(resources)
             .forEach(r => this.log("Skipping resource kind %s", r));
 
+        // First, reconcile GitRepository resources for all unique sources
+        this.log("Collecting sources from deployments");
+        const sources = await this.collectSources(deployments);
+
+        if (Object.keys(sources).length > 0) {
+            this.log("Reconciling GitRepository resources for sources: %o", sources);
+            const gitRepos = new GitRepoReconciliation(this, sources);
+            await gitRepos.prepare();
+            await gitRepos.apply();
+        }
+
+        // Then reconcile HelmRelease resources
         for (const res of resources) {
             this.log("Reconciling %s", res);
 

--- a/acs-service-setup/dumps/helm.yaml
+++ b/acs-service-setup/dumps/helm.yaml
@@ -109,7 +109,7 @@ configs:
         apiVersion: helm.toolkit.fluxcd.io/v2beta1
         kind: HelmRelease
         metadata:
-          name: "{{chart}}-{{uuid}}"
+          name: "{{prefix}}-{{uuid}}"
         spec:
           chart:
             spec:

--- a/acs-service-setup/dumps/helm.yaml
+++ b/acs-service-setup/dumps/helm.yaml
@@ -117,7 +117,7 @@ configs:
               reconcileStrategy: Revision
               sourceRef:
                 kind: GitRepository
-                name: helm-charts
+                name: "{{source}}"
           install:
             crds: CreateReplace
           upgrade:

--- a/docs/architecture/edge-management/edge-deployments.md
+++ b/docs/architecture/edge-management/edge-deployments.md
@@ -17,13 +17,15 @@ this removes the need to keep pushing more drivers into the Edge Agent
 codebase itself.
 
 Services that can be deployed to the edge must be packaged in the form
-of a [Helm](https://helm.sh) chart. These Helm charts live in another
-Git repo on the central cluster, from where the Flux installations on
-the edge clusters can pull them. A default installation of ACS will pull
-the on-prem Helm charts repo from the `edge-helm-charts` repo on the
-AMRC-FactoryPlus Github, but this can be changed in the ACS
-`values.yaml`. Currently all deployable Helm charts must be present in
-the `main` branch of the single Helm charts repo.
+of a [Helm](https://helm.sh) chart. These Helm charts live in Git repositories
+on the central cluster, from where the Flux installations on the edge clusters
+can pull them. A default installation of ACS will pull the on-prem Helm charts
+repo from the `edge-helm-charts` repo on the AMRC-FactoryPlus Github, but this
+can be changed in the ACS `values.yaml`.
+
+Helm charts can be deployed from multiple Git repositories by specifying the
+`source` field in the Edge deployment entry. This allows you to maintain your
+own chart repositories separately from the core ACS charts.
 
 In order to allow for deploying the same chart in different
 configurations, the ConfigDB contains a set of 'Helm chart template'
@@ -40,7 +42,9 @@ ConfigDB detailing what is to be deployed and where. These entries live
 under the 'Edge deployment' Application and use the UUID of the Edge
 Agent as their Object. The entry specifies the Helm charts to deploy,
 the cluster to deploy to, and a name for the deployment; if this is an
-Edge Agent then the name will become the Sparkplug Node-ID.
+Edge Agent then the name will become the Sparkplug Node-ID. The entry
+can also specify a `source` field that references a Git repository UUID,
+which allows deploying charts from different repositories.
 
 The deployment entry also specifies which host on the cluster to deploy
 to, for deployments that target a specific host. It is possible to omit
@@ -104,8 +108,11 @@ Entries are JSON objects with the following properties:
   deployment should be deployed to.
 * `name`: A name for the the deployment. For Edge Agents this will
   become the Sparkplug Node-ID.
-* `charts`: An array of UUIDs listing the charts to deploy. These
-  reference entries under the 'Helm chart template' Application.
+* `chart`: A UUID representing the Helm chart to deploy. This
+  references an entry under the 'Helm chart template' Application.
+* `source` (optional): The UUID of the Git repository containing the Helm
+  charts to deploy. If not specified, the default "helm-charts" repository
+  is used.
 
 The Edge Sync operators will pick up changes to these entries via the
 ConfigDB MQTT interface. If an update appears to have been missed then
@@ -122,9 +129,10 @@ creating a cluster or an Edge Agent.
 
 Entries are JSON objects with the following properties:
 
-* `chart`: The name of the directory in the internal Helm Charts git
-  repo containing the chart to deploy.
-* `source` (optional): Currently ignored.
+* `chart`: The name of the directory in the Git repository containing
+  the chart to deploy.
+* `source` (optional): The UUID of the Git repository containing the Helm
+  chart. If not specified, the source from the Edge deployment entry is used.
 * `values`: An object equivalent to a Helm `values.yaml` file.
 
 The `values` object will be scanned recursively for strings of the form
@@ -183,19 +191,19 @@ cluster.
 KerberosKeys objects at the edge are deployed by the Helm charts. The
 'Edge cluster' chart deploys four: `krbkeys` itself, Flux, the Edge Sync
 operator, and the Edge Monitor. The Edge Agent chart deploys an
-additional KerberosKey for each Edge Agent. 
+additional KerberosKey for each Edge Agent.
 
 KerberosKeys which create an account in the Factory+ services have an
 `account` section. This may have the following properties:
 
 * `uuid` (not with `class`): This is the UUID to use for the account.
-  The object for the account must already exist in the ConfigDB. 
+  The object for the account must already exist in the ConfigDB.
 * `class` (not with `uuid`): This is the UUID of the class to use to
   create a new account.
 * `name` (only with `class`): The General Information name of the
   generated account object.
 * `groups`: An array of group UUIDs to add the account to in the Auth
-  service. 
+  service.
 * `aces`: An array of objects with `permission` and `target` properties
   indicating explicit ACEs to grant to the account.
 * `sparkplug`: Requests creation of a `Sparkplug address information`
@@ -240,6 +248,56 @@ resource, named after the UUID of the Node it is monitoring. This Device
 will publish an Alert if the Monitor cannot get a response from the Node
 after repeated attempts. The Device will publish `DDEATH` if the
 SparkplugNode resource is removed.
+
+## Multiple Chart Sources
+
+ACS supports deploying Helm charts from multiple Git repositories. This allows
+you to maintain your own chart repositories separately from the core ACS charts.
+
+### How It Works
+
+1. Create a Git repository configuration entry in the ConfigDB:
+   ```json
+   {
+     "path": "shared/my-charts",
+     "pull": {
+       "main": {
+         "url": "https://github.com/myorg/my-charts.git",
+         "ref": "main",
+         "interval": "5m"
+       }
+     }
+   }
+   ```
+
+2. When creating an Edge deployment, specify the `source` field with the UUID
+   of your Git repository:
+   ```json
+   {
+     "cluster": "6e01521a-1151-499a-81ac-78be05a13f57",
+     "name": "MyDeployment",
+     "source": "e6d41259-ac54-42e0-b2b5-8c447001d42f",
+     "chart": "e1704187-9b83-4820-87d2-c0a1d2697525"
+   }
+   ```
+
+3. The Edge Sync operator will:
+   - Extract the `source` field from the deployment
+   - Look up the repository URL for the source UUID
+   - Create a GitRepository resource on the edge cluster for each unique source
+   - Update HelmRelease resources to reference the correct source
+
+4. Flux on the edge cluster will pull the Helm charts from the specified Git
+   repository and deploy them.
+
+### Implementation Details
+
+The Edge Sync operator creates GitRepository resources for each unique source
+used by deployments targeting the current cluster. It then creates HelmRelease
+resources that reference the correct GitRepository source.
+
+Existing deployments without a `source` field will continue to work with the
+default "helm-charts" source.
 
 ## Next Steps
 

--- a/edge-helm-charts/README.md
+++ b/edge-helm-charts/README.md
@@ -7,7 +7,7 @@ Normally an installation of ACS will clone a copy of this repo into its
 internal on-prem Git server. From there the edge clusters will pull the
 Helm charts using Flux.
 
-Helm charts are made available from the Manager by creating 
+Helm charts are made available from the Manager by creating
 _Helm chart template_ (`729fe070-5e67-4bc7-94b5-afd75cb42b03`) ConfigDB
 entries. It is possible for multiple config entries to reference the
 same chart with different configurations. There are several layers of
@@ -16,18 +16,20 @@ templating involved.
 ## Deployment process
 
 When a deployment is created in the Manager (or otherwise), this results
-in the creation of an _Edge deployment_ 
+in the creation of an _Edge deployment_
 (`f2b9417a-ef7f-421f-b387-bb8183a48cdb`) ConfigDB entry. This is what
 actually causes the deployment to be pushed to the edge.
 
 These entries contain:
 
-* `charts`: A list of charts to deploy. These are UUIDs referencing
-  _Helm chart template_ entries.
+* `charts`: A chart to deploy. This is a UUID referencing a
+  _Helm chart template_ entry.
 * `cluster`: The UUID of the cluster to deploy to.
 * `hostname`: (optional) The hostname of the machine to deploy to.
 * `name`: A string name for the deployment. For Edge Agents this becomes
   the Node name.
+* `source`: (optional) The UUID of the Git repository containing the Helm charts.
+  If not specified, the default "helm-charts" repository is used.
 
 No other configuration is currently possible at this level (this is not
 ideal). These values, along with the UUID of the deployment itself, are
@@ -37,7 +39,8 @@ with these properties:
 
 * `chart`: The name of the directory in this repo holding the chart to
   deploy.
-* `source`: Currently ignored.
+* `source`: The UUID of the Git repository containing the Helm chart. If not specified,
+  the default "helm-charts" repository is used.
 * `values`: The Helm `values.yaml` to use for the deployment.
 
 The contents of the `values` object are then used used by Helm to expand
@@ -48,7 +51,7 @@ expansion above, is rather more complicated.
 ## Creating a new chart template
 
 To deploy an existing chart with different values, start by creating a
-new ConfigDB object in the _Helm chart_ 
+new ConfigDB object in the _Helm chart_
 (`f9be0334-0ff7-43d3-9d8a-188d3e4d472b`) class. This UUID is what you
 will use in the `charts` array of your deployment.
 
@@ -160,12 +163,17 @@ file.
 
 ### Deploying the chart to the edge
 
-Once the chart is written, commit it to Git and get it pushed to your
-internal Git server. There are three ways to accomplish this:
+Once the chart is written, there are several ways to get it deployed to your edge clusters:
 
 * Changes that are accepted into an ACS release will be pushed to all
   installations which are using the default settings. Untested charts
   are unlikely to be accepted into a release.
+
+* Use the multiple chart sources feature to deploy charts from your own Git repository:
+  1. Create a Git repository configuration entry in the ConfigDB for your repository
+  2. When creating an Edge deployment, specify the `source` field with the UUID of your Git repository
+  This approach allows you to maintain your charts separately while still benefiting from
+  updates to the core ACS charts.
 
 * Push to a branch on this repo, a clone on public Github, or a clone
   created on your own infrastructure. Change the service-setup config of

--- a/edge-helm-charts/charts/edge-cluster/templates/edge-sync.yaml
+++ b/edge-helm-charts/charts/edge-cluster/templates/edge-sync.yaml
@@ -104,6 +104,9 @@ rules:
   - apiGroups: [helm.toolkit.fluxcd.io]
     resources: [helmreleases]
     verbs: [list, get, watch, create, update, patch, delete]
+  - apiGroups: [source.toolkit.fluxcd.io]
+    resources: [gitrepositories]
+    verbs: [list, get, watch, create, update, patch, delete]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
## Overview
This PR adds support for deploying Helm charts from multiple Git repositories in edge deployments. It allows users to specify a source repository for each Helm chart template, enabling more flexible chart management.

## Key Changes

### 1. Source Field in Helm Chart Templates
- Added a `source` field to specify the UUID of the Git repository containing the chart
- If not specified, defaults to the "helm-charts" repository for backward compatibility

### 2. Prefix Field for Chart Paths
- Added a `prefix` field to handle paths with slashes in chart names
- Used for kubernetes-compatible resource naming
- Defaults to the chart name if not specified

### 3. GitRepository Management
- Added a specialized GitRepoReconciliation class to manage GitRepository resources
- Edge Sync operator now creates GitRepository resources for each unique source
- Added RBAC permissions for the Edge Sync service account to manage GitRepository resources

### 4. HelmRelease Template Updates
- Updated to use the source field from the chart template
- Changed to use the prefix field for resource naming

## Example Usage

```json
{
  "chart": "my-custom-chart",
  "source": "e6d41259-ac54-42e0-b2b5-8c447001d42f",
  "prefix": "charts",
  "values": {
    "host": "localhost"
  }
}
```

## Documentation
- Updated edge-deployments.md with details about the new fields and behavior
- Added examples and implementation details