### PR TITLE
Add configurable CA certificate filename for UNS bridge

### DIFF
--- a/acs-admin/src/components/Bridges/NewBridgeDialog.vue
+++ b/acs-admin/src/components/Bridges/NewBridgeDialog.vue
@@ -134,14 +134,23 @@
               <label for="tls" class="text-sm font-medium cursor-pointer">Use TLS</label>
             </div>
 
-            <div v-if="remoteTls" class="flex flex-col gap-1 mt-3">
-              <label class="text-sm font-medium">CA Certificate ConfigMap</label>
-              <Input
-                placeholder="e.g. corporate-ca"
-                v-model="caConfigMapName"
-              />
-              <p class="text-xs text-gray-500">
-                Optional. Name of a Kubernetes ConfigMap containing a custom CA certificate (key: <code>ca.crt</code>).
+            <div v-if="remoteTls" class="grid grid-cols-2 gap-4 mt-3">
+              <div class="flex flex-col gap-1">
+                <label class="text-sm font-medium">CA Certificate ConfigMap</label>
+                <Input
+                  placeholder="e.g. corporate-ca"
+                  v-model="caConfigMapName"
+                />
+              </div>
+              <div class="flex flex-col gap-1">
+                <label class="text-sm font-medium">CA Certificate Filename</label>
+                <Input
+                  placeholder="e.g. ca.crt"
+                  v-model="caFile"
+                />
+              </div>
+              <p class="text-xs text-gray-500 col-span-2">
+                Optional. Provide the ConfigMap name and certificate filename to use a custom CA.
                 Required when the remote broker uses a certificate signed by a private CA (e.g. corporate TLS inspection).
               </p>
             </div>
@@ -334,6 +343,7 @@ export default {
       this.remoteUsername = null
       this.remotePassword = null
       this.caConfigMapName = null
+      this.caFile = null
       this.isSubmitting = false
       this.v$.$reset()
     },
@@ -359,6 +369,7 @@ export default {
           this.remotePort = values.remote.port
           this.remoteTls = values.remote.tls
           this.caConfigMapName = values.remote.caConfigMapName || null
+          this.caFile = values.remote.caFile || null
         }
       }
     },
@@ -434,6 +445,7 @@ export default {
               usernameKey: 'username',
               passwordKey: 'password',
               ...(this.caConfigMapName ? { caConfigMapName: this.caConfigMapName } : {}),
+              ...(this.caFile ? { caFile: this.caFile } : {}),
             }
           }
 
@@ -475,6 +487,7 @@ export default {
       remoteUsername: null,
       remotePassword: null,
       caConfigMapName: null,
+      caFile: null,
       isSubmitting: false,
       unsChartUuid: null,
     }

--- a/edge-helm-charts/charts/uns-bridge/README.md
+++ b/edge-helm-charts/charts/uns-bridge/README.md
@@ -45,13 +45,15 @@ CA certificate via a Kubernetes ConfigMap.
      -n <edge-namespace>
    ```
 
-2. Set `remote.caConfigMapName` in the bridge values, either via the Admin
-   UI "CA Certificate ConfigMap" field or directly in the Helm values:
+2. Set `remote.caConfigMapName` and `remote.caFile` in the bridge values,
+   either via the Admin UI or directly in the Helm values:
 
    ```yaml
    remote:
      caConfigMapName: corporate-ca
+     caFile: ca.crt
    ```
 
-The certificate is copied into the container's system CA store at startup,
-so both the custom CA and standard public CAs are trusted.
+The ConfigMap is mounted at `/ca` and mosquitto uses `bridge_cafile` pointing
+directly at the file. This works correctly with CA bundles containing multiple
+certificates, which Alpine's `bridge_capath` does not support.

--- a/edge-helm-charts/charts/uns-bridge/templates/configmap.yaml
+++ b/edge-helm-charts/charts/uns-bridge/templates/configmap.yaml
@@ -43,7 +43,11 @@ data:
     remote_password ${REMOTE_PASSWORD}
     remote_clientid ${REMOTE_USERNAME}-{{ .Values.uuid }}
 {{- if .Values.remote.tls }}
+{{- if .Values.remote.caFile }}
+    bridge_cafile /ca/{{ .Values.remote.caFile }}
+{{- else }}
     bridge_capath /etc/ssl/certs
+{{- end }}
     bridge_tls_version tlsv1.2
 {{- end }}
     bridge_protocol_version mqttv50

--- a/edge-helm-charts/charts/uns-bridge/templates/deployment.yaml
+++ b/edge-helm-charts/charts/uns-bridge/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
           secret:
             secretName: {{ .Values.remote.secretName }}
 {{- end }}
-{{- if .Values.remote.caConfigMapName }}
+{{- if .Values.remote.caFile }}
         - name: remote-ca
           configMap:
             name: {{ .Values.remote.caConfigMapName }}
@@ -59,10 +59,6 @@ spec:
             - /bin/sh
             - -c
             - |
-              # Install custom CA certificate if provided
-{{- if .Values.remote.caConfigMapName }}
-              cp /ca/ca.crt /etc/ssl/certs/custom-remote-ca.crt
-{{- end }}
               # Read credentials
               LOCAL_PASSWORD=$(cat /secrets/local/keytab)
 {{- if .Values.remote.secretName }}
@@ -104,7 +100,7 @@ spec:
               name: remote-credentials
               readOnly: true
 {{- end }}
-{{- if .Values.remote.caConfigMapName }}
+{{- if .Values.remote.caFile }}
             - mountPath: /ca
               name: remote-ca
               readOnly: true

--- a/edge-helm-charts/charts/uns-bridge/values.yaml
+++ b/edge-helm-charts/charts/uns-bridge/values.yaml
@@ -39,10 +39,13 @@ remote:
   # Keys in the secret for username and password
   usernameKey: username
   passwordKey: password
-  # Name of a ConfigMap containing a custom CA certificate (key: ca.crt)
+  # Name of a ConfigMap containing a custom CA certificate
   # Use this when the remote broker uses a certificate signed by a private CA
   # (e.g. corporate TLS inspection proxies)
   caConfigMapName: ""
+  # Key name of the CA certificate within the ConfigMap (e.g. ca.crt)
+  # When set, uses bridge_cafile instead of bridge_capath
+  caFile: ""
 
 # Image configuration
 image:


### PR DESCRIPTION
## Summary
- Adds `remote.caFile` value to specify the CA certificate key/filename within the ConfigMap
- When set, uses `bridge_cafile /ca/<filename>` instead of copying the cert into `/etc/ssl/certs` and using `bridge_capath`
- Fixes Alpine's mosquitto ignoring multi-cert bundle files in `bridge_capath` directories

## Context
We discovered that Alpine's mosquitto ignores certificate files containing multiple certificates when using `bridge_capath`. Using `bridge_cafile` to point directly at the mounted file works correctly with CA bundles.

## Test plan
- [ ] Deploy bridge with `caFile: ca.crt` and `caConfigMapName` set — verify `bridge_cafile` is used and TLS connects
- [ ] Deploy bridge with only TLS enabled (no custom CA) — verify `bridge_capath /etc/ssl/certs` fallback works
- [ ] Verify Admin UI shows both ConfigMap name and filename fields when TLS is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)