### PR TITLE
Add missing files interface error status

### DIFF
--- a/lib/js-service-client/lib/service/files.js
+++ b/lib/js-service-client/lib/service/files.js
@@ -94,7 +94,7 @@ export class Files extends ServiceInterface {
         if(st == 201) {
             return json.uuid
         }
-        this.throw(`Error uploading file: ${uuid}`);
+        this.throw(`Error uploading file: ${uuid}`, st);
     }
 
     /**


### PR DESCRIPTION
The error now throw the status returned from the fetch on upload file. 