### PR TITLE
Update HiveMQ CE version in Dockerfile

### DIFF
--- a/acs-mqtt/Dockerfile
+++ b/acs-mqtt/Dockerfile
@@ -1,4 +1,4 @@
-FROM hivemq/hivemq-ce:2023.2
+FROM hivemq/hivemq-ce:2025.4
 
 ARG krb_zipfile=hivemq-auth-krb-0.1.5-distribution.zip
 COPY ${krb_zipfile} /tmp


### PR DESCRIPTION
Upgraded the HiveMQ CE base image from version 2023.2 to 2025.4