### PR TITLE
Fix missing confirm button on ObjectSelector

### DIFF
--- a/acs-admin/src/components/ObjectSelector/ObjectSelector.vue
+++ b/acs-admin/src/components/ObjectSelector/ObjectSelector.vue
@@ -26,7 +26,12 @@
             :clickable="!multiSelect"
             @row-click="e => {$emit('update:modelValue', [e.original]); updateOpen(false)}"
             :filters="[]">
-          <template #default="slotProps">
+          <template #toolbar-left="slotProps">
+            <div class="text-slate-500 whitespace-nowrap">
+              Showing {{slotProps.table.getFilteredRowModel().rows.length}} of {{slotProps.table.getPreFilteredRowModel().rows.length}}
+            </div>
+          </template>
+          <template #toolbar-right="slotProps">
             <div class="flex items-center justify-center gap-2">
               <div v-if="multiSelect" class="whitespace-nowrap mr-4">{{slotProps.selectedObjects.length}} selected</div>
               <slot name="actions"></slot>

--- a/acs-admin/src/components/ui/data-table-searchable/DataTableSearchable.vue
+++ b/acs-admin/src/components/ui/data-table-searchable/DataTableSearchable.vue
@@ -108,7 +108,7 @@ const limitHeight = props.limitHeight
               @update:model-value="props.searchKey ? table.getColumn(props.searchKey)?.setFilterValue($event) : table.setGlobalFilter(String($event))"
           />
         </div>
-        <slot name="toolbar-right" :table="table"></slot>
+        <slot name="toolbar-right" :table="table" :selected-objects="table.getSelectedRowModel().rows.map(r => {return {...r.original, metaRowId: r.id}})"></slot>
       </template>
     </DataTableToolbar>
     <slot name="below-toolbar"></slot>


### PR DESCRIPTION
The button was looking for a default slot which has been removed.
The button now gets placed within the toolbar-right slot.
Other minor details have been re-included (how many elements are showing with the current filter).

This issue prevents users from changing members/subclasses in ConfigDB UI as well as updating groups and permissions in the Auth UI.
This fix gets that functionality working again.