### PR TITLE
Convert ReadKrb into a permission with no target

### DIFF
--- a/acs-auth/lib/dataflow.js
+++ b/acs-auth/lib/dataflow.js
@@ -256,18 +256,16 @@ export class DataFlow {
                 ids.filter(id => 
                     props.every(([k, v]) => id[k] == v))));
 
-        /* ReadKrb is repurposed here as 'read any identity' */
-        const permitted = this.permitted(upn, Perm.ReadKrb, true);
+        /* ReadKrb is repurposed here as 'read any identity'. This is
+         * now a blanket permission which can only be granted on
+         * Wildcard. It permits reading all identity records, and
+         * listing all identities. Anything else is very difficult to
+         * make work with lookups and lists from both directions. */
+        const permitted = this.permitted(upn, Perm.ReadKrb, false);
 
         return Optional.of(rxx.rx(
             rx.combineLatest(filtered, permitted),
-            rx.map(([ids, perm]) => cond.uuid
-                ? perm?.(cond.uuid)
-                    ? Response.ok(ids)
-                    : Response.of(403)
-                : perm
-                    ? Response.ok(ids.filter(id => perm(id.uuid)))
-                    : Response.of(403)),
+            rx.map(([ids, perm]) => perm ? Response.ok(ids) : Response.of(403)),
             rx.map(res => res.filter(ids => ids.length)),
         ));
     }

--- a/docs/services/notify-v2.md
+++ b/docs/services/notify-v2.md
@@ -312,10 +312,13 @@ A full update contains the complete current state of all children. The
 initial 201 update must be a full update. The `children` key must be an
 object mapping each existing child path to an HTTP response for that
 child. The `response` key must contain a response for the parent
-resource, which should normally just be `{ status: 204 }`. For
-consistency, where the client can discover the existence of a child
+resource, which should normally just be `{ status: 204 }`.
+
+For consistency, where the client can discover the existence of a child
 which will return a 403 response, this child should be included in
-`children` (with a 403 HTTP status).
+`children` (with a 403 HTTP status). This means that allowing 'blind'
+lookups which may return 403 also means allowing listing all children,
+including children to which access is denied.
 
 A child update notifies the client of a change to a single child. The
 `child` key contains the child path of that child, and the `response`


### PR DESCRIPTION
Any grant (which will normally be to Wildcard) now permits reading all identity records. This is necessary because of the following:

- In order to avoid information leaks, we were omitting identity records the client did not have access to.
- This meant that where a client made a request for an existing record they had no access to they got a 404 instead of a 403.
- Krbkeys relies on 404 responses to decide whether to create a new principal or not. A 403 will cause an exception and a retry later.
- Some timing issue was causing Krbkeys to receive 404 responses where the principal in question actually did exist. This was causing duplicate principals to be created and causing havok.

I cannot see any practical way to preserve correct 403 responses to blind lookups without exposing the full list of both UUIDs and UPNs. And having exposed the full list, of UPNs in particular, I don't see that exposing the mappings makes much difference. Principals with ReadKrb are all privileged in any case, and all have Wildcard grants.