### PR TITLE
Releasing the Helm Chart needs contents: write

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -377,6 +377,8 @@ jobs:
     if: github.event_name == 'release'
     needs: build-helm-chart
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Install Helm
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
     if: ${{ needs.choose-type.outputs.type == 'acs' }}
     uses: ./.github/workflows/publish.yml
     permissions:
-      contents: read
+      contents: write
       packages: write
       id-token: write
 


### PR DESCRIPTION
I don't fully understand how this permission was available before when it isn't declared in the job step, but maybe the top-level workflow just gets all permissions.