### PR TITLE
Granular ConfigDB object permissions

### DIFF
--- a/acs-auth/lib/api_v2.js
+++ b/acs-auth/lib/api_v2.js
@@ -142,6 +142,11 @@ export class APIv2 {
 
         const grant = req.method == "PUT" ? req.body : null;
         if (grant && !valid_grant(grant)) fail(422);
+        /* XXX There is a race condition here but I can't see how to
+         * avoid it. Our permitted list is built here, before the txn,
+         * so in principle is out of date by the time we use it. But we
+         * need to sample the ConfigDB information somewhere, and we
+         * don't have cross-service transactions. */
         const permitted = await this.data.check_targ(req.auth, Perm.WriteACL, true);
 
         const rv = await this.data.request({ type: "grant", uuid, grant, permitted });

--- a/acs-auth/lib/queries.js
+++ b/acs-auth/lib/queries.js
@@ -211,6 +211,16 @@ export default class Queries {
         `, [group]);
     }
 
+    dump_existing_perms (princs) {
+        return this.q_list(`
+            select distinct p.uuid
+            from unnest($1::uuid[]) q(uuid) 
+                join uuid u on u.uuid = q.uuid
+                join ace e on e.principal = u.id
+                join uuid p on p.id = e.permission
+        `, [princs]);
+    }
+
     dump_load_uuids (uuids) {
         return this.q_list(`
             insert into uuid (uuid)
@@ -218,7 +228,7 @@ export default class Queries {
             from unnest($1::uuid[]) u(uuid)
             on conflict do nothing
             returning uuid
-        `, [[...uuids]]);
+        `, [uuids]);
     }
 
     dump_load_krbs (krbs) {
@@ -244,8 +254,8 @@ export default class Queries {
             ),
             existing as (
                 select e.id 
-                from n_ace n join ace e
-                    on e.principal = n.princ
+                from n_ace n 
+                    join ace e on e.principal = n.princ
                         and e.permission = n.perm
                         and e.target = n.targ
             ),
@@ -257,11 +267,12 @@ export default class Queries {
             ),
             i_ace as (
                 insert into ace (principal, permission, target, plural)
+                select princ, perm, targ, plural from n_ace
                 on conflict (principal, permission, target) do update
                     set plural = excluded.plural
                     where ace.plural != excluded.plural
                 returning id
-            ),
+            )
             select id from d_ace
                 union all select id from i_ace
         `, [aces]);

--- a/acs-auth/lib/queries.js
+++ b/acs-auth/lib/queries.js
@@ -232,26 +232,38 @@ export default class Queries {
         `, [krbs]);
     }
 
-    /* XXX This form of loading gives no way for a revised version of a
-     * dump to remove old grants. This is a problem across the board
-     * with our dump loading logic but is more important here. I think
-     * the only solution that works is to introduce a 'source' for these
-     * entries such that loading a new dumps clears old data from that
-     * source. Moving the grants into the ConfigDB would make it easier
-     * to solve this in general. */
     dump_load_aces (aces) {
         return this.q_rows(`
-            insert into ace (principal, permission, target, plural)
-            select u.id, p.id, t.id, 
-                coalesce((g.g->'plural')::boolean, false)
-            from unnest($1::jsonb[]) g(g)
-                join uuid u on u.uuid::text = g.g->>'principal'
-                join uuid p on p.uuid::text = g.g->>'permission'
-                join uuid t on t.uuid::text = g.g->>'target'
-            on conflict (principal, permission, target) do update
-                set plural = excluded.plural
-                where ace.plural != excluded.plural
-            returning principal, permission, target
+            with n_ace as (
+                select u.id princ, p.id perm, t.id targ,
+                    coalesce((g.g->'plural')::boolean, false) plural
+                from unnest($1::jsonb[]) g(g)
+                    join uuid u on u.uuid = (g.g->>'principal')::uuid
+                    join uuid p on p.uuid = (g.g->>'permission')::uuid
+                    join uuid t on t.uuid = (g.g->>'target')::uuid
+            ),
+            existing as (
+                select e.id 
+                from n_ace n join ace e
+                    on e.principal = n.princ
+                        and e.permission = n.perm
+                        and e.target = n.targ
+            ),
+            d_ace as (
+                delete from ace
+                where principal in (select princ from n_ace)
+                    and id not in (select id from existing)
+                returning id
+            ),
+            i_ace as (
+                insert into ace (principal, permission, target, plural)
+                on conflict (principal, permission, target) do update
+                    set plural = excluded.plural
+                    where ace.plural != excluded.plural
+                returning id
+            ),
+            select id from d_ace
+                union all select id from i_ace
         `, [aces]);
     }
 }

