### PR TITLE
Allow hyphens in connection names for edge split

### DIFF
--- a/acs-edge/lib/driverBroker.ts
+++ b/acs-edge/lib/driverBroker.ts
@@ -10,7 +10,7 @@ import util from "util";
 import Aedes from "aedes";
 
 const prefix = "fpEdge1";
-const topicrx = new RegExp(`^${prefix}/(\\w+)/(\\w+)(?:/(\\w+))?$`);
+const topicrx = new RegExp(`^${prefix}/([\\w-]+)/(\\w+)(?:/(\\w+))?$`);
 
 function log (f, ...a) {
     const msg = util.format(f, ...a);


### PR DESCRIPTION
Updated the regular expression to permit hyphens in the first segment of the topic regex.