### PR TITLE
Add Rebirth button to Edge Manager node and device lists

### DIFF
--- a/acs-admin/src/components/EdgeManager/RebirthButton.vue
+++ b/acs-admin/src/components/EdgeManager/RebirthButton.vue
@@ -1,24 +1,32 @@
 <template>
-  <Button
-    v-if="true || canRebirth"
-    size="xs"
-    variant="ghost"
-    title="Rebirth"
-    :disabled="loading"
-    class="flex items-center justify-center gap-1.5"
-    @click.stop="rebirth"
-  >
-    <i class="fa-solid" :class="loading ? 'fa-circle-notch animate-spin' : 'fa-rotate'"></i>
-  </Button>
+  <TooltipProvider v-if="canRebirth">
+    <Tooltip>
+      <TooltipTrigger as-child>
+        <Button
+          size="xs"
+          variant="outline"
+          :disabled="loading"
+          class="ml-auto flex items-center justify-center gap-1.5 hover:bg-gray-800 hover:text-white"
+          @click.stop="rebirth"
+        >
+          <i class="fa-solid" :class="loading ? 'fa-circle-notch animate-spin' : 'fa-tower-broadcast'"></i>
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p>Rebirth</p>
+      </TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
 </template>
 
 <script>
 import { useServiceClientStore } from '@store/serviceClientStore.js'
 import { Button } from '@components/ui/button/index.js'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { toast } from 'vue-sonner'
 
 export default {
-  components: { Button },
+  components: { Button, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger },
   props: {
     address: { type: String, required: true },
     name: { type: String, required: true },

--- a/acs-admin/src/components/EdgeManager/RebirthButton.vue
+++ b/acs-admin/src/components/EdgeManager/RebirthButton.vue
@@ -1,0 +1,56 @@
+<template>
+  <Button
+    v-if="true || canRebirth"
+    size="xs"
+    variant="ghost"
+    title="Rebirth"
+    :disabled="loading"
+    class="flex items-center justify-center gap-1.5"
+    @click.stop="rebirth"
+  >
+    <i class="fa-solid" :class="loading ? 'fa-circle-notch animate-spin' : 'fa-rotate'"></i>
+  </Button>
+</template>
+
+<script>
+import { useServiceClientStore } from '@store/serviceClientStore.js'
+import { Button } from '@components/ui/button/index.js'
+import { toast } from 'vue-sonner'
+
+export default {
+  components: { Button },
+  props: {
+    address: { type: String, required: true },
+    name: { type: String, required: true },
+    isDevice: { type: Boolean, default: false },
+    canRebirth: { type: Boolean, default: false },
+  },
+  data () {
+    return { loading: false }
+  },
+  methods: {
+    async rebirth () {
+      this.loading = true
+      const ctrl = this.isDevice ? 'Device Control' : 'Node Control'
+      try {
+        await useServiceClientStore().client.CmdEsc.request_cmd({
+          address: this.address,
+          name: `${ctrl}/Rebirth`,
+          type: 'Boolean',
+          value: true,
+        })
+        toast.success(`Rebirth sent to ${this.name}`)
+      } catch (e) {
+        if (e.status === 403) {
+          toast.error(`Permission denied: cannot rebirth ${this.name}`)
+        } else {
+          toast.error(`Failed to rebirth ${this.name}`)
+        }
+        console.error(e)
+      } finally {
+        this.loading = false
+      }
+    }
+  }
+}
+</script>

--- a/acs-admin/src/composables/useCanRebirth.js
+++ b/acs-admin/src/composables/useCanRebirth.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) University of Sheffield AMRC 2025.
+ */
+
+import { ref, watch } from 'vue'
+import { useServiceClientStore } from '@store/serviceClientStore.js'
+
+const REBIRTH_PERMISSION = 'fbb9c25d-386d-4966-a325-f16471d9f7be'
+
+export function useCanRebirth (targets) {
+  const permissions = ref(new Map())
+
+  watch(targets, async (uuids) => {
+    if (!uuids || uuids.length === 0) return
+
+    const s = useServiceClientStore()
+    const results = new Map()
+
+    await Promise.all(uuids.map(async (uuid) => {
+      try {
+        const allowed = await s.client.Auth.check_acl(
+          s.username,
+          REBIRTH_PERMISSION,
+          uuid,
+          false
+        )
+        results.set(uuid, allowed)
+      } catch {
+        results.set(uuid, false)
+      }
+    }))
+
+    permissions.value = results
+  }, { immediate: true })
+
+  return permissions
+}

--- a/acs-admin/src/composables/useCanRebirth.js
+++ b/acs-admin/src/composables/useCanRebirth.js
@@ -6,6 +6,7 @@ import { ref, watch } from 'vue'
 import { useServiceClientStore } from '@store/serviceClientStore.js'
 
 const REBIRTH_PERMISSION = 'fbb9c25d-386d-4966-a325-f16471d9f7be'
+const WILDCARD = '00000000-0000-0000-0000-000000000000'
 
 export function useCanRebirth (targets) {
   const permissions = ref(new Map())
@@ -16,19 +17,29 @@ export function useCanRebirth (targets) {
     const s = useServiceClientStore()
     const results = new Map()
 
-    await Promise.all(uuids.map(async (uuid) => {
-      try {
-        const allowed = await s.client.Auth.check_acl(
-          s.username,
-          REBIRTH_PERMISSION,
-          uuid,
-          false
-        )
-        results.set(uuid, allowed)
-      } catch {
-        results.set(uuid, false)
-      }
-    }))
+    // Fetch the full ACL via the Auth service HTTP API.
+    // We call ServiceInterface.fetch directly to avoid the
+    // RxClient notify-based override of fetch_raw_acl.
+    let acl
+    try {
+      const principal = `${s.username}@${s.baseUrl.toUpperCase()}`
+      const [st, json] = await s.client.Auth.fetch(
+        `v2/acl/kerberos/${principal}`
+      )
+      if (st !== 200) throw new Error(`ACL fetch returned ${st}`)
+      acl = json
+    } catch (e) {
+      console.error('Failed to fetch ACL for rebirth check:', e)
+      return
+    }
+
+    for (const uuid of uuids) {
+      const allowed = acl.some(ace =>
+        ace.permission === REBIRTH_PERMISSION
+        && (ace.target === uuid || ace.target === WILDCARD)
+      )
+      results.set(uuid, allowed)
+    }
 
     permissions.value = results
   }, { immediate: true })

--- a/acs-admin/src/pages/EdgeManager/EdgeClusters/EdgeCluster.vue
+++ b/acs-admin/src/pages/EdgeManager/EdgeClusters/EdgeCluster.vue
@@ -159,9 +159,11 @@
 </template>
 
 <script>
+import { computed } from 'vue'
 import { useServiceClientStore } from '@store/serviceClientStore.js'
 import { useEdgeClusterStore } from '@store/useEdgeClusterStore.js'
 import { useNodeStore } from '@store/useNodeStore.js'
+import { useCanRebirth } from '@/composables/useCanRebirth.js'
 import { UUIDs } from '@amrc-factoryplus/service-client'
 import EdgeContainer from '@components/Containers/EdgeContainer.vue'
 import EdgePageSkeleton from '@components/EdgeManager/EdgePageSkeleton.vue'
@@ -213,10 +215,15 @@ export default {
   },
 
   setup () {
+    const n = useNodeStore()
+    const nodeUuids = computed(() => n.data?.map(e => e.uuid) ?? [])
+    const canRebirthMap = useCanRebirth(nodeUuids)
+
     return {
       e: useEdgeClusterStore(),
       dp: useDeploymentStore(),
-      n: useNodeStore(),
+      n,
+      canRebirthMap,
       hostColumns,
       nodeColumns,
       deploymentColumns,
@@ -234,7 +241,11 @@ export default {
     },
 
     nodes () {
-      return Array.isArray(this.n.data) ? this.n.data.filter(e => e.deployment?.cluster === this.cluster.uuid) : []
+      const filtered = Array.isArray(this.n.data) ? this.n.data.filter(e => e.deployment?.cluster === this.cluster.uuid) : []
+      return filtered.map(n => ({
+        ...n,
+        _canRebirth: this.canRebirthMap?.get(n.uuid) ?? false
+      }))
     },
 
     deployments () {

--- a/acs-admin/src/pages/EdgeManager/EdgeClusters/nodeColumns.ts
+++ b/acs-admin/src/pages/EdgeManager/EdgeClusters/nodeColumns.ts
@@ -6,6 +6,7 @@ import type {ColumnDef} from '@tanstack/vue-table'
 import {h} from 'vue'
 
 import DataTableColumnHeader from '@/components/ui/data-table/DataTableColumnHeader.vue'
+import RebirthButton from '@/components/EdgeManager/RebirthButton.vue'
 
 export interface Host {
     uuid: string,
@@ -52,5 +53,21 @@ export const nodeColumns: ColumnDef<Host>[] = [
         filterFn: (row, id, value) => {
             return value.includes(row.getValue(id))
         },
+    },
+    {
+        id: 'actions',
+        header: () => null,
+        cell: ({row}) => {
+            const addr = row.original.sparkplugAddress
+            if (!addr) return null
+            const addressStr = `${addr.group_id}/${addr.node_id}`
+            return h(RebirthButton, {
+                address: addressStr,
+                name: row.original.name,
+                canRebirth: row.original._canRebirth ?? false,
+            })
+        },
+        enableSorting: false,
+        enableHiding: false,
     }
 ]

--- a/acs-admin/src/pages/EdgeManager/EdgeClusters/nodeColumns.ts
+++ b/acs-admin/src/pages/EdgeManager/EdgeClusters/nodeColumns.ts
@@ -65,6 +65,7 @@ export const nodeColumns: ColumnDef<Host>[] = [
                 address: addressStr,
                 name: row.original.name,
                 canRebirth: row.original._canRebirth ?? false,
+                class: 'ml-auto'
             })
         },
         enableSorting: false,

--- a/acs-admin/src/pages/EdgeManager/Nodes/Node.vue
+++ b/acs-admin/src/pages/EdgeManager/Nodes/Node.vue
@@ -129,10 +129,12 @@
 </template>
 
 <script>
+import { computed } from 'vue'
 import { useNodeStore } from '@store/useNodeStore.js'
 import { useEdgeClusterStore } from '@store/useEdgeClusterStore.js'
 import { useDeviceStore } from '@store/useDeviceStore.js'
 import { useConnectionStore } from '@store/useConnectionStore.js'
+import { useCanRebirth } from '@/composables/useCanRebirth.js'
 import EdgeContainer from '@components/Containers/EdgeContainer.vue'
 import { Label } from '@components/ui/label/index.js'
 import { Input } from '@components/ui/input/index.js'
@@ -176,11 +178,16 @@ export default {
   },
 
   setup () {
+    const d = useDeviceStore()
+    const deviceUuids = computed(() => d.data?.map(e => e.uuid) ?? [])
+    const canRebirthMap = useCanRebirth(deviceUuids)
+
     return {
       c: useEdgeClusterStore(),
       n: useNodeStore(),
-      d: useDeviceStore(),
+      d,
       cn: useConnectionStore(),
+      canRebirthMap,
       inop,
       deviceColumns,
       connectionColumns,
@@ -206,7 +213,12 @@ export default {
     },
 
     devices () {
-      return Array.isArray(this.d.data) ? this.d.data.filter(e => e.deviceInformation?.node === this.node.uuid) : []
+      const filtered = Array.isArray(this.d.data) ? this.d.data.filter(e => e.deviceInformation?.node === this.node.uuid) : []
+      return filtered.map(d => ({
+        ...d,
+        _nodeAddress: this.node.sparkplugAddress,
+        _canRebirth: this.canRebirthMap?.get(d.uuid) ?? false
+      }))
     },
 
     connections () {

--- a/acs-admin/src/pages/EdgeManager/Nodes/deviceColumns.ts
+++ b/acs-admin/src/pages/EdgeManager/Nodes/deviceColumns.ts
@@ -6,6 +6,7 @@ import type {ColumnDef} from '@tanstack/vue-table'
 import {h} from 'vue'
 
 import DataTableColumnHeader from '@/components/ui/data-table/DataTableColumnHeader.vue'
+import RebirthButton from '@/components/EdgeManager/RebirthButton.vue'
 
 export interface Device {
     uuid: string,
@@ -31,6 +32,24 @@ export const deviceColumns: ColumnDef<Device>[] = [
         filterFn: (row, id, value) => {
             return value.includes(row.getValue(id))
         },
+    },
+    {
+        id: 'actions',
+        header: () => null,
+        cell: ({row}) => {
+            const addr = row.original._nodeAddress
+            const sparkplugName = row.original.deviceInformation?.sparkplugName
+            if (!addr || !sparkplugName) return null
+            const addressStr = `${addr.group_id}/${addr.node_id}/${sparkplugName}`
+            return h(RebirthButton, {
+                address: addressStr,
+                name: row.original.name,
+                isDevice: true,
+                canRebirth: row.original._canRebirth ?? false,
+            })
+        },
+        enableSorting: false,
+        enableHiding: false,
     }
     // {
     //     accessorKey: 'schema',

--- a/acs-admin/src/store/useNodeStore.js
+++ b/acs-admin/src/store/useNodeStore.js
@@ -6,5 +6,6 @@ import { useStore } from '@store/useStore.ts'
 import { UUIDs } from '@amrc-factoryplus/service-client'
 
 export const useNodeStore = useStore('node', UUIDs.Class.EdgeAgent, {
-  deployment: UUIDs.App.EdgeAgentDeployment
+  deployment: UUIDs.App.EdgeAgentDeployment,
+  sparkplugAddress: UUIDs.App.SparkplugAddress
 })

--- a/docs/plans/2026-04-09-rebirth-button-design.md
+++ b/docs/plans/2026-04-09-rebirth-button-design.md
@@ -1,0 +1,102 @@
+# Rebirth Button in Admin UI
+
+Date: 2026-04-09
+Author: Alex Godbehere
+
+## Problem
+
+There is no way to trigger a Sparkplug Rebirth (NBIRTH/DBIRTH) from the
+Admin UI. When edge agents get stuck (e.g. after a ConfigDB migration
+changes device UUIDs), the only option is to manually restart pods or
+use kubectl. A Rebirth button in the UI would let operators force a
+re-publish of the birth certificate without restarting the agent.
+
+## Solution
+
+Add a per-row "Rebirth" button to the Node list and Device list views
+in the Edge Manager. The button is only shown if the current user has
+the Rebirth CCL permission on that specific node/device.
+
+### Key UUIDs
+
+- **Rebirth CCL permission**: `fbb9c25d-386d-4966-a325-f16471d9f7be`
+- **Command Definition app**: `60e99f28-67fe-4344-a6ab-b1edb8b8e810`
+- **CmdEsc permission set group**: `9584ee09-a35a-4278-bc13-21a8be1f007c`
+
+### How Rebirth works
+
+The `CmdEsc.rebirth(address)` method in `lib/js-service-client/lib/service/cmdesc.js`
+sends a Sparkplug NCMD/DCMD via the Command Escalation service:
+
+- For nodes: `Node Control/Rebirth` (Boolean, true)
+- For devices: `Device Control/Rebirth` (Boolean, true)
+
+The CmdEsc service validates the user's ACL before forwarding the
+command. The edge agent handles the NCMD at
+`acs-edge/lib/sparkplugNode.ts:339-341` and re-publishes its birth
+certificate.
+
+### Changes
+
+#### 1. Node store  - add Sparkplug address
+
+**File:** `acs-admin/src/store/useNodeStore.js`
+
+Add `sparkplugAddress: UUIDs.App.SparkplugAddress` to the loaded
+configs. The device store already loads this; the node store does not.
+
+#### 2. ACL check composable
+
+**File:** `acs-admin/src/composables/useCanRebirth.js` (new)
+
+A Vue composable that, given a list of node/device UUIDs, checks
+whether the current user has the Rebirth permission
+(`fbb9c25d-386d-4966-a325-f16471d9f7be`) on each target via
+`client.Auth.check_acl()`.
+
+Returns a reactive `Map<uuid, boolean>` so the template can look up
+each row.
+
+The current user's principal is resolved from `serviceClientStore.username`
+(a Kerberos principal name) which `Auth.fetch_acl()` accepts directly.
+
+Calls are made per target UUID. Results are cached for the lifetime of
+the composable.
+
+#### 3. Node list  - Rebirth column
+
+**File:** `acs-admin/src/pages/EdgeManager/EdgeClusters/EdgeCluster.vue`
+**File:** `acs-admin/src/pages/EdgeManager/EdgeClusters/nodeColumns.ts`
+
+Add a new column to the node DataTable with a Rebirth button per row.
+The column uses a custom cell renderer (Vue `h()` function or inline
+component) that:
+
+- Checks `canRebirth.get(row.original.uuid)` to show/hide the button
+- On click, calls `client.CmdEsc.rebirth(address)` where `address` is
+  built from the node's `sparkplugAddress` config
+- Shows a loading spinner on the button while the request is in flight
+- Shows a success toast on completion, error toast on failure
+
+#### 4. Device list  - Rebirth column
+
+**File:** `acs-admin/src/pages/EdgeManager/Nodes/Node.vue`
+**File:** `acs-admin/src/pages/EdgeManager/Nodes/deviceColumns.ts`
+
+Same pattern as the node list. The device's Sparkplug address is already
+available in the device store.
+
+### UX
+
+- Button style: small ghost/secondary button with a refresh icon
+- Loading: spinner replaces the icon while the request is in flight
+- Success: toast "Rebirth sent to {name}"
+- Error (403): toast "Permission denied: cannot rebirth {name}"
+- Error (other): toast "Failed to rebirth {name}"
+- Button hidden entirely if user lacks permission on that target
+
+### What this doesn't change
+
+- No backend changes  - CmdEsc and the edge agent already support Rebirth
+- No new permissions  - the Rebirth CCL already exists
+- No changes to the Sparkplug protocol handling

--- a/docs/plans/2026-04-09-rebirth-button.md
+++ b/docs/plans/2026-04-09-rebirth-button.md
@@ -1,0 +1,322 @@
+# Rebirth Button Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers-extended-cc:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add per-row Rebirth buttons to the Node and Device lists in the Admin UI Edge Manager, gated by CmdEsc ACL permissions.
+
+**Architecture:** A new composable checks ACL permissions per target. The node and device column definitions each get a new "actions" column with a Rebirth button component. The button calls `CmdEsc.rebirth()` and shows loading/success/error states.
+
+**Tech Stack:** Vue 3, TanStack Table, Pinia, `@amrc-factoryplus/service-client` (CmdEsc, Auth)
+
+**Key UUIDs:**
+- Rebirth CCL permission: `fbb9c25d-386d-4966-a325-f16471d9f7be`
+
+---
+
+### Task 1: Add sparkplugAddress to node store
+
+**Files:**
+- Modify: `acs-admin/src/store/useNodeStore.js`
+
+**Step 1: Add sparkplugAddress config**
+
+The node store currently loads only `deployment`. Add `sparkplugAddress` to match the device store pattern.
+
+Current code:
+```js
+export const useNodeStore = useStore('node', UUIDs.Class.EdgeAgent, {
+  deployment: UUIDs.App.EdgeAgentDeployment
+})
+```
+
+New code:
+```js
+export const useNodeStore = useStore('node', UUIDs.Class.EdgeAgent, {
+  deployment: UUIDs.App.EdgeAgentDeployment,
+  sparkplugAddress: UUIDs.App.SparkplugAddress
+})
+```
+
+**Step 2: Commit**
+
+```bash
+git add acs-admin/src/store/useNodeStore.js
+git commit -m "admin: add sparkplugAddress to node store"
+```
+
+---
+
+### Task 2: Create RebirthButton component
+
+**Files:**
+- Create: `acs-admin/src/components/EdgeManager/RebirthButton.vue`
+
+**Context:** This is a small button component that:
+- Accepts props: `address` (Sparkplug address string like `group/node` or `group/node/device`), `name` (display name for toasts), `canRebirth` (boolean)
+- If `canRebirth` is false, renders nothing
+- On click, calls `useServiceClientStore().client.CmdEsc.rebirth(address)` - note that `rebirth()` accepts a string address as well as an Address object (it's interpolated into the URL via template literal)
+- Shows a loading spinner during the request
+- Shows success/error toast via `vue-sonner`
+- Stops click event propagation (so it doesn't trigger row click navigation)
+
+The button style should match the existing ghost button pattern in the codebase (see `EdgeCluster.vue:133-135` for the Re-Bootstrap button as reference).
+
+**Step 1: Create the component**
+
+```vue
+<template>
+  <Button
+    v-if="canRebirth"
+    size="xs"
+    variant="ghost"
+    title="Rebirth"
+    :disabled="loading"
+    class="flex items-center justify-center gap-1.5"
+    @click.stop="rebirth"
+  >
+    <i class="fa-solid" :class="loading ? 'fa-circle-notch animate-spin' : 'fa-rotate'"></i>
+  </Button>
+</template>
+
+<script>
+import { useServiceClientStore } from '@store/serviceClientStore.js'
+import { Button } from '@components/ui/button/index.js'
+import { toast } from 'vue-sonner'
+
+export default {
+  components: { Button },
+  props: {
+    address: { type: String, required: true },
+    name: { type: String, required: true },
+    canRebirth: { type: Boolean, default: false },
+  },
+  data () {
+    return { loading: false }
+  },
+  methods: {
+    async rebirth () {
+      this.loading = true
+      try {
+        await useServiceClientStore().client.CmdEsc.rebirth(this.address)
+        toast.success(`Rebirth sent to ${this.name}`)
+      } catch (e) {
+        if (e.status === 403) {
+          toast.error(`Permission denied: cannot rebirth ${this.name}`)
+        } else {
+          toast.error(`Failed to rebirth ${this.name}`)
+        }
+        console.error(e)
+      } finally {
+        this.loading = false
+      }
+    }
+  }
+}
+</script>
+```
+
+**Step 2: Commit**
+
+```bash
+git add acs-admin/src/components/EdgeManager/RebirthButton.vue
+git commit -m "admin: add RebirthButton component"
+```
+
+---
+
+### Task 3: Create useCanRebirth composable
+
+**Files:**
+- Create: `acs-admin/src/composables/useCanRebirth.js`
+
+**Context:** This composable checks whether the current user has the Rebirth CCL permission (`fbb9c25d-386d-4966-a325-f16471d9f7be`) on a list of target UUIDs. It uses `Auth.check_acl()` which accepts a Kerberos principal string directly (see `lib/js-service-client/lib/service/auth.js:107-110`).
+
+The composable takes a reactive list of target UUIDs and returns a reactive `Map<uuid, boolean>`.
+
+**Step 1: Create the composable**
+
+```js
+import { ref, watch } from 'vue'
+import { useServiceClientStore } from '@store/serviceClientStore.js'
+
+const REBIRTH_PERMISSION = 'fbb9c25d-386d-4966-a325-f16471d9f7be'
+
+export function useCanRebirth (targets) {
+  const permissions = ref(new Map())
+
+  watch(targets, async (uuids) => {
+    if (!uuids || uuids.length === 0) return
+
+    const s = useServiceClientStore()
+    const results = new Map()
+
+    await Promise.all(uuids.map(async (uuid) => {
+      try {
+        const allowed = await s.client.Auth.check_acl(
+          s.username,
+          REBIRTH_PERMISSION,
+          uuid,
+          false
+        )
+        results.set(uuid, allowed)
+      } catch {
+        results.set(uuid, false)
+      }
+    }))
+
+    permissions.value = results
+  }, { immediate: true })
+
+  return permissions
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add acs-admin/src/composables/useCanRebirth.js
+git commit -m "admin: add useCanRebirth composable"
+```
+
+---
+
+### Task 4: Add Rebirth column to node list
+
+**Files:**
+- Modify: `acs-admin/src/pages/EdgeManager/EdgeClusters/nodeColumns.ts`
+- Modify: `acs-admin/src/pages/EdgeManager/EdgeClusters/EdgeCluster.vue`
+
+**Context:** The node DataTable uses `nodeColumns` for its column definitions. We need to add an actions column that renders a `RebirthButton`. The button needs the Sparkplug address (from the node's `sparkplugAddress` config) and the ACL check result.
+
+The `sparkplugAddress` config value is an object like `{ group: "...", node: "..." }`. The CmdEsc URL expects `group/node` as a string.
+
+**Step 1: Add actions column to nodeColumns.ts**
+
+Add a new column after the `hostname` column:
+
+```ts
+{
+    id: 'actions',
+    header: () => null,
+    cell: ({ row }) => {
+        const addr = row.original.sparkplugAddress
+        if (!addr) return null
+        const addressStr = `${addr.group}/${addr.node}`
+        return h(RebirthButton, {
+            address: addressStr,
+            name: row.original.name,
+            canRebirth: row.original._canRebirth ?? false,
+        })
+    },
+    enableSorting: false,
+    enableHiding: false,
+}
+```
+
+Add the import at the top of nodeColumns.ts:
+```ts
+import RebirthButton from '@/components/EdgeManager/RebirthButton.vue'
+```
+
+**Step 2: Wire up ACL checks in EdgeCluster.vue**
+
+In `EdgeCluster.vue`, import and use the composable:
+
+```js
+import { useCanRebirth } from '@/composables/useCanRebirth.js'
+import { computed } from 'vue'
+```
+
+In `setup()`:
+```js
+const n = useNodeStore()
+const nodeUuids = computed(() => n.data?.map(e => e.uuid) ?? [])
+const canRebirthMap = useCanRebirth(nodeUuids)
+```
+
+In the `nodes` computed property, augment each node with the permission:
+```js
+nodes () {
+  const filtered = Array.isArray(this.n.data)
+    ? this.n.data.filter(e => e.deployment?.cluster === this.cluster.uuid)
+    : []
+  return filtered.map(n => ({
+    ...n,
+    _canRebirth: this.canRebirthMap?.get(n.uuid) ?? false
+  }))
+},
+```
+
+Expose `canRebirthMap` from setup by returning it alongside the other values.
+
+**Step 3: Commit**
+
+```bash
+git add acs-admin/src/pages/EdgeManager/EdgeClusters/nodeColumns.ts
+git add acs-admin/src/pages/EdgeManager/EdgeClusters/EdgeCluster.vue
+git commit -m "admin: add Rebirth button to node list"
+```
+
+---
+
+### Task 5: Add Rebirth column to device list
+
+**Files:**
+- Modify: `acs-admin/src/pages/EdgeManager/Nodes/deviceColumns.ts`
+- Modify: `acs-admin/src/pages/EdgeManager/Nodes/Node.vue`
+
+**Context:** Same pattern as Task 4. The device store already has `sparkplugAddress`. The device Sparkplug address includes the device name: `{ group: "...", node: "...", device: "..." }`. The CmdEsc URL expects `group/node/device`.
+
+**Step 1: Add actions column to deviceColumns.ts**
+
+Add a new column after the `name` column:
+
+```ts
+{
+    id: 'actions',
+    header: () => null,
+    cell: ({ row }) => {
+        const addr = row.original.sparkplugAddress
+        if (!addr) return null
+        const addressStr = `${addr.group}/${addr.node}/${addr.device}`
+        return h(RebirthButton, {
+            address: addressStr,
+            name: row.original.name,
+            canRebirth: row.original._canRebirth ?? false,
+        })
+    },
+    enableSorting: false,
+    enableHiding: false,
+}
+```
+
+Add the import:
+```ts
+import RebirthButton from '@/components/EdgeManager/RebirthButton.vue'
+```
+
+**Step 2: Wire up ACL checks in Node.vue**
+
+Same pattern as EdgeCluster.vue - import `useCanRebirth`, create a computed list of device UUIDs, augment the `devices` computed property with `_canRebirth`.
+
+**Step 3: Commit**
+
+```bash
+git add acs-admin/src/pages/EdgeManager/Nodes/deviceColumns.ts
+git add acs-admin/src/pages/EdgeManager/Nodes/Node.vue
+git commit -m "admin: add Rebirth button to device list"
+```
+
+---
+
+### Task 6: Manual test
+
+**Steps:**
+1. Run the admin UI in dev mode (`cd acs-admin && npm run dev`)
+2. Navigate to an edge cluster with nodes
+3. Verify Rebirth button appears per-node row (only for nodes the user has permission on)
+4. Click Rebirth on a node - verify loading spinner, success toast
+5. Navigate into a node to see the device list
+6. Verify Rebirth button appears per-device row
+7. Click Rebirth on a device - verify loading spinner, success toast
+8. Test with a user that lacks Rebirth permission - verify buttons are hidden


### PR DESCRIPTION
## Summary

- Per-row Rebirth button on Node and Device lists in the Edge Manager
- Sends `Node Control/Rebirth` or `Device Control/Rebirth` via CmdEsc
- Button only shown if user has the Rebirth CCL permission (checked via Auth HTTP API with wildcard support)
- Loading spinner during request, success/error toasts
- Tooltip on hover

## Changes

- `RebirthButton.vue` - new component with CmdEsc integration and tooltip
- `useCanRebirth.js` - composable that checks Rebirth ACL per target
- `nodeColumns.ts` / `EdgeCluster.vue` - Rebirth column in node list
- `deviceColumns.ts` / `Node.vue` - Rebirth column in device list
- `useNodeStore.js` - added sparkplugAddress config

## Test Plan

- [x] Verify Rebirth button appears for nodes/devices the user has permission on
- [x] Verify button is hidden for users without Rebirth CCL permission
- [x] Click Rebirth on a node - verify NBIRTH is re-published
- [x] Click Rebirth on a device - verify DBIRTH is re-published
- [x] Verify loading spinner and success toast
- [x] Verify tooltip shows on hover