--- a/acs-configdb/lib/api-v1.js
+++ b/acs-configdb/lib/api-v1.js
@@ -89,7 +89,7 @@ export class APIv1 {
     }
 
     async apps_post(req, res) {
-        const ok = await this.auth.check_acl(req.auth, Perm.Manage_Obj, Class.App, true);
+        const ok = await this.auth.check_acl(req.auth, Perm.ManageObj, Class.App, true);
         if (!ok) return res.status(403).end();
 
         const uuid = req.body.uuid;
@@ -108,7 +108,7 @@ export class APIv1 {
     }
 
     async app_get(req, res) {
-        const ok = await this.auth.check_acl(req.auth, Perm.Manage_Obj, Class.App, true);
+        const ok = await this.auth.check_acl(req.auth, Perm.ManageObj, Class.App, true);
         if (!ok) return res.status(403).end();
 
         const uuid = req.params.app;
@@ -155,7 +155,7 @@ export class APIv1 {
 
     async config_search(req, res) {
         const {app, "class": klass} = req.params;
-        const ok = await this.auth.check_acl(req.auth, Perm.Read_App, app, true);
+        const ok = await this.auth.check_acl(req.auth, Perm.ReadApp, app, true);
         if (!ok) return res.status(403).end();
 
         const query = this.config_search_parse(req.query);
@@ -186,8 +186,8 @@ export class APIv1 {
     }
 
     async dump_save(req, res) {
-        const ok = await this.auth.check_acl(req.auth, Perm.Manage_Obj, UUIDs.Null)
-            && await this.auth.check_acl(req.auth, Perm.Read_App, UUIDs.Null);
+        const ok = await this.auth.check_acl(req.auth, Perm.ManageObj, UUIDs.Null)
+            && await this.auth.check_acl(req.auth, Perm.ReadApp, UUIDs.Null);
         if (!ok) return res.status(403).end();
 
         const dump = await this.model.dump_save();

--- a/acs-configdb/lib/api-v2.js
+++ b/acs-configdb/lib/api-v2.js
@@ -92,7 +92,7 @@ export class APIv2 {
         if (!Valid.uuid.test(req.params.app))
             return res.status(410).end();
 
-        const ok = await this.auth.check_acl(req.auth, Perm.Manage_Obj, Class.App, true);
+        const ok = await this.auth.check_acl(req.auth, Perm.ManageObj, Class.App, true);
         if (!ok) return res.status(403).end();
 
         const uuid = req.params.app;
@@ -111,7 +111,7 @@ export class APIv2 {
     }
 
     async object_list(req, res) {
-        const ok = await this.auth.check_acl(req.auth, Perm.Manage_Obj, UUIDs.Null);
+        const ok = await this.auth.check_acl(req.auth, Perm.ManageObj, UUIDs.Null);
         if (!ok) return res.status(403).end();
 
         let list = await this.model.object_list();
@@ -119,7 +119,7 @@ export class APIv2 {
     }
 
     async object_ranks (req, res) {
-        const ok = await this.auth.check_acl(req.auth, Perm.Manage_Obj, UUIDs.Null);
+        const ok = await this.auth.check_acl(req.auth, Perm.ManageObj, UUIDs.Null);
         if (!ok) return res.status(403).end();
 
         const list = await this.model.object_ranks();
@@ -129,7 +129,7 @@ export class APIv2 {
     async object_create(req, res) {
         const spec = req.body;
 
-        const ok = await this.auth.check_acl(req.auth, Perm.Manage_Obj, 
+        const ok = await this.auth.check_acl(req.auth, Perm.ManageObj, 
             spec.class ?? UUIDs.Null, true);
         if (!ok) return res.status(403).end();
 
@@ -150,7 +150,7 @@ export class APIv2 {
         if (!Valid.uuid.test(object))
             return res.status(410).end();
 
-        const ok = await this.auth.check_acl(req.auth, Perm.Delete_Obj, object, true);
+        const ok = await this.auth.check_acl(req.auth, Perm.DeleteObj, object, true);
         if (!ok) return res.status(403).end();
 
         const [st, rv] = await this.model.object_delete(object);
@@ -160,7 +160,7 @@ export class APIv2 {
     }
 
     async class_list(req, res) {
-        const ok = await this.auth.check_acl(req.auth, Perm.Manage_Obj, UUIDs.Null);
+        const ok = await this.auth.check_acl(req.auth, Perm.ManageObj, UUIDs.Null);
         if (!ok) return res.status(403).end();
         const list = await this.model.class_list();
         return res.status(200).json(list);
@@ -171,7 +171,7 @@ export class APIv2 {
         if (!Valid.uuid.test(klass))
             return res.status(410).end();
 
-        const ok = await this.auth.check_acl(req.auth, Perm.Manage_Obj, klass, true);
+        const ok = await this.auth.check_acl(req.auth, Perm.ManageObj, klass, true);
         if (!ok) return res.status(403).end();
 
         const members = await this.model.class_lookup(klass, "membership");
@@ -188,7 +188,7 @@ export class APIv2 {
         if (!Valid.uuid.test(klass) || (object && !Valid.uuid.test(object)))
             return res.status(410).end();
 
-        const ok = await this.auth.check_acl(req.auth, Perm.Manage_Obj, klass, true);
+        const ok = await this.auth.check_acl(req.auth, Perm.ManageObj, klass, true);
         if (!ok) return res.status(403).end();
 
         if (object) {
@@ -206,7 +206,7 @@ export class APIv2 {
         if (!Valid.uuid.test(klass) || !Valid.uuid.test(object))
             return res.status(410).end();
 
-        const ok = await this.auth.check_acl(req.auth, Perm.Manage_Obj, klass, true);
+        const ok = await this.auth.check_acl(req.auth, Perm.ManageObj, klass, true);
         if (!ok) return res.status(403).end();
 
         const st = await action(this.model).call(this.model, klass, object);
@@ -218,7 +218,7 @@ export class APIv2 {
         if (!Valid.uuid.test(app) || (klass && !Valid.uuid.test(klass)))
             return res.status(410).end();
 
-        const ok = await this.auth.check_acl(req.auth, Perm.Read_App, app, true);
+        const ok = await this.auth.check_acl(req.auth, Perm.ReadApp, app, true);
         if (!ok) return res.status(403).end();
 
         let list = klass
@@ -236,7 +236,7 @@ export class APIv2 {
         if (!Valid.uuid.test(app) || !Valid.uuid.test(object))
             return res.status(410).end();
 
-        const ok = await this.auth.check_acl(req.auth, Perm.Read_App,
+        const ok = await this.auth.check_acl(req.auth, Perm.ReadApp,
             req.params.app, true);
         if (!ok) return res.status(403).end();
 
@@ -259,7 +259,7 @@ export class APIv2 {
         const { app, object } = req.params;
         if (!Valid.uuid.test(app) || !Valid.uuid.test(object))
             return res.status(410).end();
-        const ok = await this.auth.check_acl(req.auth, Perm.Write_App,
+        const ok = await this.auth.check_acl(req.auth, Perm.WriteApp,
             req.params.app, true);
         if (!ok) return res.status(403).end();
 
@@ -279,7 +279,7 @@ export class APIv2 {
         const { app, object } = req.params;
         if (!Valid.uuid.test(app) || !Valid.uuid.test(object))
             return res.status(410).end();
-        const ok = await this.auth.check_acl(req.auth, Perm.Write_App,
+        const ok = await this.auth.check_acl(req.auth, Perm.WriteApp,
             req.params.app, true);
         if (!ok) return res.status(403).end();
 
@@ -298,7 +298,7 @@ export class APIv2 {
             return res.status(415).end();
 
         const ok = await Promise.all(
-            [Perm.Read_App, Perm.Write_App]
+            [Perm.ReadApp, Perm.WriteApp]
             .map(p => this.auth.check_acl(req.auth, p, app, true)));
         if (ok.includes(false))
             return res.status(403).end();
@@ -340,7 +340,7 @@ export class APIv2 {
         const {app, "class": klass} = req.params;
         if (!Valid.uuid.test(app) || (klass && !Valid.uuid.test(klass)))
             return res.status(410).end();
-        const ok = await this.auth.check_acl(req.auth, Perm.Read_App, app, true);
+        const ok = await this.auth.check_acl(req.auth, Perm.ReadApp, app, true);
         if (!ok) return res.status(403).end();
 
         const query = this.config_search_parse(req.query);
@@ -356,8 +356,8 @@ export class APIv2 {
     }
 
     async dump_save(req, res) {
-        const ok = await this.auth.check_acl(req.auth, Perm.Manage_Obj, UUIDs.Null)
-            && await this.auth.check_acl(req.auth, Perm.Read_App, UUIDs.Null);
+        const ok = await this.auth.check_acl(req.auth, Perm.ManageObj, UUIDs.Null)
+            && await this.auth.check_acl(req.auth, Perm.ReadApp, UUIDs.Null);
         if (!ok) return res.status(403).end();
 
         const dump = await this.model.dump_save();

--- a/acs-configdb/lib/api-v2.js
+++ b/acs-configdb/lib/api-v2.js
@@ -16,6 +16,34 @@ const Valid = {
     uuid:   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
 };
 
+const Relations = [
+    {
+        path:   "member",
+        table:  "all_membership",
+        cperm:  Perm.ReadMembers,
+        //operm:  Perm.ReadMemberships,
+    }, {
+        path:   "direct/member",
+        table:  "membership",
+        cperm:  Perm.WriteMembers,
+        operm:  Perm.WriteMembership,
+        add:    m => m.class_add_member,
+        remove: m => m.class_remove_member,
+    }, {
+        path:   "subclass",
+        table:  "all_subclass",
+        cperm:  Perm.ReadSubclasses,
+        //operm:  Perm.ReadSuperclasses,
+    }, {
+        path:   "direct/subclass",
+        table:  "subclass",
+        cperm:  Perm.WriteSubclasses,
+        operm:  Perm.ReadSubclasses,
+        add:    m => m.class_add_subclass,
+        remove: m => m.class_remove_subclass,
+    },
+];
+
 export class APIv2 {
     constructor(opts) {
         this.fplus = opts.fplus;
@@ -59,22 +87,19 @@ export class APIv2 {
 
         api.get("/class/:class", this.class_info.bind(this));
 
-        const clookup = (path, table) => {
-            const lookup = this.class_lookup.bind(this, table);
-            api.get(`/class/:class/${path}`, lookup);
-            api.get(`/class/:class/${path}/:object`, lookup);
-        };
-        clookup("direct/member", "membership");
-        clookup("direct/subclass", "subclass");
-        clookup("member", "all_membership");
-        clookup("subclass", "all_subclass");
+        for (const r of Relations) {
+            const prefix = `/class/:class/${r.path}`;
 
-        api.route("/class/:class/direct/member/:object")
-            .put(this.class_rel.bind(this, m => m.class_add_member))
-            .delete(this.class_rel.bind(this, m => m.class_remove_member));
-        api.route("/class/:class/direct/subclass/:object")
-            .put(this.class_rel.bind(this, m => m.class_add_subclass))
-            .delete(this.class_rel.bind(this, m => m.class_remove_subclass));
+            const lookup = this.class_lookup.bind(this, r.cperm, r.table);
+            api.get(prefix, lookup);
+            api.get(`${prefix}/:object`, lookup);
+
+            if (r.add) {
+                api.route(`${prefix}/:object`)
+                    .put(this.class_rel.bind(this, r, r.add))
+                    .delete(this.class_rel.bind(this, r, r.remove));
+            }
+        }
 
         api.get("/app/:app/object", this.config_list.bind(this));
         api.get("/app/:app/class/:class", this.config_list.bind(this));
@@ -84,34 +109,16 @@ export class APIv2 {
             .put(this.config_put.bind(this))
             .delete(this.config_delete.bind(this))
             .patch(this.config_patch.bind(this));
+        
+        const deny = (req, res) => res.status(403).end();
 
-        api.get("/save", this.dump_save.bind(this));
-    }
-
-    async app_get(req, res) {
-        if (!Valid.uuid.test(req.params.app))
-            return res.status(410).end();
-
-        const ok = await this.auth.check_acl(req.auth, Perm.ManageObj, Class.App, true);
-        if (!ok) return res.status(403).end();
-
-        const uuid = req.params.app;
-        /* XXX What verification do we want here? Do we insist that an
-         * App-UUID is a member of Application, or do we allow any
-         * object? */
-        const klass = await this.model.object_class(uuid);
-        if (klass != Class.App)
-            res.status(404).end();
-
-        const info = await this.model.config_get(
-            {app: App.Info, object: uuid});
-        const name = info?.config?.name ?? "";
-
-        res.status(200).json({uuid, name});
+        /* Deny /save for now; the dumps are useless until we can
+         * generate v2 dumps and ownerships. */
+        api.get("/save", deny);
     }
 
     async object_list(req, res) {
-        const ok = await this.auth.check_acl(req.auth, Perm.ManageObj, UUIDs.Null);
+        const ok = await this.auth.check_acl(req.auth, Perm.ListObj, UUIDs.Null);
         if (!ok) return res.status(403).end();
 
         let list = await this.model.object_list();
@@ -119,7 +126,7 @@ export class APIv2 {
     }
 
     async object_ranks (req, res) {
-        const ok = await this.auth.check_acl(req.auth, Perm.ManageObj, UUIDs.Null);
+        const ok = await this.auth.check_acl(req.auth, Perm.ListObj, UUIDs.Null);
         if (!ok) return res.status(403).end();
 
         const list = await this.model.object_ranks();
@@ -129,8 +136,9 @@ export class APIv2 {
     async object_create(req, res) {
         const spec = req.body;
 
-        const ok = await this.auth.check_acl(req.auth, Perm.ManageObj, 
-            spec.class ?? UUIDs.Null, true);
+        const ok = await this.auth.check_acl(req.auth, 
+            spec.uuid ? Perm.CreateSpecificObj : Perm.CreateObj, 
+            spec.class, true);
         if (!ok) return res.status(403).end();
 
         spec.owner ??= await this.auth.resolve_upn(req.auth, SpecialObj.Unowned);
@@ -159,19 +167,14 @@ export class APIv2 {
         rv ? res.json(rv) : res.end();
     }
 
-    async class_list(req, res) {
-        const ok = await this.auth.check_acl(req.auth, Perm.ManageObj, UUIDs.Null);
-        if (!ok) return res.status(403).end();
-        const list = await this.model.class_list();
-        return res.status(200).json(list);
-    }
-
     async class_info (req, res) {
         const klass = req.params.class;
         if (!Valid.uuid.test(klass))
             return res.status(410).end();
 
-        const ok = await this.auth.check_acl(req.auth, Perm.ManageObj, klass, true);
+        const acl = await this.auth.fetch_acl(req.auth);
+        const ok = [Perm.ReadMembers, Perm.ReadSubclasses]
+            .every(p => acl(p, klass, true));
         if (!ok) return res.status(403).end();
 
         const members = await this.model.class_lookup(klass, "membership");
@@ -183,12 +186,12 @@ export class APIv2 {
         return res.status(200).json({ members, subclasses });
     }
 
-    async class_lookup (rel, req, res) {
+    async class_lookup (perm, rel, req, res) {
         const { class: klass, object } = req.params;
         if (!Valid.uuid.test(klass) || (object && !Valid.uuid.test(object)))
             return res.status(410).end();
 
-        const ok = await this.auth.check_acl(req.auth, Perm.ManageObj, klass, true);
+        const ok = await this.auth.check_acl(req.auth, perm, klass, true);
         if (!ok) return res.status(403).end();
 
         if (object) {
@@ -201,12 +204,13 @@ export class APIv2 {
         return res.status(200).json(list);
     }
 
-    async class_rel (action, req, res) {
+    async class_rel (rel, action, req, res) {
         const { class: klass, object } = req.params;
         if (!Valid.uuid.test(klass) || !Valid.uuid.test(object))
             return res.status(410).end();
 
-        const ok = await this.auth.check_acl(req.auth, Perm.ManageObj, klass, true);
+        const acl = await this.auth.fetch_acl(req.auth);
+        const ok = acl(rel.cperm, klass, true) && acl(rel.operm, object, true);
         if (!ok) return res.status(403).end();
 
         const st = await action(this.model).call(this.model, klass, object);
@@ -353,14 +357,5 @@ export class APIv2 {
             : Object.fromEntries(results.map(r => [r.uuid, r.results]));
 
         return res.status(200).json(json);
-    }
-
-    async dump_save(req, res) {
-        const ok = await this.auth.check_acl(req.auth, Perm.ManageObj, UUIDs.Null)
-            && await this.auth.check_acl(req.auth, Perm.ReadApp, UUIDs.Null);
-        if (!ok) return res.status(403).end();
-
-        const dump = await this.model.dump_save();
-        res.status(200).json(dump);
     }
 }

--- a/acs-configdb/lib/api-v2.js
+++ b/acs-configdb/lib/api-v2.js
@@ -11,38 +11,11 @@ import { UUIDs } from "@amrc-factoryplus/service-client";
 import * as etags from "./etags.js";
 
 import {App, Class, Perm, SpecialObj} from "./constants.js";
+import { Relations } from "./relations.js";
 
 const Valid = {
     uuid:   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
 };
-
-const Relations = [
-    {
-        path:   "member",
-        table:  "all_membership",
-        cperm:  Perm.ReadMembers,
-        //operm:  Perm.ReadMemberships,
-    }, {
-        path:   "direct/member",
-        table:  "membership",
-        cperm:  Perm.WriteMembers,
-        operm:  Perm.WriteMembership,
-        add:    m => m.class_add_member,
-        remove: m => m.class_remove_member,
-    }, {
-        path:   "subclass",
-        table:  "all_subclass",
-        cperm:  Perm.ReadSubclasses,
-        //operm:  Perm.ReadSuperclasses,
-    }, {
-        path:   "direct/subclass",
-        table:  "subclass",
-        cperm:  Perm.WriteSubclasses,
-        operm:  Perm.ReadSubclasses,
-        add:    m => m.class_add_subclass,
-        remove: m => m.class_remove_subclass,
-    },
-];
 
 export class APIv2 {
     constructor(opts) {

--- a/acs-configdb/lib/auth.js
+++ b/acs-configdb/lib/auth.js
@@ -13,8 +13,12 @@ export class Auth {
         this.log = opts.fplus.debug.bound("authz");
     }
 
-    async check_acl(principal, permission, target, wild) {
-        const acl = await this.auth.fetch_acl(principal, Perm.All);
+    fetch_acl (principal) {
+        return this.auth.fetch_acl(principal, Perm.All);
+    }
+
+    async check_acl (principal, permission, target, wild) {
+        const acl = await this.fetch_acl(principal);
         return acl(permission, target, wild);
     }
 

--- a/acs-configdb/lib/constants.js
+++ b/acs-configdb/lib/constants.js
@@ -52,13 +52,13 @@ export const Device_Info = {
 
 export const Perm = {
     All: "c43c7157-a50b-4d2a-ac1a-86ff8e8e88c1",
-    Read_App: "4a339562-cd57-408d-9d1a-6529a383ea4b",
-    Write_App: "6c799ccb-d2ad-4715-a2a7-3c8728d6c0bf",
-    Manage_Obj: "f0b7917b-d475-4888-9d5a-2af96b3c26b6",
-    Delete_Obj: "6957174b-7b08-45ca-ac5c-c03ab6928a6e",
-    Manage_App: "95c7cbcb-ce60-49ed-aa81-2fe3eec4559d",
-    Give_To: "4eaab346-4d1e-11f0-800e-dfdc061c6a63",
-    Take_From: "6ad67652-5009-11f0-9404-73b79124c3d5",
+    ReadApp: "4a339562-cd57-408d-9d1a-6529a383ea4b",
+    WriteApp: "6c799ccb-d2ad-4715-a2a7-3c8728d6c0bf",
+    ManageObj: "f0b7917b-d475-4888-9d5a-2af96b3c26b6",
+    DeleteObj: "6957174b-7b08-45ca-ac5c-c03ab6928a6e",
+    ManageApp: "95c7cbcb-ce60-49ed-aa81-2fe3eec4559d",
+    GiveTo: "4eaab346-4d1e-11f0-800e-dfdc061c6a63",
+    TakeFrom: "6ad67652-5009-11f0-9404-73b79124c3d5",
 };
 
 export const BootstrapUUIDs = { App, Perm, SpecialObj };

--- a/acs-configdb/lib/constants.js
+++ b/acs-configdb/lib/constants.js
@@ -52,13 +52,32 @@ export const Device_Info = {
 
 export const Perm = {
     All: "c43c7157-a50b-4d2a-ac1a-86ff8e8e88c1",
+
     ReadApp: "4a339562-cd57-408d-9d1a-6529a383ea4b",
     WriteApp: "6c799ccb-d2ad-4715-a2a7-3c8728d6c0bf",
-    ManageObj: "f0b7917b-d475-4888-9d5a-2af96b3c26b6",
+
+    ListObj: "6b4d73ea-50f1-11f0-9333-132037a152a5",
+    CreateObj: "ae09e2ba-50ef-11f0-ac03-1f9f5e6548be",
+    CreateSpecificObj: "e3491b9c-50f1-11f0-8e16-e75c8f93227b",
+    ReadMembers: "d4fd61da-50ef-11f0-ad24-335234e4c8a2",
+    WriteMembers: "c2759f6e-50ef-11f0-8730-ef0ba0514a0e",
+    WriteMemberships: "e08d89bc-50ef-11f0-8352-83e3d3d35028",
+    ReadSubclasses: "e6bb9978-50ef-11f0-b3c2-b79b9f64d2ff",
+    WriteSubclasses: "ed11bd2a-50ef-11f0-9f85-df13a1dff9e6",
+    WriteSuperclasses: "fb8e5048-50ef-11f0-91c5-7fd3cb373fbb",
+
+    /* Unimplemented */
+    //ReadMemberships: "db9f5dae-50ef-11f0-b846-8393c17d1574",
+    //ReadSuperclasses: "f590e476-50ef-11f0-a120-e7c6d06d79ed",
+
     DeleteObj: "6957174b-7b08-45ca-ac5c-c03ab6928a6e",
-    ManageApp: "95c7cbcb-ce60-49ed-aa81-2fe3eec4559d",
     GiveTo: "4eaab346-4d1e-11f0-800e-dfdc061c6a63",
     TakeFrom: "6ad67652-5009-11f0-9404-73b79124c3d5",
+
+    /* Obsolete */
+    //ManageApp: "95c7cbcb-ce60-49ed-aa81-2fe3eec4559d",
+    // Reimplemented as a composite permission
+    //ManageObj: "f0b7917b-d475-4888-9d5a-2af96b3c26b6",
 };
 
 export const BootstrapUUIDs = { App, Perm, SpecialObj };

--- a/acs-configdb/lib/load.js
+++ b/acs-configdb/lib/load.js
@@ -34,7 +34,7 @@ export class Loader {
          * an atomic create endpoint. OTOH, doing detailed and correct
          * permission checking will be difficult from within the dump
          * code. */
-        const perms = [Perm.Manage_Obj, Perm.Take_From, Perm.Write_App];
+        const perms = [Perm.ManageObj, Perm.TakeFrom, Perm.WriteApp];
         for (const perm of perms) {
             const ok = await this.auth.check_acl(req.auth, perm, UUIDs.Null, false);
             if (!ok) {

--- a/acs-configdb/lib/load.js
+++ b/acs-configdb/lib/load.js
@@ -34,7 +34,13 @@ export class Loader {
          * an atomic create endpoint. OTOH, doing detailed and correct
          * permission checking will be difficult from within the dump
          * code. */
-        const perms = [Perm.ManageObj, Perm.TakeFrom, Perm.WriteApp];
+        const perms = [
+            Perm.CreateSpecificObj,
+            Perm.WriteMembers, Perm.WriteMemberships,
+            Perm.WriteSubclasses, Perm.WriteSuperclasses,
+            Perm.TakeFrom,
+            Perm.WriteApp,
+        ];
         for (const perm of perms) {
             const ok = await this.auth.check_acl(req.auth, perm, UUIDs.Null, false);
             if (!ok) {

--- a/acs-configdb/lib/model.js
+++ b/acs-configdb/lib/model.js
@@ -102,6 +102,12 @@ export default class Model extends EventEmitter {
         return rv;
     }
 
+    async fetch_acl () {
+        if (!this.upn)
+            return () => false;
+        return this.authz.fetch_acl(this.upn);
+    }
+
     async check_acl (perm, targ) {
         if (!this.upn)
             return;

--- a/acs-configdb/lib/model.js
+++ b/acs-configdb/lib/model.js
@@ -297,10 +297,10 @@ export default class Model extends EventEmitter {
          * Everyone implicitly has: TakeFrom Self; GiveTo Self, Unowned.
          */
         const f_ok = from.owner == await this.client_uuid()
-            || await this.check_acl(Perm.Take_From, from.owner);
+            || await this.check_acl(Perm.TakeFrom, from.owner);
         const t_ok = to.owner == SpecialObj.Unowned
             || to.owner == await this.client_uuid()
-            || await this.check_acl(Perm.Give_To, to.owner);
+            || await this.check_acl(Perm.GiveTo, to.owner);
         if (!f_ok || !t_ok) return 403;
 
         const owner = await this._obj_id(q, to.owner);
@@ -454,7 +454,7 @@ export default class Model extends EventEmitter {
 
         const ok = spec.owner == SpecialObj.Unowned
             || spec.owner == await this.client_uuid()
-            || await this.check_acl(Perm.Give_To, spec.owner);
+            || await this.check_acl(Perm.GiveTo, spec.owner);
         if (!ok) return [403];
 
         const o_id = await this._obj_id(q, spec.owner);

--- a/acs-configdb/lib/notify.js
+++ b/acs-configdb/lib/notify.js
@@ -14,6 +14,7 @@ import {
 }  from "@amrc-factoryplus/service-api";
 
 import { Perm } from "./constants.js";
+import { Relations } from "./relations.js";
 import * as rxu from "./rx-util.js";
 
 const mk_res = (response, ix) => ({ status: ix ? 200 : 201, response });
@@ -196,10 +197,10 @@ class ConfigWatch {
  * lookup meaning we might miss notifications. It would be better to
  * pass the update in the sequence but I think that would mean caching
  * the whole class structure js-side. */
-function class_watch (rel, session, klass) {
+function class_watch (rel, perm, session, klass) {
     const model = session.model;
 
-    const ck_acl = acl_checker(session, Perm.ManageObj, klass, true);
+    const ck_acl = acl_checker(session, perm, klass, true);
 
     return rxx.rx(
         model.updates,
@@ -231,25 +232,14 @@ export class CDBNotify extends Notify {
                 handler:    (s, f, a) => new ConfigWatch(s, a).config_search(f),
             }),
         ];
+        const rel = r => new WatchFilter({
+            path:       `v2/class/:class/${r.path}/`,
+            handler:    class_watch.bind(null, r.table, r.cperm),
+        });
         return [
             ...v1_2("v1"),
             ...v1_2("v2"),
-            new WatchFilter({
-                path:       "v2/class/:class/member/",
-                handler:    class_watch.bind(null, "all_membership"),
-            }),
-            new WatchFilter({
-                path:       "v2/class/:class/subclass/",
-                handler:    class_watch.bind(null, "all_subclass"),
-            }),
-            new WatchFilter({
-                path:       "v2/class/:class/direct/member/",
-                handler:    class_watch.bind(null, "membership"),
-            }),
-            new WatchFilter({
-                path:       "v2/class/:class/direct/subclass/",
-                handler:    class_watch.bind(null, "subclass"),
-            }),
+            ...Relations.map(rel),
         ];
     }
     

--- a/acs-configdb/lib/notify.js
+++ b/acs-configdb/lib/notify.js
@@ -92,7 +92,7 @@ class ConfigWatch {
             this.model.updates,
             rx.filter(u => u.type == "config"));
 
-        this.check_acl = acl_checker(this.session, Perm.Read_App, this.app, true);
+        this.check_acl = acl_checker(this.session, Perm.ReadApp, this.app, true);
     }
 
     single_config (object) {
@@ -199,7 +199,7 @@ class ConfigWatch {
 function class_watch (rel, session, klass) {
     const model = session.model;
 
-    const ck_acl = acl_checker(session, Perm.Manage_Obj, klass, true);
+    const ck_acl = acl_checker(session, Perm.ManageObj, klass, true);
 
     return rxx.rx(
         model.updates,

--- a/acs-configdb/lib/relations.js
+++ b/acs-configdb/lib/relations.js
@@ -1,0 +1,43 @@
+/* ACS ConfigDB
+ * Relation definitions
+ * Copyright 2025 University of Sheffield AMRC
+ */
+
+import { Perm } from "./constants.js";
+
+/*  path    URL path segment for the API
+ *  table   Backend table/view
+ *  cperm   Class-end permission
+ *  operm   Object-end permission
+ *  add     Model method to add a relation
+ *  remove  Model method to remove a relation
+ */
+
+export const Relations = [
+    {
+        path:   "member",
+        table:  "all_membership",
+        cperm:  Perm.ReadMembers,
+        //operm:  Perm.ReadMemberships,
+    }, {
+        path:   "direct/member",
+        table:  "membership",
+        cperm:  Perm.WriteMembers,
+        operm:  Perm.WriteMembership,
+        add:    m => m.class_add_member,
+        remove: m => m.class_remove_member,
+    }, {
+        path:   "subclass",
+        table:  "all_subclass",
+        cperm:  Perm.ReadSubclasses,
+        //operm:  Perm.ReadSuperclasses,
+    }, {
+        path:   "direct/subclass",
+        table:  "subclass",
+        cperm:  Perm.WriteSubclasses,
+        operm:  Perm.ReadSubclasses,
+        add:    m => m.class_add_subclass,
+        remove: m => m.class_remove_subclass,
+    },
+];
+

--- a/acs-service-setup/dumps/acs-v2.yaml
+++ b/acs-service-setup/dumps/acs-v2.yaml
@@ -21,13 +21,26 @@ objects:
   # Directory perms are in directory.yaml
 
   !u ACS.PermGroup.ConfigDB:
-    !u ConfigDB.Perm.ReadConfig:      { name: "Read config for app" }
-    !u ConfigDB.Perm.WriteConfig:     { name: "Write config for app" }
-    !u ConfigDB.Perm.ManageAppSchema: { name: "Manage application schema" }
-    !u ConfigDB.Perm.ManageObjects:   { name: "Manage objects" }
-    !u ConfigDB.Perm.DeleteObjects:   { name: "Delete objects" }
-    !u ConfigDB.Perm.TakeFrom:        { name: "Take ownership from" }
-    !u ConfigDB.Perm.GiveTo:          { name: "Give ownership to" }
+    !u ConfigDB.Perm.ReadConfig:            { name: "Read config for app" }
+    !u ConfigDB.Perm.WriteConfig:           { name: "Write config for app" }
+
+    !u ConfigDB.Perm.ListObjects:           { name: "List objects" }
+    !u ConfigDB.Perm.CreateObject:          { name: "Create object" }
+    !u ConfigDB.Perm.CreateSpecificObject:  { name: "Create specific object" }
+    !u ConfigDB.Perm.ReadMembers:           { name: "Read class members" }
+    !u ConfigDB.Perm.WriteMembers:          { name: "Write class members" }
+    !u ConfigDB.Perm.WriteMemberships:      { name: "Write object memberships" }
+    !u ConfigDB.Perm.ReadSubclasses:        { name: "Read class subclasses" }
+    !u ConfigDB.Perm.WriteSubclasses:       { name: "Write class subclasses" }
+    !u ConfigDB.Perm.WriteSuperclasses:     { name: "Write class superclasses" }
+
+    # Unimplemented
+    #!u ConfigDB.Perm.ReadMemberships:      { name: "Read object memberships" }
+    #!u ConfigDB.Perm.ReadSuperclasses:     { name: "Read class superclasses" }
+
+    !u ConfigDB.Perm.DeleteObject:          { name: "Delete object" }
+    !u ConfigDB.Perm.TakeFrom:              { name: "Take ownership from" }
+    !u ConfigDB.Perm.GiveTo:                { name: "Give ownership to" }
 
   !u ACS.PermGroup.MQTT:
     !u MQTT.Perm.ReadNode:            { name: "Read Node" }

--- a/acs-service-setup/dumps/admin.yaml
+++ b/acs-service-setup/dumps/admin.yaml
@@ -100,4 +100,4 @@ grants:
     !u ACS.PermGroup.ConfigDB: null
     !u ACS.PermGroup.Directory: null
     !u ACS.PermGroup.Git: null
-
+    !u Files.Perm.All: null

--- a/acs-service-setup/dumps/clusters.yaml
+++ b/acs-service-setup/dumps/clusters.yaml
@@ -416,8 +416,11 @@ grants:
       !u Git.App.Config: false
       !u UUIDs.App.SparkplugAddress: false
 
-    !u UUIDs.Permission.ConfigDB.ManageObjects:
+    !u ConfigDB.Perm.CreateObject:
       !u Clusters.Class.Account: false
+    !u ConfigDB.Perm.WriteMemberships:
+      !u UUIDs.Special.Mine: true
+    !u ConfigDB.Perm.WriteMembers:
       !u Clusters.Class.ClusterGroups: true
 
     !u Git.Perm.Pull:
@@ -430,27 +433,25 @@ grants:
       !u Clusters.Requirement.EdgeRepos: true
       !u Local.RepoGroup.Cluster: true
 
-  # XXX Do we still need this? KrbKeys sealed to edge clusters have been
-  # replaced with krbkeys generated on the edge.
-  !u ACS.ServiceAccount.KrbKeys:
-    !u Clusters.Perm.Secrets: null
-
   !u Local.Role.EdgeFlux:
     !u Git.Perm.Pull:
       !u Local.RepoGroup.Shared: true
 
   !u Local.Role.EdgeKrbkeys:
-    !u ConfigDB.Perm.ManageObjects:
-      # XXX Should this be removed? Or should these two be for different
-      # permissions?
+    !u ConfigDB.Perm.CreateObject:
       !u Auth.Class.EdgeService: false
+    !u ConfigDB.Perm.WriteMemberships:
+      !u UUIDs.Special.Mine: true
+    !u ConfigDB.Perm.WriteMembers:
       !u Edge.Group.EdgeGroup: true
+
     !u ConfigDB.Perm.ReadConfig:
       !u UUIDs.App.Info: false
       !u UUIDs.App.SparkplugAddress: false
     !u ConfigDB.Perm.WriteConfig:
       !u UUIDs.App.Info: false
       !u UUIDs.App.SparkplugAddress: false
+
     !u Auth.Perm.ReadKerberos: null
     # XXX This is root-equivalent
     !u Auth.Perm.ManageKerberos: null

--- a/acs-service-setup/dumps/clusters.yaml
+++ b/acs-service-setup/dumps/clusters.yaml
@@ -442,6 +442,8 @@ grants:
       !u Auth.Class.EdgeService: false
     !u ConfigDB.Perm.WriteMemberships:
       !u UUIDs.Special.Mine: true
+      # XXX This is too broad. Ideally we need a group per cluster.
+      !u Local.Role.EdgeAgent: true
     !u ConfigDB.Perm.WriteMembers:
       !u Edge.Group.EdgeGroup: true
 

--- a/acs-service-setup/dumps/composite.yaml
+++ b/acs-service-setup/dumps/composite.yaml
@@ -43,6 +43,25 @@ objects:
       enum:
         - !u ACS.Perm.MQTT.ReadWholeNamespace
         - !u UUIDs.Permission.CmdEsc.Rebirth
+    !u ACS.Perm.Composite.ManageObjects:
+      name: "Manage objects"
+      subclassOf:
+        - !u UUIDs.Class.Permission
+      enum:
+        - !u ConfigDB.Perm.ListObjects
+        - !u ConfigDB.Perm.CreateObject
+        - !u ConfigDB.Perm.CreateSpecificObject
+        - !u ConfigDB.Perm.DeleteObject
+        - !u ConfigDB.Perm.ReadMembers
+        - !u ConfigDB.Perm.WriteMembers
+        - !u ConfigDB.Perm.WriteMemberships
+        - !u ConfigDB.Perm.ReadSubclasses
+        - !u ConfigDB.Perm.WriteSubclasses
+        - !u ConfigDB.Perm.WriteSuperclasses
+        # Unimplemented
+        #- !u ConfigDB.Perm.ReadMemberships
+        #- !u ConfigDB.Perm.ReadSuperclasses
+
 ---
 service: !u UUIDs.Service.Authentication
 version: 2

--- a/acs-service-setup/dumps/files.yaml
+++ b/acs-service-setup/dumps/files.yaml
@@ -67,6 +67,3 @@ grants:
     !u ConfigDB.Perm.ManageObjects:
       !u Files.Class.File: false
 
-  !u ACS.Group.Administrator:
-    !u Files.Perm.All: null
-

--- a/acs-service-setup/dumps/files.yaml
+++ b/acs-service-setup/dumps/files.yaml
@@ -64,6 +64,4 @@ grants:
       !u Files.App.Config: false
     !u ConfigDB.Perm.WriteConfig:
       !u Files.App.Config: false
-    !u ConfigDB.Perm.ManageObjects:
-      !u Files.Class.File: false
 

--- a/acs-service-setup/dumps/service-accounts.yaml
+++ b/acs-service-setup/dumps/service-accounts.yaml
@@ -27,7 +27,7 @@ objects:
     !u ACS.ServiceAccount.KrbKeys:
       name: "Kerberos keys operator"
     !u ACS.ServiceAccount.Manager:
-      name: "Manager"
+      name: "ACS v2 Manager"
     !u ACS.ServiceAccount.MQTT:
       name: "MQTT broker"
     !u ACS.ServiceAccount.Warehouse:
@@ -97,26 +97,20 @@ grants:
     !u ConfigDB.Perm.WriteConfig:
       !u UUIDs.App.Info: false
       !u UUIDs.App.SparkplugAddress: false
-    !u ConfigDB.Perm.ManageObjects: null
+    !u ConfigDB.Perm.CreateObject:
+      !u Auth.Class.PrincipalType: true
+    !u ConfigDB.Perm.WriteMemberships:
+      !u UUIDs.Special.Mine: true
+    !u ConfigDB.Perm.WriteMembers:
+      !u Auth.Class.Role: true
+    # XXX Do we still need this? KrbKeys sealed to edge clusters have been
+    # replaced with krbkeys generated on the edge.
+    !u Clusters.Perm.Secrets: null
 
-  !u ACS.ServiceAccount.Manager:
-    !u ConfigDB.Perm.ManageObjects:
-      !u Clusters.Class.Cluster: false
-      !u Auth.Class.EdgeAgent: false
-    !u ConfigDB.Perm.ReadConfig:
-      !u UUIDs.App.ServiceConfig: false
-      !u UUIDs.App.Info: false
-      !u Clusters.App.EdgeStatus: false
-      !u Clusters.App.Cluster: false
-      !u Clusters.App.HelmChart: false
-      !u Edge.App.AgentConfig: false
-    !u ConfigDB.Perm.WriteConfig:
-      !u Clusters.App.Cluster: false
-      !u Edge.App.Deployment: false
-      !u Edge.App.AgentConfig: false
-      !u UUIDs.App.Info: false
-      !u UUIDs.App.SparkplugAddress: false
-    !u Clusters.Perm.Clusters: null
+
+  # This is the account for the old V2 Manager. It is redundant now so
+  # revoke all its permissions.
+  !u ACS.ServiceAccount.Manager: {}
 
   !u ACS.ServiceAccount.CmdEsc:
     !u UUIDs.Permission.ConfigDB.ReadConfig:

--- a/acs-service-setup/lib/fixups.js
+++ b/acs-service-setup/lib/fixups.js
@@ -5,7 +5,9 @@
 
 import k8s from "@kubernetes/client-node";
 
-import { Auth } from "./uuids.js";
+import { UUIDs } from "@amrc-factoryplus/service-client";
+
+import { ACS, Auth, Clusters } from "./uuids.js";
 
 const APIVERSION = "factoryplus.app.amrc.co.uk/v1";
 const ACCUUID = "krbkeys.factoryplus.app.amrc.co.uk/account-uuid";
@@ -30,10 +32,22 @@ class FixupAccounts {
         await this.edge_accounts();
     }
 
+    async set_owner (obj, owner) {
+        if (!owner) {
+            this.log("Can't find correct owner for %s");
+            return;
+        }
+        this.log("Setting ownership of %s to %s", obj, owner);
+        await this.fplus.ConfigDB.patch_config(UUIDs.App.Registration,
+            obj, "merge", { owner });
+    }
+
     /* We need to reset ownership on account objects which should be owned
      * by krbkeys. For central krbkeys we don't know whether additional
      * resources have been deployed so we need to check the cluster. */
     async central_krbkeys () {
+        this.log("Resetting ownership on central KerberosKey accounts");
+        
         const kc = new k8s.KubeConfig();
         kc.loadFromCluster();
         const namespace = kc.getContextObject(kc.currentContext).namespace;
@@ -46,7 +60,9 @@ class FixupAccounts {
         const accounts = body.items
             .map(k => k.metadata?.annotations?.[ACCUUID])
             .filter(v => v != null);
-        this.log("CENTRAL KRBKEYS: %o", accounts);
+
+        for (const a of accounts)
+            await this.set_owner(a, ACS.ServiceAccount.KrbKeys);
     }
 
     /* For edge accounts we have to make a few more assumptions as we
@@ -54,8 +70,15 @@ class FixupAccounts {
      * and Edge Krbkeys accounts were created by cluster-manager, and
      * all other Edge accounts were created by the edge krbkeys. */
     async edge_accounts () {
+        this.log("Resetting ownership on edge accounts");
+
         const auth = this.fplus.Auth;
         const cdb = this.fplus.ConfigDB;
+
+        const clmgrs = await cdb.class_members(Clusters.Requirement.ServiceAccount);
+        if (clmgrs.length != 1)
+            throw new Error("Can't locate Cluster Manager service account");
+        const clmgr = clmgrs[0];
 
         const members = c => cdb.class_members(c).then(l => new Set(l));
 
@@ -64,27 +87,26 @@ class FixupAccounts {
         const flux = await members(this.Local.Role.EdgeFlux);
         const krbkeys = await members(this.Local.Role.EdgeKrbkeys);
 
-        const clmgr = flux.union(krbkeys);
-        const edge = service.difference(clmgr).union(agent);
+        const for_cl = flux.union(krbkeys);
+        const for_kk = service.difference(for_cl).union(agent);
 
-        this.log("CLUSTER MANAGER: %o", clmgr);
-        this.log("EDGE KRBKEYS: %o", edge);
+        this.log("Setting ownership for Cluster Manager accounts");
+        for (const a of for_cl)
+            await this.set_owner(a, clmgr);
 
         /* Now we have to place the edge accounts with their owners. To
          * do this we need to extract the clusters from the UPNs. */
-        const upns = await Promise.all([...krbkeys, ...edge]
+        const upns = await Promise.all([...krbkeys, ...for_kk]
             .map(u => auth.get_identity(u, "kerberos")
                 .then(upn => [u, /^[^/]+\/([^/@]+)/.exec(upn)?.[1]])));
         const clusters = new Map(upns.filter(([u, c]) => c));
-        this.log("CLUSTERS: %o", clusters);
 
-        const kk_c = new Map([...krbkeys]
+        const cluster_kk = new Map([...krbkeys]
             .map(k => [clusters.get(k), k])
             .filter(([k, v]) => k));
-        this.log("KRBKEYS: %o", kk_c);
 
-        for (const e of edge) {
-            this.log("EDGE ACCOUNT %s OWNER %s", e, kk_c.get(clusters.get(e)));
-        }
+        this.log("Setting ownership for edge krbkeys accounts");
+        for (const e of for_kk)
+            await this.set_owner(e, cluster_kk.get(clusters.get(e)));
     }
 }

--- a/acs-service-setup/lib/fixups.js
+++ b/acs-service-setup/lib/fixups.js
@@ -82,13 +82,20 @@ class FixupAccounts {
 
         const members = c => cdb.class_members(c).then(l => new Set(l));
 
-        const agent = await members(Auth.Class.EdgeAgent);
+        /* Edge Agents are owned by their creators. These will have to
+         * be fixed manually as we have no way of knowing who they are.
+         * For now the edge krbkeys have change-membership permission on
+         * all Edge Agents; this isn't ideal but I haven't worked out
+         * how to implement a class of Agents per cluster yet.
+         */
+        //const agent = await members(Auth.Class.EdgeAgent);
+        
         const service = await members(Auth.Class.EdgeService);
         const flux = await members(this.Local.Role.EdgeFlux);
         const krbkeys = await members(this.Local.Role.EdgeKrbkeys);
 
         const for_cl = flux.union(krbkeys);
-        const for_kk = service.difference(for_cl).union(agent);
+        const for_kk = service.difference(for_cl);
 
         this.log("Setting ownership for Cluster Manager accounts");
         for (const a of for_cl)

--- a/acs-service-setup/lib/fixups.js
+++ b/acs-service-setup/lib/fixups.js
@@ -3,14 +3,86 @@
  * Copyright 2023 AMRC
  */
 
-/* This file is currently redundant; it did migrations needed when
- * upgrading ACS v2 -> v3. These have now been removed; we do not
- * support skipping major versions. I am keeping the file, as we will
- * probably need more fixups in the future... */
+import k8s from "@kubernetes/client-node";
 
-export async function fixups (ss) {
-    //const { fplus } = ss;
+import { Auth } from "./uuids.js";
+
+const APIVERSION = "factoryplus.app.amrc.co.uk/v1";
+const ACCUUID = "krbkeys.factoryplus.app.amrc.co.uk/account-uuid";
+
+export async function fixups (ss, local) {
+    const { fplus } = ss;
+
+    await new FixupAccounts(fplus, local).run();
 
     return;
 }
 
+class FixupAccounts {
+    constructor (fplus, local) {
+        this.fplus = fplus;
+        this.log = fplus.debug.bound("accounts");
+        this.Local = local;
+    }
+
+    async run () {
+        await this.central_krbkeys();
+        await this.edge_accounts();
+    }
+
+    /* We need to reset ownership on account objects which should be owned
+     * by krbkeys. For central krbkeys we don't know whether additional
+     * resources have been deployed so we need to check the cluster. */
+    async central_krbkeys () {
+        const kc = new k8s.KubeConfig();
+        kc.loadFromCluster();
+        const namespace = kc.getContextObject(kc.currentContext).namespace;
+        const objs = k8s.KubernetesObjectApi.makeApiClient(kc);
+        
+        const { response, body } = await objs.list(APIVERSION, "KerberosKey", namespace);
+        if (response.statusCode != 200)
+            throw new Error(`Can't list KerberosKeys: ${response.statusCode}`);
+
+        const accounts = body.items
+            .map(k => k.metadata?.annotations?.[ACCUUID])
+            .filter(v => v != null);
+        this.log("CENTRAL KRBKEYS: %o", accounts);
+    }
+
+    /* For edge accounts we have to make a few more assumptions as we
+     * don't have access to the edge cluster. So we assume all Edge Flux
+     * and Edge Krbkeys accounts were created by cluster-manager, and
+     * all other Edge accounts were created by the edge krbkeys. */
+    async edge_accounts () {
+        const auth = this.fplus.Auth;
+        const cdb = this.fplus.ConfigDB;
+
+        const members = c => cdb.class_members(c).then(l => new Set(l));
+
+        const agent = await members(Auth.Class.EdgeAgent);
+        const service = await members(Auth.Class.EdgeService);
+        const flux = await members(this.Local.Role.EdgeFlux);
+        const krbkeys = await members(this.Local.Role.EdgeKrbkeys);
+
+        const clmgr = flux.union(krbkeys);
+        const edge = service.difference(clmgr).union(agent);
+
+        this.log("CLUSTER MANAGER: %o", clmgr);
+        this.log("EDGE KRBKEYS: %o", edge);
+
+        /* Now we have to place the edge accounts with their owners. To
+         * do this we need to extract the clusters from the UPNs. */
+        const upns = await Promise.all([...krbkeys, ...edge]
+            .map(u => auth.get_identity(u, "kerberos")
+                .then(upn => [u, /\.(.*)@/.exec(upn)?.[1]])));
+        const clusters = new Map(upns.filter(([u, c]) => c));
+        this.log("CLUSTERS: %o", clusters);
+
+        const kk_c = new Map([...krbkeys].map(k => [clusters.get(k), k]));
+        this.log("KRBKEYS: %o", kk_c);
+
+        for (const e of edge) {
+            this.log("EDGE ACCOUNT %s OWNER %s", e, kk_c.get(clusters.get(e)));
+        }
+    }
+}

--- a/acs-service-setup/lib/fixups.js
+++ b/acs-service-setup/lib/fixups.js
@@ -74,11 +74,13 @@ class FixupAccounts {
          * do this we need to extract the clusters from the UPNs. */
         const upns = await Promise.all([...krbkeys, ...edge]
             .map(u => auth.get_identity(u, "kerberos")
-                .then(upn => [u, /\.(.*)@/.exec(upn)?.[1]])));
+                .then(upn => [u, /^[^/]+\/([^/@]+)/.exec(upn)?.[1]])));
         const clusters = new Map(upns.filter(([u, c]) => c));
         this.log("CLUSTERS: %o", clusters);
 
-        const kk_c = new Map([...krbkeys].map(k => [clusters.get(k), k]));
+        const kk_c = new Map([...krbkeys]
+            .map(k => [clusters.get(k), k])
+            .filter(([k, v]) => k));
         this.log("KRBKEYS: %o", kk_c);
 
         for (const e of edge) {

--- a/acs-service-setup/lib/service-setup.js
+++ b/acs-service-setup/lib/service-setup.js
@@ -61,12 +61,12 @@ export class ServiceSetup {
         await this.wait_for(fplus.Auth, "2.0.0");
         await this.wait_for(fplus.ConfigDB, "2.0.0");
 
-        this.log("Running fixups");
-        await fixups(this);
-
         this.log("Creating local UUIDs");
         const local = await setup_local_uuids(this);
         this.dumps.set_local_uuids(local);
+
+        this.log("Running fixups");
+        await fixups(this, local);
 
         this.log("Loading service dump files");
         await this.dumps.load_dumps(false);

--- a/acs-service-setup/lib/uuids.js
+++ b/acs-service-setup/lib/uuids.js
@@ -97,15 +97,18 @@ export const ACS = {
      * ServiceRequirement groups to grant them permissions. */
     ServiceAccount: {
         Auth:                   "1e1989ab-14e4-42bd-8171-495230acc406",
-        ClusterManager:         "127cde3c-773a-4f61-b0ba-7412a2695253",
         CmdEsc:                 "23d4e8f9-76c0-49d5-addc-00b6ac05ee58",
         ConfigDB:               "36861e8d-9152-40c4-8f08-f51c2d7e3c25",
         Directory:              "5cc3b068-938f-4bb2-8ceb-64338a02fbeb",
         Git:                    "626df296-8156-4c67-8aed-aac70161aa8b",
         KrbKeys:                "a04b4195-7db4-4480-b3f3-4d22c08b96ea",
-        Manager:                "2340e706-1280-420c-84a6-016547b55e95",
         MQTT:                   "2f42daeb-4521-4522-8e19-85dfb73db88e",
         Warehouse:              "388ddbdc-4eb4-4ae8-bbd0-9be32f3c31e8",
+
+        /* Obsolete: these are now dynamic */
+        ClusterManager:         "127cde3c-773a-4f61-b0ba-7412a2695253",
+        /* These accounts are obsolete */
+        Manager:                "2340e706-1280-420c-84a6-016547b55e95",
     },
     Driver: {
         /* Edge Agent internal drivers */

--- a/acs-service-setup/lib/uuids.js
+++ b/acs-service-setup/lib/uuids.js
@@ -31,6 +31,7 @@ export const ACS = {
             CmdEsc:             "dbd0c099-6c59-4bc6-aa92-4ba8a9b543f4",
             EdgeNode:           "87e4a5b7-9a89-4796-a216-39666a47b9d2",
             EdgeNodeConsumer:   "17a64293-b82d-4db4-af4d-63359bb62934",
+            ManageObjects:      "f0b7917b-d475-4888-9d5a-2af96b3c26b6",
             PrimaryApp:         "c0d17bcf-2a90-40e5-b244-07bf631f7417",
             Warehouse:          "6958c812-fbe2-4e6c-b997-6f850b89f679",
         },
@@ -155,11 +156,29 @@ export const ConfigDB = {
     Perm: {
         ReadConfig: "4a339562-cd57-408d-9d1a-6529a383ea4b",
         WriteConfig: "6c799ccb-d2ad-4715-a2a7-3c8728d6c0bf",
-        ManageAppSchema: "95c7cbcb-ce60-49ed-aa81-2fe3eec4559d",
-        ManageObjects: "f0b7917b-d475-4888-9d5a-2af96b3c26b6",
-        DeleteObjects: "6957174b-7b08-45ca-ac5c-c03ab6928a6e",
+
+        ListObjects: "6b4d73ea-50f1-11f0-9333-132037a152a5",
+        CreateObject: "ae09e2ba-50ef-11f0-ac03-1f9f5e6548be",
+        CreateSpecificObject: "e3491b9c-50f1-11f0-8e16-e75c8f93227b",
+        ReadMembers: "d4fd61da-50ef-11f0-ad24-335234e4c8a2",
+        WriteMembers: "c2759f6e-50ef-11f0-8730-ef0ba0514a0e",
+        WriteMemberships: "e08d89bc-50ef-11f0-8352-83e3d3d35028",
+        ReadSubclasses: "e6bb9978-50ef-11f0-b3c2-b79b9f64d2ff",
+        WriteSubclasses: "ed11bd2a-50ef-11f0-9f85-df13a1dff9e6",
+        WriteSuperclasses: "fb8e5048-50ef-11f0-91c5-7fd3cb373fbb",
+
+        /* Unimplemented */
+        //ReadMemberships: "db9f5dae-50ef-11f0-b846-8393c17d1574",
+        //ReadSuperclasses: "f590e476-50ef-11f0-a120-e7c6d06d79ed",
+
+        DeleteObject: "6957174b-7b08-45ca-ac5c-c03ab6928a6e",
         GiveTo: "4eaab346-4d1e-11f0-800e-dfdc061c6a63",
         TakeFrom: "6ad67652-5009-11f0-9404-73b79124c3d5",
+    
+        /* Obsolete */
+        //ManageAppSchema: "95c7cbcb-ce60-49ed-aa81-2fe3eec4559d",
+        /* Implemented as a composite permission */
+        //ManageObjects: "f0b7917b-d475-4888-9d5a-2af96b3c26b6",
     }
 };
 

--- a/acs-service-setup/package.json
+++ b/acs-service-setup/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "@amrc-factoryplus/service-client": "file:../lib/js-service-client",
+    "@kubernetes/client-node": "^1.3.0",
     "tsort": "^0.0.1",
     "uuid": "^11.1.0",
     "yaml": "^2.3.4"

--- a/acs-service-setup/package.json
+++ b/acs-service-setup/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "@amrc-factoryplus/service-client": "file:../lib/js-service-client",
-    "@kubernetes/client-node": "^1.3.0",
+    "@kubernetes/client-node": "^0.19.0",
     "tsort": "^0.0.1",
     "uuid": "^11.1.0",
     "yaml": "^2.3.4"

--- a/deploy/templates/configdb/configdb.yaml
+++ b/deploy/templates/configdb/configdb.yaml
@@ -127,9 +127,9 @@ spec:
               value: "{{ .Values.configdb.bodyLimit }}"
             - name: BOOTSTRAP_ACL
               value: |
-                sv1auth@{{ .Values.identity.realm }}:Perm.Read_App:App.Registration
-                sv1auth@{{ .Values.identity.realm }}:Perm.Read_App:App.SparkplugAddress
-                sv1auth@{{ .Values.identity.realm }}:Perm.Manage_Obj:SpecialObj.Wildcard
+                sv1auth@{{ .Values.identity.realm }}:Perm.ReadApp:App.Registration
+                sv1auth@{{ .Values.identity.realm }}:Perm.ReadApp:App.SparkplugAddress
+                sv1auth@{{ .Values.identity.realm }}:Perm.ManageObj:SpecialObj.Wildcard
             - name: ROOT_PRINCIPAL
               value: admin@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
             # This is the value published via MQTT. The CDB editor does

--- a/deploy/templates/configdb/configdb.yaml
+++ b/deploy/templates/configdb/configdb.yaml
@@ -127,9 +127,10 @@ spec:
               value: "{{ .Values.configdb.bodyLimit }}"
             - name: BOOTSTRAP_ACL
               value: |
-                sv1auth@{{ .Values.identity.realm }}:Perm.ReadApp:App.Registration
-                sv1auth@{{ .Values.identity.realm }}:Perm.ReadApp:App.SparkplugAddress
-                sv1auth@{{ .Values.identity.realm }}:Perm.ManageObj:SpecialObj.Wildcard
+                sv1auth:Perm.ReadApp:App.Registration
+                sv1auth:Perm.ReadApp:App.SparkplugAddress
+                sv1auth:Perm.ReadMembers:SpecialObj.Wildcard
+                sv1auth:Perm.ReadSubclasses:SpecialObj.Wildcard
             - name: ROOT_PRINCIPAL
               value: admin@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
             # This is the value published via MQTT. The CDB editor does

--- a/deploy/templates/service-setup.yaml
+++ b/deploy/templates/service-setup.yaml
@@ -125,9 +125,12 @@ metadata:
   name: service-setup-role
   namespace: {{ .Release.Namespace }}
 rules:
-  - apiGroups: [ "apps" ]
-    resources: [ "deployments" ]
-    verbs: [ "get", "patch", "update", "list", "watch" ]
+  - apiGroups: [apps]
+    resources: [deployments]
+    verbs: [get, patch, update, list, watch]
+  - apiGroups: [factoryplus.app.amrc.co.uk]
+    resources: [kerberos-keys]
+    verbs: [list, get]
 
 ---
 

--- a/lib/js-service-client/lib/service-client.js
+++ b/lib/js-service-client/lib/service-client.js
@@ -15,6 +15,7 @@ function opts_from_env (env) {
         DIRECTORY_URL
         MQTT_URL
         BOOTSTRAP_ACL
+        REALM
         ROOT_PRINCIPAL
         SERVICE_USERNAME:username
         SERVICE_PASSWORD:password

--- a/lib/js-service-client/lib/service/auth.js
+++ b/lib/js-service-client/lib/service/auth.js
@@ -21,16 +21,19 @@ via the ServiceCLient) are:
 - `root_principal`: A Kerberos UPN which overrides all permission checks.
 - `bootstrap_acl`: A string giving ACL entries for bootstrap purposes.
 - `bootstrap_uuids`: An object giving names for the bootstrap ACL UUIDs.
+- `realm`: A string holding the realm for resolving bootstrap ACL princpals.
 
 The bootstrap ACL is normally provided via the BOOTSTRAP_ACL environment
-variable. This is to support services which need some ACL information before the Auth service is available.
+variable. This is to support services which need some ACL information
+before the Auth service is available.
 
 The string will be split on newlines and then on colons, with each line
 having three fields, principal, permission and target. The principal
 must be a Kerberos UPN; no other forms of identity are recognised. The
-permission and target are UUIDs but will first be looked up in the
-`bootstrap_uuids` objects. No group expansion will be performed as this
-is for use before the Auth service is available.
+configured realm will be appended to each principal. The permission and
+target are UUIDs but will first be looked up in the `bootstrap_uuids`
+objects. No group expansion will be performed as this is for use before
+the Auth service is available.
 
 */
 export class Auth extends ServiceInterface {
@@ -44,7 +47,7 @@ export class Auth extends ServiceInterface {
     }
 
     _build_bs_acl (opts) {
-        const { bootstrap_acl, bootstrap_uuids } = opts;
+        const { bootstrap_acl, bootstrap_uuids, realm } = opts;
 
         const wk = new WellKnown({ uuids: bootstrap_uuids ?? {} });
 
@@ -55,7 +58,7 @@ export class Auth extends ServiceInterface {
             .filter(l => l.length)
             .map(l => l.split(":"))
             .map(([princ, perm, targ]) => 
-                [princ, { 
+                [`${princ}@${realm}`, { 
                     permission:     wk.lookup(perm),
                     target:         wk.lookup(targ),
                 }]);

--- a/lib/js-service-client/lib/service/service-interface.js
+++ b/lib/js-service-client/lib/service/service-interface.js
@@ -169,7 +169,7 @@ This calls Fetch.fetch with some additional functionality.
             url:        "load",
             body:       dump,
         });
-        if (st == 200) return;
+        if (st == 200 || st == 204) return;
         this.throw("Failed to load dump", st);
     }
 


### PR DESCRIPTION
**This has not been fully tested and is not ready for merge. Also it should be rebased onto main.**

Currently the _Manage objects_ ConfigDB permission covers a large range of actions. This is because the object model has been made richer but the permission structure has not been expanded to cover new actions.

Divide the _Manage objects_ permission into finer-grained permissions. Ensure appropriate permissions are granted to appropriate services. This requires use of ownership and _Mine_ permissions, so a fixup step is needed to reset ownership on some existing objects.