### PR TITLE
Add Principal Auth Support

### DIFF
--- a/lib/js-service-api/lib/auth.js
+++ b/lib/js-service-api/lib/auth.js
@@ -20,7 +20,8 @@ const DATE_FUZZ = 1*60*1000;
 export class FplusHttpAuth {
     /* Opts is an object; properties as follows. ? means optional.
      *  realm:              Our Kerberos realm
-     *  hostname:           A hostname we have a Kerberos key for.
+     *  hostname:           A hostname we have a Kerberos key for instead of the principle.
+     *  principle:          The principle we have a kerberos key for instead a hostname for non "HTTP/" principles.
      *  keytab:             The path to our keytab file (our private key).
      *  session_length?:    How long should tokens be valid for? (ms)
      *
@@ -31,7 +32,7 @@ export class FplusHttpAuth {
      */
     constructor (opts) {
         this.realm = opts.realm;
-        this.principal = `HTTP/${opts.hostname}`;
+        this.principal = opts.hostname ? `HTTP/${opts.hostname}` : opts.principal;
         this.keytab = opts.keytab;
         this.session_length = opts.session_length ?? SESSION_LENGTH;
         this.log = opts.log 


### PR DESCRIPTION
The service API can now accept non http principals to retrieve an auth ticket.