### PR TITLE
Add custom CA certificate support for UNS bridge

### DIFF
--- a/acs-admin/src/components/Bridges/NewBridgeDialog.vue
+++ b/acs-admin/src/components/Bridges/NewBridgeDialog.vue
@@ -134,6 +134,18 @@
               <label for="tls" class="text-sm font-medium cursor-pointer">Use TLS</label>
             </div>
 
+            <div v-if="remoteTls" class="flex flex-col gap-1 mt-3">
+              <label class="text-sm font-medium">CA Certificate ConfigMap</label>
+              <Input
+                placeholder="e.g. corporate-ca"
+                v-model="caConfigMapName"
+              />
+              <p class="text-xs text-gray-500">
+                Optional. Name of a Kubernetes ConfigMap containing a custom CA certificate (key: <code>ca.crt</code>).
+                Required when the remote broker uses a certificate signed by a private CA (e.g. corporate TLS inspection).
+              </p>
+            </div>
+
             <div class="grid grid-cols-2 gap-4 mt-4">
               <div class="flex flex-col gap-1">
                 <label class="text-sm font-medium">Username <span class="text-red-500">*</span></label>
@@ -321,6 +333,7 @@ export default {
       this.remoteTls = true
       this.remoteUsername = null
       this.remotePassword = null
+      this.caConfigMapName = null
       this.isSubmitting = false
       this.v$.$reset()
     },
@@ -345,6 +358,7 @@ export default {
           this.remoteHost = values.remote.host
           this.remotePort = values.remote.port
           this.remoteTls = values.remote.tls
+          this.caConfigMapName = values.remote.caConfigMapName || null
         }
       }
     },
@@ -418,7 +432,8 @@ export default {
               tls: this.remoteTls,
               secretName: secretName,
               usernameKey: 'username',
-              passwordKey: 'password'
+              passwordKey: 'password',
+              ...(this.caConfigMapName ? { caConfigMapName: this.caConfigMapName } : {}),
             }
           }
 
@@ -459,6 +474,7 @@ export default {
       remoteTls: true,
       remoteUsername: null,
       remotePassword: null,
+      caConfigMapName: null,
       isSubmitting: false,
       unsChartUuid: null,
     }

--- a/edge-helm-charts/charts/uns-bridge/README.md
+++ b/edge-helm-charts/charts/uns-bridge/README.md
@@ -23,9 +23,35 @@ The bridge uses a local Mosquitto instance that:
 - Forwarding to remote MQTT broker
 - Configurable topic filters
 - Support for TLS on remote connection
+- Custom CA certificate support for corporate TLS inspection or private CAs
 - Remote credentials are accepted via the admin UI and encrypted using
   sealed secrets (as per the normal edge-deployment flow)
 
 ⚠️ **Known Limitations:**
 - Remote brokers must support basic authentication (username/password).
   No authentication is not supported.
+
+## Custom CA Certificates
+
+If the remote broker uses a certificate signed by a private CA (e.g.
+corporate networks that perform TLS inspection), you can provide a custom
+CA certificate via a Kubernetes ConfigMap.
+
+1. Create a ConfigMap containing the CA certificate with the key `ca.crt`:
+
+   ```bash
+   kubectl create configmap corporate-ca \
+     --from-file=ca.crt=/path/to/corporate-ca.pem \
+     -n <edge-namespace>
+   ```
+
+2. Set `remote.caConfigMapName` in the bridge values, either via the Admin
+   UI "CA Certificate ConfigMap" field or directly in the Helm values:
+
+   ```yaml
+   remote:
+     caConfigMapName: corporate-ca
+   ```
+
+The certificate is copied into the container's system CA store at startup,
+so both the custom CA and standard public CAs are trusted.

--- a/edge-helm-charts/charts/uns-bridge/templates/deployment.yaml
+++ b/edge-helm-charts/charts/uns-bridge/templates/deployment.yaml
@@ -47,6 +47,11 @@ spec:
           secret:
             secretName: {{ .Values.remote.secretName }}
 {{- end }}
+{{- if .Values.remote.caConfigMapName }}
+        - name: remote-ca
+          configMap:
+            name: {{ .Values.remote.caConfigMapName }}
+{{- end }}
       containers:
         - name: mosquitto
 {{ list . "mosquitto" | include "uns-bridge.image" | indent 10 }}
@@ -54,6 +59,10 @@ spec:
             - /bin/sh
             - -c
             - |
+              # Install custom CA certificate if provided
+{{- if .Values.remote.caConfigMapName }}
+              cp /ca/ca.crt /etc/ssl/certs/custom-remote-ca.crt
+{{- end }}
               # Read credentials
               LOCAL_PASSWORD=$(cat /secrets/local/keytab)
 {{- if .Values.remote.secretName }}
@@ -93,6 +102,11 @@ spec:
 {{- if .Values.remote.secretName }}
             - mountPath: /secrets/remote
               name: remote-credentials
+              readOnly: true
+{{- end }}
+{{- if .Values.remote.caConfigMapName }}
+            - mountPath: /ca
+              name: remote-ca
               readOnly: true
 {{- end }}
 

--- a/edge-helm-charts/charts/uns-bridge/values.yaml
+++ b/edge-helm-charts/charts/uns-bridge/values.yaml
@@ -39,6 +39,10 @@ remote:
   # Keys in the secret for username and password
   usernameKey: username
   passwordKey: password
+  # Name of a ConfigMap containing a custom CA certificate (key: ca.crt)
+  # Use this when the remote broker uses a certificate signed by a private CA
+  # (e.g. corporate TLS inspection proxies)
+  caConfigMapName: ""
 
 # Image configuration
 image:


### PR DESCRIPTION
## Summary
- Adds `remote.caConfigMapName` Helm value to mount a custom CA certificate ConfigMap into the UNS bridge container
- The CA cert is copied into `/etc/ssl/certs/` at startup so both custom and system CAs are trusted via `bridge_capath`
- Exposes an optional "CA Certificate ConfigMap" field in the Admin UI (visible when TLS is enabled)

## Context
Users on corporate networks with TLS inspection were getting "A TLS error occurred" because the proxy-injected CA wasn't trusted by the Mosquitto container. This allows them to provide their org's CA via a Kubernetes ConfigMap.