### PR TITLE
Decrease minimum Grafana dashboard refresh interval

### DIFF
--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -342,6 +342,8 @@ grafana:
       header_name: X-Auth-Principal
       header_property: username
       auto_sign_up: true
+    dashboards:
+      min_refresh_interval: 500ms
   sidecar:
     datasources:
       enabled: true


### PR DESCRIPTION
Adds a minimum refresh interval to `grafana` in `values.yaml`.

This gives people a bit more freedom in setting their Grafana dashboard refresh rates. The 500ms interval is a _minimum_ and is set in the dashboard settings; the _default_ interval remains 5s.