### PR TITLE
Move composite grants into service-accounts

### DIFF
--- a/acs-service-setup/dumps/composite.yaml
+++ b/acs-service-setup/dumps/composite.yaml
@@ -61,13 +61,3 @@ objects:
         # Unimplemented
         #- !u ConfigDB.Perm.ReadMemberships
         #- !u ConfigDB.Perm.ReadSuperclasses
-
----
-service: !u UUIDs.Service.Authentication
-version: 2
-grants:
-# XXX These should be replaced with individual grants.
-  !u ACS.ServiceAccount.CmdEsc:
-    !u ACS.Perm.Composite.CmdEsc: null
-  !u ACS.ServiceAccount.Warehouse:
-    !u ACS.Perm.Composite.Warehouse: null

--- a/acs-service-setup/dumps/service-accounts.yaml
+++ b/acs-service-setup/dumps/service-accounts.yaml
@@ -120,3 +120,9 @@ grants:
       !u UUIDs.App.SparkplugAddress: false
     !u UUIDs.Permission.Auth.ReadACL:
       !u ACS.PermGroup.CmdEsc: true
+    # XXX This should be replaced by a service role
+    !u ACS.Perm.Composite.CmdEsc: null
+
+  !u ACS.ServiceAccount.Warehouse:
+    # XXX This should be replaced by a service role
+    !u ACS.Perm.Composite.Warehouse: null


### PR DESCRIPTION
The Auth service now treats Auth dumps as authoritative; all other grants to the given principals are removed. So we must make all grants to a given principal in the same place.