### PR TITLE
Add an example service

### DIFF
--- a/acs-example-service/bin/api.js
+++ b/acs-example-service/bin/api.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+import { RxClient, UUIDs } from '@amrc-factoryplus/rx-client';
+import { WebAPI } from '@amrc-factoryplus/service-api';
+import { routes } from '../lib/routes.js';
+import { Version, Service } from '../lib/constants.js';
+import { clean_up } from "../lib/startup.js";
+
+const { env } = process;
+
+const fplus = await new RxClient({
+  env,
+}).init();
+
+const api = await new WebAPI({
+  ping: {
+    version: Version,
+    service: UUIDs.Service.ExampleService,
+    software: {
+      vendor: 'AMRC',
+      application: 'acs-example-service',
+    },
+  },
+  debug: fplus.debug,
+  realm: env.REALM,
+  hostname: env.HOSTNAME,
+  keytab: env.SERVER_KEYTAB,
+  http_port: env.PORT,
+  max_age: env.CACHE_MAX_AGE,
+  routes: routes({
+    fplus,
+  }),
+}).init();
+
+api.run();

--- a/acs-example-service/lib/api-v1.js
+++ b/acs-example-service/lib/api-v1.js
@@ -1,0 +1,76 @@
+import { APIError } from "@amrc-factoryplus/service-api";
+
+function fail(status, message) {
+  throw new APIError(status);
+}
+
+export class APIv1 {
+  constructor(opts) {
+    this.data = opts.data;
+    this.fplus = opts.fplus;
+    this.auth = this.fplus.Auth;
+    this.log = this.fplus.debug.bound("api-v1");
+    this.routes = this.setup_routes();
+  }
+
+  setup_routes() {
+    let api = express.Router();
+
+    api.route("/name/:uuid")
+      .get(this.name_get.bind(this))
+      .put(this.name_put.bind(this))
+
+    return api;
+  }
+
+
+  async name_get(req, res) {
+    const { uuid } = req.params;
+
+    // This URL could not possibly exist (different from "could exist in the future")
+    if (!valid_uuid(uuid)) fail(410);
+
+    const names = await rx.firstValueFrom(this.data.names);
+    const name = names.get(uuid);
+    if (!name) fail(404);
+
+    const ok = await this.auth.check_acl(
+      // Principal
+      req.auth,
+      // Your own service permission
+      Perm.MyGetNamePermission,
+      // Target UUID
+      uuid,
+      // Do we accept wildcards?
+      true,
+    );
+
+    if (!ok) {
+      fail(403);
+    }
+
+    return res.status(200).json(name);
+  }
+
+  async name_put(req, res) {
+    const { uuid } = req.params;
+    if (!valid_uuid(uuid)) fail(410);
+
+    // May need this in your own service. We don't in this case. This is checking validity of what you give the service.
+    // if (grant && !valid_grant(grant)) fail(422);
+
+    const ok = await this.auth.check_acl(
+      req.auth,
+      Perm.MyPutNamePermission,
+      uuid,
+      true,
+    );
+
+    if (!ok) {
+      fail(403);
+    }
+
+    const retval = await this.data.request({ type: "name", object: uuid, name: req.body });
+    return res.status(retval.status).end();
+  }
+}

