### PR TITLE
Optimize ARM builds using native runners

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Check if build required
         id: check
         run: |
-          docker manifest inspect ghcr.io/amrc-factoryplus/acs-base-${{ matrix.type }}:${{ env.BASE_JS_VERSION }} || echo "needs-build=true" >> $GITHUB_OUTPUT
+          docker manifest inspect ghcr.io/amrc-factoryplus/acs-base-${{ matrix.type }}:${{ env.BASE_JS_VERSION }}-amd64 || echo "needs-build=true" >> $GITHUB_OUTPUT
       - name: Checkout
         if: steps.check.outputs.needs-build == 'true'
         uses: actions/checkout@v4
@@ -60,7 +60,7 @@ jobs:
       - name: Check if build required
         id: check
         run: |
-          docker manifest inspect ghcr.io/amrc-factoryplus/acs-base-${{ matrix.type }}:${{ env.BASE_JS_VERSION }} || echo "needs-build=true" >> $GITHUB_OUTPUT
+          docker manifest inspect ghcr.io/amrc-factoryplus/acs-base-${{ matrix.type }}:${{ env.BASE_JS_VERSION }}-arm64 || echo "needs-build=true" >> $GITHUB_OUTPUT
       - name: Checkout
         if: steps.check.outputs.needs-build == 'true'
         uses: actions/checkout@v4
@@ -116,7 +116,7 @@ jobs:
           docker buildx imagetools create -t ghcr.io/amrc-factoryplus/${{ steps.prepare.outputs.service-name }}-${{ matrix.type }}:${{ env.BASE_JS_VERSION }} \
             ghcr.io/amrc-factoryplus/${{ steps.prepare.outputs.service-name }}-${{ matrix.type }}:${{ env.BASE_JS_VERSION }}-amd64 \
             ghcr.io/amrc-factoryplus/${{ steps.prepare.outputs.service-name }}-${{ matrix.type }}:${{ env.BASE_JS_VERSION }}-arm64
-          digest=$(docker buildx imagetools inspect ghcr.io/amrc-factoryplus/${{ steps.prepare.outputs.service-name }}-${{ matrix.type }}:${{ env.BASE_JS_VERSION }} --format '{{.Manifest.Digest}}')
+          digest=$(docker buildx imagetools inspect ghcr.io/amrc-factoryplus/${{ steps.prepare.outputs.service-name }}-${{ matrix.type }}:${{ env.BASE_JS_VERSION }} --format '{{json .Manifest.Digest}}' | tr -d '"')
           echo "digest=${digest}" >> $GITHUB_OUTPUT
       - uses: ./.github/actions/cleanup
         id: cleanup
@@ -385,7 +385,7 @@ jobs:
           docker buildx imagetools create -t ghcr.io/amrc-factoryplus/${{ steps.prepare.outputs.service-name }}:${{ steps.prepare.outputs.version }} \
             ghcr.io/amrc-factoryplus/${{ steps.prepare.outputs.service-name }}:${{ steps.prepare.outputs.version }}-amd64 \
             ghcr.io/amrc-factoryplus/${{ steps.prepare.outputs.service-name }}:${{ steps.prepare.outputs.version }}-arm64
-          digest=$(docker buildx imagetools inspect ghcr.io/amrc-factoryplus/${{ steps.prepare.outputs.service-name }}:${{ steps.prepare.outputs.version }} --format '{{.Manifest.Digest}}')
+          digest=$(docker buildx imagetools inspect ghcr.io/amrc-factoryplus/${{ steps.prepare.outputs.service-name }}:${{ steps.prepare.outputs.version }} --format '{{json .Manifest.Digest}}' | tr -d '"')
           echo "digest=${digest}" >> $GITHUB_OUTPUT
       - uses: ./.github/actions/cleanup
         id: cleanup


### PR DESCRIPTION
Split `build-arm-js` and `build-base-js` jobs into separate amd64 and arm64 runs to leverage GitHub's native ARM runners for faster compilation. The amd64 jobs run on `ubuntu-latest` while arm64 jobs use `ubuntu-24.04-arm` for native builds without cross-compilation overhead. Separate merge jobs create multi-arch manifests after both platforms complete.

**Changes:**
- Split `build-base-js` into `build-base-js-amd64`, `build-base-js-arm64`, and `build-base-js-merge` jobs
- Split `build-arm-js` into `build-arm-js-amd64` and `build-arm-js-arm64` jobs with native ARM runner
- Each platform builds with its native architecture-specific runner tags (`-amd64` and `-arm64`)
- Merge jobs combine architecture-specific images into multi-arch manifests

**Benefits:** Eliminates cross-compilation slowdown on ARM builds by using native ARM runners, significantly reducing build times for the edge services.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author