### PR TITLE
Pass correct permission to ACS build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -170,7 +170,6 @@ jobs:
       contents: read
       packages: write
       id-token: write
-      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -218,7 +217,6 @@ jobs:
       contents: read
       packages: write
       id-token: write
-      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -263,7 +261,6 @@ jobs:
       contents: read
       packages: write
       id-token: write
-      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -301,7 +298,6 @@ jobs:
       contents: read
       packages: write
       id-token: write
-      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,6 +43,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
 
   js-lib:
     needs: choose-type


### PR DESCRIPTION
The ACS build needs `id-token: write` for something to do with cosign. (I still don't understand what cosign does for us.)

Remove `pull-requests: write`, this is old and no longer required.