--- a/acs-example-service/lib/dataflow.js
+++ b/acs-example-service/lib/dataflow.js
@@ -1,0 +1,80 @@
+import { RxClient, UUIDs } from '@amrc-factoryplus/rx-client';
+
+export class DataFlow {
+  constructor(opts) {
+    const { fplus } = opts;
+
+    this.root = opts.root_principal;
+
+    this.log = fplus.debug.bound("data");
+    this.cdb = fplus.ConfigDB;
+
+    /* Requests to update the database */
+    this.requests = new rx.Subject();
+    /* Responses to these requests */
+    this.responses = this._build_responses();
+
+    this.names = this._build_names();
+  }
+
+  update_name(r) {
+    // Something like this but returning an HTTP-like response. (put_config returns an exception that needs catching)
+    this.cdb.put_config(UUIDs.App.Info, r.object, { name: r.name });
+  };
+
+  _build_names() {
+    return rxx.rx(
+      cdb.search_app(UUIDs.App.Info),
+      // rx.map acts on the sequence of responses, entries.map acts on the entries maps
+      rx.map(entries => entries.map(entry => entry.name)),
+      // Cache the map (1 refers to 1 previous value)
+      rx.shareReplay(1));
+  }
+
+  _build_responses() {
+
+    const updaters = {
+      // This tells you what to do with a "name" type object
+      // UUIDs.App.Info == "General Information" application
+      name: this.update_name,
+    };
+
+    return rxx.rx(this.requests,
+      rx.mergeMap(r => {
+        const updater = updaters[r.type]
+          ?? (async () => ({ status: 500 }));
+
+        return updater.call(this, r)
+          .then(rv => ({ ...rv, type: r.type, request: r.request }));
+      }),
+      rx.share());
+  }
+
+
+  run() {
+    this.groups.subscribe(gs => this.log("GROUPS UPDATE"));
+    //imm.Map(gs).toJS()));
+    this.grants.subscribe(es => this.log("GRANT UPDATE"));
+  }
+
+  /** Request a change to the database.
+   *
+   * This submits a change request to the database and returns a
+   * Promise containing an HTTP status code for the outcome. If a
+   * change is made then the change will also be published to
+   * `updates`.
+   *
+   * @param r A request object. Must contain a `kind` field.
+   * @returns A response object containing a `status` field.
+   */
+  request(r) {
+    const request = uuidv4();
+    /* Construct the Promise to the response before we send the
+     * request. This avoids a race condition. */
+    const response = rx.firstValueFrom(rxx.rx(
+      this.responses,
+      rx.filter(r => r.request == request)));
+    this.requests.next({ ...r, request });
+    return response;
+  }
+}

--- a/acs-example-service/lib/notify.js
+++ b/acs-example-service/lib/notify.js
@@ -1,0 +1,55 @@
+import * as rx from "rxjs";
+
+import * as rxx from "@amrc-factoryplus/rx-util";
+import { Notify } from "@amrc-factoryplus/service-api";
+
+export class AuthNotify {
+  constructor(opts) {
+    this.data = opts.data;
+    this.log = opts.debug.bound("notify");
+
+    this.notify = this.build_notify(opts.api);
+  }
+
+  run() {
+    this.log("Running notify server");
+    this.notify.run();
+  }
+
+  build_notify(api) {
+    const notify = new Notify({
+      api,
+      log: this.log,
+    });
+
+    // This is basically Express. This is more strict in that directories must end with a "/". It won't redirect.
+    notify.watch("v1/name/", this.name_list.bind(this));
+    notify.watch("v1/name/:object", this.object_name.bind(this));
+
+    return notify;
+  }
+
+  /**
+  * Get names for all objects the principal can see.
+  */
+  name_list(sess) {
+    // We should combine this with the session permissions to see the objects
+    return rxx.rx(
+      this.data.names,
+      rx.map(entries => entries.keySeq().toArray()),
+      rx.mergeMap(
+        // You need to filter out what they can't see here using `sess` (not in a .filter :))
+      ),
+      rx.map(
+        // You need to build your response objects here
+      ));
+  }
+
+
+  /**
+  * Get changes to the name of a particular object `obj`.
+  */
+  object_name(sess, obj) {
+    // Do similar to `name_list` here.
+  }
+}

--- a/acs-example-service/lib/routes.js
+++ b/acs-example-service/lib/routes.js
@@ -1,0 +1,9 @@
+import { APIv1 } from './api-v1.js';
+
+export function routes(opts) {
+  const api_v1 = new APIv1(opts);
+
+  return (app) => {
+    app.use('/v1', api_v1.routes);
+  };
+}

--- a/acs-example-service/package.json
+++ b/acs-example-service/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "acs-example-service",
+  "version": "1.0.0",
+  "description": "This is an example new service for getting and updating names of objects.",
+  "main": "server.js",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@amrc-factoryplus/rx-client": "file:../lib/js-rx-client",
+    "@amrc-factoryplus/rx-util": "file:../lib/js-rx-util",
+    "@amrc-factoryplus/service-api": "file:../lib/js-service-api",
+    "@amrc-factoryplus/service-client": "file:../lib/js-service-client",
+    "@dotenvx/dotenvx": "^1.39.0",
+    "express": "^4.21.2",
+    "stream-size": "^0.0.6",
+    "uuid": "^11.0.5"
+  },
+  "devDependencies": {
+    "eslint": "^9.23.0"
+  }
+}


### PR DESCRIPTION
This adds an example service intended to act as a template for other contributors to use. This service isn't connected up to the build in any way, so won't be built in to an actual ACS deployment.

The service exposes both a HTTP and a change-notify API for updating the names of objects in ConfigDB. It does this by editing objects in the "General Information" application. The implementation details for checking principal permissions over change-notify are left unfinished, but the intent is documented.