### PR TITLE
Prevent ConfigDB text editor disappearing when string is emptied

### DIFF
--- a/acs-admin/src/pages/ConfigDB/Applications/ApplicationObjectEditor.vue
+++ b/acs-admin/src/pages/ConfigDB/Applications/ApplicationObjectEditor.vue
@@ -17,7 +17,7 @@
       </div>
     </div>
     <MonacoEditor
-        v-if="v$.code.$model"
+        v-if="v$.code.$model !== null && v$.code.$model !== undefined"
         class="editor h-[40em] w-[95%] border b-slate-300"
         :language="format"
         :value="v$.code.$model"


### PR DESCRIPTION
The element was checking if the string was "truthy", but an empty string isn't. 
It now more appropriately checks for null or undefined.

Fix #519 