### PR TITLE
Allow publishing JS libs to NPM

### DIFF
--- a/.github/workflows/js-lib.yaml
+++ b/.github/workflows/js-lib.yaml
@@ -1,0 +1,43 @@
+name: Publish JS lib
+
+on:
+  workflow_call:
+    inputs:
+      libdir:
+        description: "Lib dir to publish"
+        required: true
+        type: string
+      version:
+        description: "Version to publish as"
+        required: true
+        type: string
+    secrets:
+      NPM_TOKEN:
+        description: "NPM access token"
+        required: true
+          
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
+      - name: Publish package
+        working-directory: ${{ inputs.libdir }}
+        run: |
+          version="${{ inputs.version }}"
+          version="${version#v}"
+          echo "Updating version to: $version"
+          jq ".version = \"$version\"" package.json > package.json.tmp
+          mv package.json.tmp package.json
+
+          npm install --verbose
+
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+          npm publish --access=public --dry-run

--- a/.github/workflows/js-lib.yaml
+++ b/.github/workflows/js-lib.yaml
@@ -40,4 +40,4 @@ jobs:
           npm install --verbose
 
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
-          npm publish --access=public --dry-run
+          npm publish --access=public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,7 @@ env:
   BASE_JS_VERSION: v4.0.0
 
 on:
-  release:
-    types: [ published ]
+  workflow_call: {}
 
 jobs:
   build-base-js:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,56 @@
+# GH Actions workflow file
+# ACS monorepo release action
+#
+# This workflow runs every time a release is published from the ACS
+# monorepo. Its function is to choose what form of release we are making
+# based on the syntax of the release tag. These forms are recognised;
+# here vSEMVER is a semver version string with an initial 'v'.
+#
+#   vSEMVER               Publish a release of ACS itself
+#   js/some-lib/vSEMVER   Publish an in-tree JS library to NPM
+
+name: Choose release type
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  choose-type:
+    runs-on: ubuntu-latest
+    outputs:
+      type: ${{ steps.choose.outputs.type }}
+      library: ${{ steps.choose.outputs.library }}
+      version: ${{ steps.choose.outputs.version }}
+    steps:
+      - id: choose
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          echo "version=$(basename "$tag")" >>"$GITHUB_OUTPUT"
+          prefix="$(dirname "$tag")"
+          if [ "$prefix" = "." ]
+          then
+            echo "type=acs" >>"$GITHUB_OUTPUT"
+          else
+            echo "type=$(dirname "$prefix")" >>"$GITHUB_OUTPUT"
+            echo "library=$(basename "$prefix")" >>"$GITHUB_OUTPUT"
+          fi
+
+  acs:
+    needs: choose-type
+    if: ${{ needs.choose-type.outputs.type == 'acs' }}
+    uses: ./.github/workflows/publish.yml
+    permissions:
+      contents: read
+      packages: write
+
+  js-lib:
+    needs: choose-type
+    if: ${{ needs.choose-type.outputs.type == 'js' }}
+    uses: ./.github/workflows/js-lib.yaml
+    with:
+      libdir: "lib/js-${{ needs.choose-type.outputs.library }}"
+      version: "${{ needs.choose-type.outputs.version }}"
+    secrets: inherit
+
+


### PR DESCRIPTION
Change the GH actions to support publishing the in-tree JS libs to NPM. Support this using release tags of the form `js/lib-name/vN.N.N` and a new top-level workflow to choose which form of release this is. The existing release workflow no longer runs on `release` but on `workflow_call`.