### PR TITLE
Start integrating the MetaDB as the ConfigDB

### DIFF
--- a/acs-admin/src/components/LoginDialog.vue
+++ b/acs-admin/src/components/LoginDialog.vue
@@ -32,6 +32,12 @@
           </div>
           <Input @keydown.enter="login" v-model="password" id="password" type="password" required/>
         </div>
+        <div class="grid gap-2">
+          <div class="flex items-center gap-3">
+            <Checkbox id="verbose" v-model="verbose" />
+            <label for="verbose" class="text-sm font-medium cursor-pointer">Verbose logging</label>
+          </div>
+        </div>
         <Button :disabled="buttonDisabled" @click="login" type="submit" class="w-full">
           <div v-if="!loggingIn">Login</div>
           <div v-else class="flex items-center justify-center">
@@ -48,6 +54,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Checkbox } from '@/components/ui/checkbox'
 import { useServiceClientStore } from '@/store/serviceClientStore.js'
 import {toast} from "vue-sonner";
 
@@ -62,6 +69,7 @@ export default {
     CardDescription,
     CardHeader,
     CardTitle,
+    Checkbox,
     Input,
     Label,
   },
@@ -91,7 +99,7 @@ export default {
         username: this.username,
         password: this.password,
         browser: true,
-        verbose: import.meta.env.VERBOSE ?? "",
+        verbose: this.verbose ? "ALL" : (import.meta.env.VERBOSE ?? ""),
       })
         this.$router.push("/");
       }catch(e){
@@ -107,6 +115,7 @@ export default {
       loggingIn: false,
       username: null,
       password: null,
+      verbose: false,
     }
   },
 }

--- a/acs-krb-keys-operator/lib/amrc/factoryplus/service_client/configdb.py
+++ b/acs-krb-keys-operator/lib/amrc/factoryplus/service_client/configdb.py
@@ -17,7 +17,7 @@ class ConfigDB (ServiceInterface):
         self.service = uuids.Service.ConfigDB
 
     def get_config (self, app, obj):
-        st, json = self.fetch(f"v1/app/{app}/object/{obj}")
+        st, json = self.fetch(f"v2/app/{app}/object/{obj}")
         if st == 404:
             return
         if st != 200:
@@ -27,7 +27,7 @@ class ConfigDB (ServiceInterface):
     def put_config (self, app, obj, json):
         st, _ = self.fetch(
             method="PUT",
-            url=f"v1/app/{app}/object/{obj}",
+            url=f"v2/app/{app}/object/{obj}",
             json=json)
         if st == 204:
             return False
@@ -38,7 +38,7 @@ class ConfigDB (ServiceInterface):
     def patch_config (self, app, obj, patch):
         st, _ = self.fetch(
             method="PATCH",
-            url=f"v1/app/{app}/object/{obj}",
+            url=f"v2/app/{app}/object/{obj}",
             content_type="application/merge-patch+json",
             json=patch)
         if st == 204:
@@ -48,7 +48,7 @@ class ConfigDB (ServiceInterface):
     def delete_config (self, app, obj):
         st, _ = self.fetch(
             method="DELETE",
-            url=f"v1/app/{app}/object/{obj}")
+            url=f"v2/app/{app}/object/{obj}")
         if st == 204:
             return
         self.error(f"Can't remove {app} for {obj}", st)
@@ -60,7 +60,7 @@ class ConfigDB (ServiceInterface):
 
         st, json = self.fetch(
             method="POST",
-            url="v1/object",
+            url="v2/object",
             json=req)
 
         if st == 200 and excl:

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/api/Load.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/api/Load.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 
 import uk.co.amrc.factoryplus.metadb.db.*;
 
+@Path("")
 public class Load {
     @Inject private RdfStore db;
     @Inject private SecurityContext auth;

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/api/Load.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/api/Load.java
@@ -1,0 +1,36 @@
+/*
+ * Factory+ metadata database
+ * Dump loading
+ * Copyright 2026 University of Sheffield AMRC
+ */
+
+package uk.co.amrc.factoryplus.metadb.api;
+
+import java.util.UUID;
+
+import jakarta.inject.*;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.*;
+
+import jakarta.json.*;
+
+import io.vavr.control.Option;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import uk.co.amrc.factoryplus.metadb.db.*;
+
+public class Load {
+    @Inject private RdfStore db;
+    @Inject private SecurityContext auth;
+
+    private static final Logger log = LoggerFactory.getLogger(Load.class);
+
+    @POST @Path("load")
+    public void load (JsonValue dump)
+    {
+        log.info("Attempt to load dump {}", dump);
+    }
+}
+

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/api/Sparql.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/api/Sparql.java
@@ -26,6 +26,7 @@ import org.apache.jena.query.*;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFLanguages;
+import org.apache.jena.riot.RIOT;
 import org.apache.jena.riot.WebContent;
 import org.apache.jena.sparql.resultset.SPARQLResult;
 import org.apache.jena.update.*;
@@ -43,6 +44,12 @@ public class Sparql {
     @Inject private SecurityContext auth;
 
     private static final Logger log = LoggerFactory.getLogger(Sparql.class);
+
+    static {
+        /* This will be called automatically when we call a RIOT
+         * function, but that's too late for the selection logic below. */
+        RIOT.init();
+    }
 
     private static final List<Variant> RS_TYPES = buildVariants(
         "application/sparql-results+json",
@@ -76,7 +83,7 @@ public class Sparql {
         {
             return Option.of(req.selectVariant(accept))
                 .map(v -> v.getMediaType().toString())
-                .map(ctToLang)
+                .flatMap(ct -> Option.of(ctToLang.apply(ct)))
                 .getOrElseThrow(() -> new WebApplicationException(406));
         }
 

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/api/V2Config.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/api/V2Config.java
@@ -64,7 +64,9 @@ public class V2Config {
     {
         log.info("Put config for {}/{}", app, obj);
         store.requestExecute(auth, req -> {
+            log.info("Put config: calling checkACL");
             req.checkACL(Vocab.Perm.WriteApp, app);
+            log.info("Put config: calling putValue");
             req.configEntry(app, obj).putValue(config);
         });
     }

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/Dataflow.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/Dataflow.java
@@ -98,7 +98,8 @@ public class Dataflow
         select ?classU ?objU
         where {
             ?class <core/uuid> ?classU.
-            ?obj ?rel ?class; <core/uuid> ?objU.
+            graph ?graph { ?obj ?rel ?class. }
+            ?obj <core/uuid> ?objU.
         }
     """);
 
@@ -111,6 +112,7 @@ public class Dataflow
     private Set<UUID> _fetchRelation (Relation.Bound bound)
     {
         var rs = db.selectQuery(Q_relation, 
+            "graph",            bound.graph(),
             "rel",              bound.prop(),
             bound.selectVar(),  bound.literal());
         return Iterator.ofAll(rs)

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/Dataflow.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/Dataflow.java
@@ -12,6 +12,7 @@ import java.util.concurrent.TimeUnit;
 import jakarta.json.JsonValue;
 
 import io.reactivex.rxjava3.core.*;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 import io.reactivex.rxjava3.subjects.*;
 
 import io.vavr.collection.*;
@@ -76,6 +77,7 @@ public class Dataflow
 
     private Observable<Update.Config> buildConfigUpdates ()
     {
+        /* We must start synchronous, inside the txn */
         return modelUpdates
             .map(ds -> QueryExecution.dataset(ds)
                 .query(Q_appUpdates)
@@ -84,11 +86,47 @@ public class Dataflow
                 rs.forEachRemaining(em::onNext);
                 em.onComplete();
             }))
+            /* From here we move to the Rx computation threads */
+            .observeOn(Schedulers.computation())
             .map(Update.Config::ofQuerySolution)
             .share();
     }
 
     public Observable<Update.Config> configUpdates () { return configUpdates; }
+
+    private static final Query Q_classMembers = Vocab.query("""
+        select ?objU
+        where {
+            ?class <core/uuid> ?classU.
+            ?obj a ?class; <core/uuid> ?objU.
+        }
+    """);
+
+    private CacheSeq<UUID, Set<UUID>> _cacheClassMembers =
+        CacheSeq.builder(this::_buildClassMembers)
+            .withTimeout(1, TimeUnit.HOURS)
+            .withReplay()
+            .build();
+
+    private Observable<Set<UUID>> _buildClassMembers (UUID klass)
+    {
+        /* Start synchronous */
+        return modelUpdates
+            /* For now requery every time. In principal we could filter
+             * by rank of class changed to limit the churn. */
+            .map(upd -> db.selectQuery(Q_classMembers, "classU", klass))
+            .map(rs -> Iterator.ofAll(rs)
+                .map(qs -> Util.decodeLiteral(qs.get("objU"), UUID.class))
+                .toSet())
+            /* Move to computation thread */
+            .observeOn(Schedulers.computation())
+            .distinctUntilChanged();
+    }
+
+    public Observable<Set<UUID>> classMembers (UUID klass)
+    {
+        return _cacheClassMembers.get(klass);
+    }
 
     public Observable<Update.Config> appUpdates (UUID app)
     {

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/Dataflow.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/Dataflow.java
@@ -111,6 +111,7 @@ public class Dataflow
 
     private Set<UUID> _fetchRelation (Relation.Bound bound)
     {
+        log.info("Fetch relation {}", bound);
         var rs = db.selectQuery(Q_relation, 
             "graph",            bound.graph(),
             "rel",              bound.prop(),

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/Dataflow.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/Dataflow.java
@@ -108,17 +108,31 @@ public class Dataflow
             .withReplay()
             .build();
 
+    private Set<UUID> _fetchClassMembers (UUID klass)
+    {
+        var rs = db.selectQuery(Q_classMembers, 
+            "classU", Vocab.uuidLiteral(klass));
+        return Iterator.ofAll(rs)
+            .map(qs -> Util.decodeLiteral(qs.get("objU"), UUID.class))
+            .toSet();
+    }
+
     private Observable<Set<UUID>> _buildClassMembers (UUID klass)
     {
-        /* Start synchronous */
-        return modelUpdates
+        /* This is synchronous and comes from an update txn */
+        var updates =  modelUpdates
             /* For now requery every time. In principal we could filter
              * by rank of class changed to limit the churn. */
-            .map(upd -> db.selectQuery(Q_classMembers, "classU", klass))
-            .map(rs -> Iterator.ofAll(rs)
-                .map(qs -> Util.decodeLiteral(qs.get("objU"), UUID.class))
-                .toSet())
-            /* Move to computation thread */
+            .map(upd -> _fetchClassMembers(klass));
+
+        return Single.fromCallable(() ->
+                db.calculateRead(() -> _fetchClassMembers(klass)))
+            /* Make the initial query on the Rx io sched */
+            .subscribeOn(Schedulers.io())
+            /* Subsequent updates will pass down within an update txn */
+            .toObservable()
+            .concatWith(updates)
+            /* Move to computation sched */
             .observeOn(Schedulers.computation())
             .distinctUntilChanged();
     }

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/Dataflow.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/Dataflow.java
@@ -94,39 +94,40 @@ public class Dataflow
 
     public Observable<Update.Config> configUpdates () { return configUpdates; }
 
-    private static final Query Q_classMembers = Vocab.query("""
-        select ?objU
+    private static final Query Q_relation = Vocab.query("""
+        select ?classU ?objU
         where {
             ?class <core/uuid> ?classU.
-            ?obj a ?class; <core/uuid> ?objU.
+            ?obj ?rel ?class; <core/uuid> ?objU.
         }
     """);
 
-    private CacheSeq<UUID, Set<UUID>> _cacheClassMembers =
-        CacheSeq.builder(this::_buildClassMembers)
+    private CacheSeq<Relation.Bound, Set<UUID>> _cacheRelation =
+        CacheSeq.builder(this::_buildRelation)
             .withTimeout(1, TimeUnit.HOURS)
             .withReplay()
             .build();
 
-    private Set<UUID> _fetchClassMembers (UUID klass)
+    private Set<UUID> _fetchRelation (Relation.Bound bound)
     {
-        var rs = db.selectQuery(Q_classMembers, 
-            "classU", Vocab.uuidLiteral(klass));
+        var rs = db.selectQuery(Q_relation, 
+            "rel",              bound.prop(),
+            bound.selectVar(),  bound.literal());
         return Iterator.ofAll(rs)
-            .map(qs -> Util.decodeLiteral(qs.get("objU"), UUID.class))
+            .map(qs -> Util.decodeLiteral(qs.get(bound.resultVar()), UUID.class))
             .toSet();
     }
 
-    private Observable<Set<UUID>> _buildClassMembers (UUID klass)
+    private Observable<Set<UUID>> _buildRelation (Relation.Bound bound)
     {
         /* This is synchronous and comes from an update txn */
         var updates =  modelUpdates
             /* For now requery every time. In principal we could filter
              * by rank of class changed to limit the churn. */
-            .map(upd -> _fetchClassMembers(klass));
+            .map(upd -> _fetchRelation(bound));
 
         return Single.fromCallable(() ->
-                db.calculateRead(() -> _fetchClassMembers(klass)))
+                db.calculateRead(() -> _fetchRelation(bound)))
             /* Make the initial query on the Rx io sched */
             .subscribeOn(Schedulers.io())
             /* Subsequent updates will pass down within an update txn */
@@ -137,9 +138,9 @@ public class Dataflow
             .distinctUntilChanged();
     }
 
-    public Observable<Set<UUID>> classMembers (UUID klass)
+    public Observable<Set<UUID>> relation (Relation.Bound bound)
     {
-        return _cacheClassMembers.get(klass);
+        return _cacheRelation.get(bound);
     }
 
     public Observable<Update.Config> appUpdates (UUID app)

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/MetaDBNotify.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/MetaDBNotify.java
@@ -40,6 +40,7 @@ public class MetaDBNotify
         notify = NotifyV2.builder(db.auth())
             .watch("v2/app/{app}/object/", this::appList)
             .search("v2/app/{app}/object/", this::appSearch)
+            .watch("v2/app/{app}/object/{object}", this::configWatch)
             .watch("v2/class/{class}/{relation}/", this::classRelation)
             .watch("v2/class/{class}/direct/{relation}/", this::classDirectRelation)
             .build();
@@ -55,10 +56,9 @@ public class MetaDBNotify
                 .build());
     }
 
-
     private record SubHandler (Session sess, Map<String, String> args)
     {
-        private static <T> Observable<Response<T>> invalid ()
+        public static <T> Observable<Response<T>> invalid ()
         {
             return Observable.just(Response.of(410));
         }
@@ -125,6 +125,20 @@ public class MetaDBNotify
                 .mapKeys(UUID::toString)
                 .mapValues(v -> v.toResponse())))
             .map(SearchUpdate::ofResponse);
+    }
+
+    private Observable<Response<JsonValue>> configWatch (
+        Session sess, Map<String, String> args)
+    {
+        log.info("configWatch: {}", args);
+        var sh = new SubHandler(sess, args);
+        return sh.findUUID("object")
+            .map(obj -> sh.fromUUID("app", data::appValues, Vocab.Perm.ReadApp)
+                .map(r -> r.flatMap(cs -> cs
+                    .get(obj)
+                    .map(v -> v.toResponse())
+                    .getOrElse(Response::empty))))
+            .getOrElse(SubHandler::invalid);
     }
 
     private Observable<Response<JsonValue>> classRelation (

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/MetaDBNotify.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/MetaDBNotify.java
@@ -38,6 +38,7 @@ public class MetaDBNotify
         notify = NotifyV2.builder(db.auth())
             .watch("v2/app/{app}/object/", this::appList)
             .search("v2/app/{app}/object/", this::appSearch)
+            .watch("v2/class/{class}/member/", this::classMembers)
             .build();
     }
 
@@ -91,5 +92,13 @@ public class MetaDBNotify
                 .mapKeys(UUID::toString)
                 .mapValues(v -> v.toResponse())))
             .map(SearchUpdate::ofResponse);
+    }
+
+    private Observable<Response> classMembers (Session sess, Map<String, String> args)
+    {
+        log.info("classMembers: {}", args);
+        return new SubHandler(sess, args)
+            .fromUUID("class", data::classMembers, Vocab.Perm.ReadMembers)
+            .map(MetaDBNotify::setUpdate);
     }
 }

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/MetaDBNotify.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/MetaDBNotify.java
@@ -4,6 +4,7 @@
  * Copyright 2026 University of Sheffield AMRC
  */
 
+/* XXX Should this be in api? */
 package uk.co.amrc.factoryplus.metadb.db;
 
 import java.util.UUID;
@@ -16,6 +17,7 @@ import org.slf4j.LoggerFactory;
 
 import io.reactivex.rxjava3.core.*;
 import io.vavr.collection.*;
+import io.vavr.control.*;
 
 import uk.co.amrc.factoryplus.client.*;
 import uk.co.amrc.factoryplus.notify.*;
@@ -39,6 +41,7 @@ public class MetaDBNotify
             .watch("v2/app/{app}/object/", this::appList)
             .search("v2/app/{app}/object/", this::appSearch)
             .watch("v2/class/{class}/{relation}/", this::classRelation)
+            .watch("v2/class/{class}/direct/{relation}/", this::classDirectRelation)
             .build();
     }
 
@@ -60,28 +63,39 @@ public class MetaDBNotify
             return Observable.just(Response.of(410));
         }
 
+        public Option<UUID> findUUID (String arg)
+        {
+            return args.get(arg)
+                .flatMap(Decoders::parseUUID);
+        }
+
         public <T> Observable<Response<T>> fromUUID (
             String arg,
             Function<UUID, Observable<T>> factory,
             UUID permission)
         {
-            return args.get(arg)
-                .flatMap(Decoders::parseUUID)
+            return findUUID(arg)
                 .map(uuid -> factory.apply(uuid)
-                    .map(Response::ok)
                     .compose(sess.applyACL(permission, uuid)))
                 .getOrElse(SubHandler::invalid);
         }
-        
-        public Observable<Response<JsonValue>> fromRelation (
-            String rarg, String oarg, boolean asClass,
-            Function<Relation.Bound, Observable<Set<UUID>>> factory)
+
+        public Option<Relation.Bound> bindRelation (
+            UUID uuid, String rarg, boolean asClass, boolean direct)
         {
             return args.get(rarg)
                 .flatMap(Relation::find)
-                .map(r -> fromUUID(oarg,
-                        u -> factory.apply(r.bind(u, asClass)),
-                        r.readClass())
+                .map(r -> r.bind(uuid, asClass, direct));
+        }
+        
+        public Observable<Response<JsonValue>> fromRelation (
+            String oarg, String rarg, boolean asClass, boolean direct,
+            Function<Relation.Bound, Observable<Set<UUID>>> factory)
+        {
+            return findUUID(oarg)
+                .flatMap(u -> bindRelation(u, rarg, asClass, direct))
+                .map(bound -> factory.apply(bound)
+                    .compose(sess.applyACL(bound.perm(), bound.uuid()))
                     .map(MetaDBNotify::setUpdate))
                 .getOrElse(SubHandler::invalid);
         }
@@ -116,8 +130,16 @@ public class MetaDBNotify
     private Observable<Response<JsonValue>> classRelation (
         Session sess, Map<String, String> args)
     {
-        log.info("classMembers: {}", args);
+        log.info("classRelation: {}", args);
         return new SubHandler(sess, args)
-            .fromRelation("relation", "class", true, data::relation);
+            .fromRelation("class", "relation", true, false, data::relation);
+    }
+
+    private Observable<Response<JsonValue>> classDirectRelation (
+            Session sess, Map<String, String> args)
+    {
+        log.info("classDirectRelation: {}", args);
+        return new SubHandler(sess, args)
+            .fromRelation("class", "relation", true, true, data::relation);
     }
 }

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/MetaDBNotify.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/MetaDBNotify.java
@@ -38,13 +38,13 @@ public class MetaDBNotify
         notify = NotifyV2.builder(db.auth())
             .watch("v2/app/{app}/object/", this::appList)
             .search("v2/app/{app}/object/", this::appSearch)
-            .watch("v2/class/{class}/member/", this::classMembers)
+            .watch("v2/class/{class}/{relation}/", this::classRelation)
             .build();
     }
 
     public NotifyV2 notifyV2 () { return notify; }
 
-    private static <U> Response setUpdate (Response<Set<U>> src)
+    private static <U> Response<JsonValue> setUpdate (Response<Set<U>> src)
     {
         return src
             .map(s -> s.map(u -> u.toString()))
@@ -55,7 +55,12 @@ public class MetaDBNotify
 
     private record SubHandler (Session sess, Map<String, String> args)
     {
-        private <T> Observable<Response<T>> fromUUID (
+        private static <T> Observable<Response<T>> invalid ()
+        {
+            return Observable.just(Response.of(410));
+        }
+
+        public <T> Observable<Response<T>> fromUUID (
             String arg,
             Function<UUID, Observable<T>> factory,
             UUID permission)
@@ -65,7 +70,20 @@ public class MetaDBNotify
                 .map(uuid -> factory.apply(uuid)
                     .map(Response::ok)
                     .compose(sess.applyACL(permission, uuid)))
-                .getOrElse(Observable.just(Response.of(410)));
+                .getOrElse(SubHandler::invalid);
+        }
+        
+        public Observable<Response<JsonValue>> fromRelation (
+            String rarg, String oarg, boolean asClass,
+            Function<Relation.Bound, Observable<Set<UUID>>> factory)
+        {
+            return args.get(rarg)
+                .flatMap(Relation::find)
+                .map(r -> fromUUID(oarg,
+                        u -> factory.apply(r.bind(u, asClass)),
+                        r.readClass())
+                    .map(MetaDBNotify::setUpdate))
+                .getOrElse(SubHandler::invalid);
         }
     }
 
@@ -74,7 +92,8 @@ public class MetaDBNotify
      * configs, which is also not correct. Probably appValues needs to
      * return an Observable<Option<Map>>. */
 
-    private Observable<Response> appList (Session sess, Map<String, String> args)
+    private Observable<Response<JsonValue>> appList (
+        Session sess, Map<String, String> args)
     {
         log.info("appList: {}", args);
         return new SubHandler(sess, args)
@@ -94,11 +113,11 @@ public class MetaDBNotify
             .map(SearchUpdate::ofResponse);
     }
 
-    private Observable<Response> classMembers (Session sess, Map<String, String> args)
+    private Observable<Response<JsonValue>> classRelation (
+        Session sess, Map<String, String> args)
     {
         log.info("classMembers: {}", args);
         return new SubHandler(sess, args)
-            .fromUUID("class", data::classMembers, Vocab.Perm.ReadMembers)
-            .map(MetaDBNotify::setUpdate);
+            .fromRelation("relation", "class", true, data::relation);
     }
 }

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/ObjectStructure.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/ObjectStructure.java
@@ -44,28 +44,6 @@ public class ObjectStructure extends RequestHandler.Component
         return new ObjectStructure(req);
     }
 
-    /* XXX Ideally both of these switch statements would become
-     * data-driven. Possibly an :apiName relation from the property? But
-     * with only two valid cases it does not seem worth it for now. */
-    public record Relation (Property prop, int offset,
-        UUID readClass, /*UUID readObj,*/ UUID writeClass, UUID writeObject)
-    {
-        public static Relation of (String relation) {
-            switch (relation) {
-                case "member":
-                    return new Relation(RDF.type, 1, 
-                        Vocab.Perm.ReadMembers, /*Vocab.Perm.ReadMemberships,*/
-                        Vocab.Perm.WriteMembers, Vocab.Perm.WriteMemberships);
-                case "subclass":
-                    return new Relation(RDFS.subClassOf, 0,
-                        Vocab.Perm.ReadSubclasses, /*Vocab.Perm.ReadSuperclasses,*/
-                        Vocab.Perm.WriteSubclasses, Vocab.Perm.WriteSuperclasses);
-                default:
-                    throw new SvcErr.NotFound("No such relation");
-            }
-        }
-    }
-
     private static final Set<Resource> IMMUTABLE = Set.of(
         Vocab.App.Application, Vocab.Special,
         Vocab.App.Registration, Vocab.App.ConfigSchema,
@@ -205,7 +183,7 @@ public class ObjectStructure extends RequestHandler.Component
         var rel = Relation.of(relation);
         var graph = direct ? db().direct() : db().derived();
 
-        request().checkACL(direct ? rel.readClass : rel.writeClass, uuid);
+        request().checkACL(direct ? rel.readClass() : rel.writeClass(), uuid);
 
         var klass = db().findObjectOrError(uuid);
         return graph
@@ -224,7 +202,7 @@ public class ObjectStructure extends RequestHandler.Component
         /* We don't check the object permissions here because (a) there
          * are no readObject perms defined and (b) the information can
          * be derived from listRelation anyway so there's no point. */
-        request().checkACL(direct ? rel.readClass : rel.writeClass, klass);
+        request().checkACL(direct ? rel.readClass() : rel.writeClass(), klass);
 
         var kres = db().findObjectOrError(klass).node();
         var ores = db().findObjectOrError(object).node();
@@ -239,8 +217,8 @@ public class ObjectStructure extends RequestHandler.Component
     {
         var rel = Relation.of(relation);
 
-        request().checkACL(rel.writeClass, klass);
-        request().checkACL(rel.writeObject, object);
+        request().checkACL(rel.writeClass(), klass);
+        request().checkACL(rel.writeObject(), object);
 
         var kres = db().findObjectOrError(klass).node();
         var ores = db().findObjectOrError(object).node();
@@ -257,8 +235,8 @@ public class ObjectStructure extends RequestHandler.Component
     {
         var rel = Relation.of(relation);
 
-        request().checkACL(rel.writeClass, klass);
-        request().checkACL(rel.writeObject, object);
+        request().checkACL(rel.writeClass(), klass);
+        request().checkACL(rel.writeObject(), object);
 
         var kres = db().findObjectOrError(klass).node();
         var ores = db().findObjectOrError(object).node();

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/RdfStore.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/RdfStore.java
@@ -95,11 +95,47 @@ public class RdfStore
         schemaTracker.start();
     }
 
-    public void executeRead (Runnable r) { dataset.executeRead(r); }
-    public <T> T calculateRead (Supplier<T> s) { return dataset.calculateRead(s); }
+    private ConcurrentHashMap<String, Boolean> _txnrw = new ConcurrentHashMap<>();
 
-    public void executeWrite (Runnable r) { dataset.executeWrite(r); }
-    public <T> T calculateWrite (Supplier<T> s) { return dataset.calculateWrite(s); }
+    private void _txnlog (String msg)
+    {
+        log.info("TXN: {} ({}): {}", 
+            msg, _txnrw.size(), Thread.currentThread().getName());
+        log.info("TXN: open: {}", _txnrw.toString());
+    }
+
+    private <T> T _txn (boolean rw, Supplier<T> supp)
+    {
+        var name = Thread.currentThread().getName();
+        try {
+            _txnlog("BEGIN");
+            _txnrw.put(name, rw);
+            var rv = supp.get();
+            _txnrw.remove(name);
+            _txnlog("COMMIT");
+
+            return rv;
+        }
+        catch (Throwable e) {
+            _txnrw.remove(name);
+            _txnlog("ABORT");
+            throw e;
+        }
+    }
+
+    public void executeRead (Runnable r) { 
+        _txn(false, () -> {dataset.executeRead(r); return 1;});
+    }
+    public <T> T calculateRead (Supplier<T> s) { 
+        return _txn(false, () -> dataset.calculateRead(s));
+    }
+
+    public void executeWrite (Runnable r) { 
+        _txn(true, () -> {dataset.executeWrite(r); return 1;});
+    }
+    public <T> T calculateWrite (Supplier<T> s) { 
+        return _txn(true, () -> dataset.calculateWrite(s)); 
+    }
 
     public <T> T requestRead (SecurityContext ctx, Function<RequestHandler, T> cb)
     {
@@ -131,11 +167,14 @@ public class RdfStore
      */
     public <T> T requestWrite (SecurityContext ctx, Function<RequestHandler, T> cb)
     {
+        var thr = Thread.currentThread().getName();
         var req = new RequestHandler(this, ctx);
         var listener = new ModelUpdate();
         T rv;
 
         try {
+            _txnlog("BEGIN");
+            _txnrw.put(thr, true);
             dataset.begin(ReadWrite.WRITE);
             direct.register(listener);
             rv = cb.apply(req);
@@ -143,10 +182,14 @@ public class RdfStore
              * the domains. This could be optimised by using the
              * change-notify information collected up to this point. */
             req.appUpdater().update();
+            _txnrw.remove(thr);
+            _txnlog("COMMIT");
             dataset.commit();
         }
         catch (Throwable e) {
             dataset.abort();
+            _txnrw.remove(thr);
+            _txnlog("ABORT");
             throw e;
         }
         finally {
@@ -158,7 +201,9 @@ public class RdfStore
         /* It is important that all dataflow processing that queries the
          * update dataset happens syncronously. Otherwise it won't be in
          * this transaction. */
-        update.executeRead(() -> dataflow.modelUpdate(update));
+        update.executeRead(() -> {
+            dataflow.modelUpdate(update);
+        });
 
         return rv;
     }

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/RdfStore.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/RdfStore.java
@@ -139,7 +139,8 @@ public class RdfStore
 
     public <T> T requestRead (SecurityContext ctx, Function<RequestHandler, T> cb)
     {
-        return calculateRead(() -> cb.apply(new RequestHandler(this, ctx)));
+        var req = new RequestHandler(this, ctx).start();
+        return calculateRead(() -> cb.apply(req));
     }
 
     /* Jena ModelChangedListeners do not appear to respect inference
@@ -168,7 +169,8 @@ public class RdfStore
     public <T> T requestWrite (SecurityContext ctx, Function<RequestHandler, T> cb)
     {
         var thr = Thread.currentThread().getName();
-        var req = new RequestHandler(this, ctx);
+        var req = new RequestHandler(this, ctx)
+            .start();
         var listener = new ModelUpdate();
         T rv;
 

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/RdfStore.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/RdfStore.java
@@ -95,30 +95,31 @@ public class RdfStore
         schemaTracker.start();
     }
 
-    private ConcurrentHashMap<String, Boolean> _txnrw = new ConcurrentHashMap<>();
+    //private ConcurrentHashMap<String, Boolean> _txnrw = new ConcurrentHashMap<>();
 
-    private void _txnlog (String msg)
+    private void _txnlog (String msg, boolean open, boolean rw)
     {
-        log.info("TXN: {} ({}): {}", 
-            msg, _txnrw.size(), Thread.currentThread().getName());
-        log.info("TXN: open: {}", _txnrw.toString());
+//        var name = Thread.currentThread().getName();
+//
+//        if (!open)
+//            _txnrw.remove(name);
+//        log.info("TXN: {} {} ({})", msg, rw, _txnrw.size());
+//        log.info("TXN: open: {}", _txnrw.toString());
+//        if (open)
+//            _txnrw.put(name, rw);
     }
 
     private <T> T _txn (boolean rw, Supplier<T> supp)
     {
-        var name = Thread.currentThread().getName();
         try {
-            _txnlog("BEGIN");
-            _txnrw.put(name, rw);
+            _txnlog("BEGIN", true, rw);
             var rv = supp.get();
-            _txnrw.remove(name);
-            _txnlog("COMMIT");
+            _txnlog("COMMIT", false, rw);
 
             return rv;
         }
         catch (Throwable e) {
-            _txnrw.remove(name);
-            _txnlog("ABORT");
+            _txnlog("ABORT", false, rw);
             throw e;
         }
     }
@@ -168,15 +169,13 @@ public class RdfStore
      */
     public <T> T requestWrite (SecurityContext ctx, Function<RequestHandler, T> cb)
     {
-        var thr = Thread.currentThread().getName();
         var req = new RequestHandler(this, ctx)
             .start();
         var listener = new ModelUpdate();
         T rv;
 
         try {
-            _txnlog("BEGIN");
-            _txnrw.put(thr, true);
+            _txnlog("BEGIN", true, true);
             dataset.begin(ReadWrite.WRITE);
             direct.register(listener);
             rv = cb.apply(req);
@@ -184,14 +183,12 @@ public class RdfStore
              * the domains. This could be optimised by using the
              * change-notify information collected up to this point. */
             req.appUpdater().update();
-            _txnrw.remove(thr);
-            _txnlog("COMMIT");
+            _txnlog("COMMIT", false, true);
             dataset.commit();
         }
         catch (Throwable e) {
             dataset.abort();
-            _txnrw.remove(thr);
-            _txnlog("ABORT");
+            _txnlog("ABORT", false, true);
             throw e;
         }
         finally {

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/Relation.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/Relation.java
@@ -17,14 +17,14 @@ import io.vavr.control.*;
 import uk.co.amrc.factoryplus.service.SvcErr;
 
 public record Relation (String name, Property prop, int offset,
-    UUID readClass, /*UUID readObj,*/ UUID writeClass, UUID writeObject)
+    UUID readClass, UUID readObject, UUID writeClass, UUID writeObject)
 {
     private static List<Relation> known = List.of(
         new Relation("member", RDF.type, 1, 
-            Vocab.Perm.ReadMembers, /*Vocab.Perm.ReadMemberships,*/
+            Vocab.Perm.ReadMembers, Vocab.Perm.ReadMemberships,
             Vocab.Perm.WriteMembers, Vocab.Perm.WriteMemberships),
         new Relation("subclass", RDFS.subClassOf, 0,
-            Vocab.Perm.ReadSubclasses, /*Vocab.Perm.ReadSuperclasses,*/
+            Vocab.Perm.ReadSubclasses, Vocab.Perm.ReadSuperclasses,
             Vocab.Perm.WriteSubclasses, Vocab.Perm.WriteSuperclasses));
 
     public static Option<Relation> find (String relation)
@@ -38,20 +38,30 @@ public record Relation (String name, Property prop, int offset,
             .getOrElseThrow(() -> new SvcErr.NotFound("No such relation"));
     }
 
-    public static record Bound (Relation relation, UUID uuid, boolean asClass)
+    public static record Bound (Relation relation, UUID uuid,
+        boolean asClass, boolean direct)
     {
+        public Resource graph () { return direct ? Vocab.G_direct : Vocab.G_derived; }
         public Property prop () { return relation.prop(); }
         public Literal literal () { return Vocab.uuidLiteral(uuid); }
 
         public String selectVar () { return asClass ? "classU" : "objU"; }
         public String resultVar () { return asClass ? "objU" : "classU"; }
+
+        public UUID perm ()
+        {
+            if (direct) {
+                return asClass ? relation.writeClass() : relation.writeObject();
+            }
+            else {
+                return asClass ? relation.readClass() : relation.readObject();
+            }
+        }
     }
 
-    public Bound bind (UUID uuid, boolean asClass)
+    public Bound bind (UUID uuid, boolean asClass, boolean direct)
     {
-        return new Bound(this, uuid, asClass);
+        return new Bound(this, uuid, asClass, direct);
     }
-    public Bound bindClass (UUID uuid) { return bind(uuid, true); }
-    public Bound bindObject (UUID uuid) { return bind(uuid, false); }
 }
 

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/Relation.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/Relation.java
@@ -1,0 +1,57 @@
+/*
+ * Factory+ metadata database
+ * Object relations exposed via the API
+ * Copyright 2026 University of Sheffield AMRC
+ */
+
+package uk.co.amrc.factoryplus.metadb.db;
+
+import java.util.UUID;
+
+import org.apache.jena.rdf.model.*;
+import org.apache.jena.vocabulary.*;
+
+import io.vavr.collection.*;
+import io.vavr.control.*;
+
+import uk.co.amrc.factoryplus.service.SvcErr;
+
+public record Relation (String name, Property prop, int offset,
+    UUID readClass, /*UUID readObj,*/ UUID writeClass, UUID writeObject)
+{
+    private static List<Relation> known = List.of(
+        new Relation("member", RDF.type, 1, 
+            Vocab.Perm.ReadMembers, /*Vocab.Perm.ReadMemberships,*/
+            Vocab.Perm.WriteMembers, Vocab.Perm.WriteMemberships),
+        new Relation("subclass", RDFS.subClassOf, 0,
+            Vocab.Perm.ReadSubclasses, /*Vocab.Perm.ReadSuperclasses,*/
+            Vocab.Perm.WriteSubclasses, Vocab.Perm.WriteSuperclasses));
+
+    public static Option<Relation> find (String relation)
+    {
+        return known.find(r -> r.name.equals(relation));
+    }
+
+    public static Relation of (String relation)
+    {
+        return find(relation)
+            .getOrElseThrow(() -> new SvcErr.NotFound("No such relation"));
+    }
+
+    public static record Bound (Relation relation, UUID uuid, boolean asClass)
+    {
+        public Property prop () { return relation.prop(); }
+        public Literal literal () { return Vocab.uuidLiteral(uuid); }
+
+        public String selectVar () { return asClass ? "classU" : "objU"; }
+        public String resultVar () { return asClass ? "objU" : "classU"; }
+    }
+
+    public Bound bind (UUID uuid, boolean asClass)
+    {
+        return new Bound(this, uuid, asClass);
+    }
+    public Bound bindClass (UUID uuid) { return bind(uuid, true); }
+    public Bound bindObject (UUID uuid) { return bind(uuid, false); }
+}
+

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/RequestHandler.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/RequestHandler.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 
 import io.vavr.Lazy;
 
+import uk.co.amrc.factoryplus.client.FPAuth;
 import uk.co.amrc.factoryplus.service.*;
 
 /* Eventually these objects will need to be associated with a txn, and a
@@ -47,6 +48,9 @@ public class RequestHandler
     private Lazy<Resource> now;
     private String upn;
 
+    /* Initialised by start() */
+    private FPAuth.Checker checker;
+
     public RequestHandler (RdfStore db, SecurityContext ctx)
     {
         this.db = db;
@@ -60,15 +64,24 @@ public class RequestHandler
     public Resource getInstant () { return now.get(); }
     public String upn () { return upn; }
 
+    /* This will throw if we can't contact the Auth service. It's
+     * important this throws on-thread as we need to abort the current
+     * HTTP request. It's also important we fetch this before the txn
+     * starts to avoid attempting external network access with a txn
+     * open. */
+    public RequestHandler start ()
+    {
+        log.info("Fetching ACL for {}", upn);
+        checker = db().fplus().auth()
+            .fetchChecker(upn)
+            .blockingGet();
+        return this;
+    }
+
     public void checkACL (UUID perm, UUID target)
     {
         log.info("Checking permission for {} / {}", perm, target);
-        var ok = db().fplus().auth()
-            .fetchPermitted(upn, perm, target)
-            /* We must throw on-thread as we are in a txn. */
-            .blockingGet();
-
-        if (!ok)
+        if (!checker.check(perm, target))
             throw new SvcErr.Forbidden();
     }
 

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/RequestHandler.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/RequestHandler.java
@@ -63,21 +63,12 @@ public class RequestHandler
     public void checkACL (UUID perm, UUID target)
     {
         log.info("Checking permission for {} / {}", perm, target);
-        var not = db().fplus().auth()
+        var ok = db().fplus().auth()
             .fetchPermitted(upn, perm, target)
-            /* We must throw on-thread as we are in a txn. However
-             * .timout will pass us over to the computation thread, so
-             * we must materialise the result to avoid it being passed
-             * to the global error handler. */
-            .timeout(10, TimeUnit.SECONDS)
-            .materialize()
+            /* We must throw on-thread as we are in a txn. */
             .blockingGet();
 
-        if (not.isOnError()) {
-            log.info("Error checking ACL", not.getError());
-            throw new SvcErr.Timeout();
-        }
-        if (!not.getValue())
+        if (!ok)
             throw new SvcErr.Forbidden();
     }
 

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/RequestHandler.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/RequestHandler.java
@@ -9,6 +9,7 @@ package uk.co.amrc.factoryplus.metadb.db;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import jakarta.ws.rs.core.SecurityContext;
 
@@ -62,11 +63,21 @@ public class RequestHandler
     public void checkACL (UUID perm, UUID target)
     {
         log.info("Checking permission for {} / {}", perm, target);
-        var ok = db().fplus().auth()
+        var not = db().fplus().auth()
             .fetchPermitted(upn, perm, target)
-            /* This must throw on-thread as we will be within a txn. */
+            /* We must throw on-thread as we are in a txn. However
+             * .timout will pass us over to the computation thread, so
+             * we must materialise the result to avoid it being passed
+             * to the global error handler. */
+            .timeout(10, TimeUnit.SECONDS)
+            .materialize()
             .blockingGet();
-        if (!ok)
+
+        if (not.isOnError()) {
+            log.info("Error checking ACL", not.getError());
+            throw new SvcErr.Timeout();
+        }
+        if (!not.getValue())
             throw new SvcErr.Forbidden();
     }
 

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/Vocab.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/Vocab.java
@@ -83,9 +83,9 @@ public class Vocab
         public static final UUID WriteSubclasses = U("ed11bd2a-50ef-11f0-9f85-df13a1dff9e6");
         public static final UUID WriteSuperclasses = U("fb8e5048-50ef-11f0-91c5-7fd3cb373fbb");
 
-        /* Unimplemented */
-        //public static final UUID ReadMemberships = U("db9f5dae-50ef-11f0-b846-8393c17d1574");
-        //public static final UUID ReadSuperclasses = U("f590e476-50ef-11f0-a120-e7c6d06d79ed");
+        /* Currently unused */
+        public static final UUID ReadMemberships = U("db9f5dae-50ef-11f0-b846-8393c17d1574");
+        public static final UUID ReadSuperclasses = U("f590e476-50ef-11f0-a120-e7c6d06d79ed");
 
         public static final UUID DeleteObj = U("6957174b-7b08-45ca-ac5c-c03ab6928a6e");
         public static final UUID GiveTo = U("4eaab346-4d1e-11f0-800e-dfdc061c6a63");

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/Vocab.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/db/Vocab.java
@@ -9,9 +9,6 @@ package uk.co.amrc.factoryplus.metadb.db;
 import java.util.UUID;
 import java.net.URI;
 
-import io.vavr.control.Try;
-import io.vavr.control.Option;
-
 import org.apache.jena.rdf.model.*;
 import org.apache.jena.shared.PrefixMapping;
 import org.apache.jena.sparql.core.Prologue;
@@ -67,6 +64,13 @@ public class Vocab
 
         public static final Property forP           = prop("app/for");
         public static final Property value          = prop("app/value");
+    }
+
+    /* This is for the bootstrap ACLs. */
+    public static class Target {
+        public static final UUID Registration = U("cb40bed5-49ad-4443-a7f5-08c75009da8f");
+        public static final UUID SparkplugAddr = U("8e32801b-f35a-4cbf-a5c3-2af64d3debd7");
+        public static final UUID Wildcard = U("00000000-0000-0000-0000-000000000000");
     }
 
     public static class Perm {

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/main/Main.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/main/Main.java
@@ -27,8 +27,10 @@ import org.slf4j.LoggerFactory;
 /* Note we have Java Sets but Vavr Maps and Lists */
 import io.vavr.collection.List;
 import io.vavr.collection.HashMap;
+import io.vavr.control.Option;
 
-import uk.co.amrc.factoryplus.client.*;
+import uk.co.amrc.factoryplus.client.FPServiceClient;
+import uk.co.amrc.factoryplus.client.FPAuth.Grant;
 import uk.co.amrc.factoryplus.providers.*;
 import uk.co.amrc.factoryplus.metadb.db.*;
 
@@ -63,18 +65,23 @@ public final class Main {
     private FPServiceClient createServiceClient ()
     {
         var fplus = new FPServiceClient();
-        fplus.getOptionConf("auth_principal")
-            .peek(auth -> {
-                var acl = List.of(
-                    new FPAuth.Grant(Vocab.Perm.ReadApp, Vocab.Target.Registration),
-                    /* XXX I'm not sure why this is needed? */
-                    new FPAuth.Grant(Vocab.Perm.ReadApp, Vocab.Target.SparkplugAddr),
-                    /* XXX These are broader than strictly necessary. */
-                    new FPAuth.Grant(Vocab.Perm.ReadMembers, Vocab.Target.Wildcard),
-                    new FPAuth.Grant(Vocab.Perm.ReadSubclasses, Vocab.Target.Wildcard));
-                log.info("Setting Auth bootstrap ACL for {} to {}", auth, acl);
-                fplus.auth().setBootstrapACLs(HashMap.of(auth, acl));
-            });
+        
+        var acls = HashMap.of(
+            "auth_principal", List.of(
+                new Grant(Vocab.Perm.ReadApp, Vocab.Target.Registration),
+                /* XXX I'm not sure why this is needed? */
+                new Grant(Vocab.Perm.ReadApp, Vocab.Target.SparkplugAddr),
+                /* XXX These are broader than strictly necessary. */
+                new Grant(Vocab.Perm.ReadMembers, Vocab.Target.Wildcard),
+                new Grant(Vocab.Perm.ReadSubclasses, Vocab.Target.Wildcard)));
+
+        var resolved = acls
+            .mapKeys(fplus::getOptionConf)
+            .filterKeys(Option::isDefined)
+            .mapKeys(Option::get);
+
+        log.info("Setting bootstrap ACLs to {}", resolved);
+        fplus.auth().setBootstrapACLs(resolved);
 
         return fplus;
     }

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/main/Main.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/main/Main.java
@@ -24,6 +24,10 @@ import org.glassfish.jersey.server.ServerProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/* Note we have Java Sets but Vavr Maps and Lists */
+import io.vavr.collection.List;
+import io.vavr.collection.HashMap;
+
 import uk.co.amrc.factoryplus.client.*;
 import uk.co.amrc.factoryplus.providers.*;
 import uk.co.amrc.factoryplus.metadb.db.*;
@@ -50,14 +54,29 @@ public final class Main {
     {
         this.port = port;
 
-        this.fplus = new FPServiceClient();
+        this.fplus = createServiceClient();
         this.auth = new AuthProvider(fplus);
         this.model = new RdfStore(fplus, auth, dataDir);
         this.server = createServer();
     }
 
-    interface Throws<T> {
-        public T get () throws Throwable;
+    private FPServiceClient createServiceClient ()
+    {
+        var fplus = new FPServiceClient();
+        fplus.getOptionConf("auth_principal")
+            .peek(auth -> {
+                var acl = List.of(
+                    new FPAuth.Grant(Vocab.Perm.ReadApp, Vocab.Target.Registration),
+                    /* XXX I'm not sure why this is needed? */
+                    new FPAuth.Grant(Vocab.Perm.ReadApp, Vocab.Target.SparkplugAddr),
+                    /* XXX These are broader than strictly necessary. */
+                    new FPAuth.Grant(Vocab.Perm.ReadMembers, Vocab.Target.Wildcard),
+                    new FPAuth.Grant(Vocab.Perm.ReadSubclasses, Vocab.Target.Wildcard));
+                log.info("Setting Auth bootstrap ACL for {} to {}", auth, acl);
+                fplus.auth().setBootstrapACLs(HashMap.of(auth, acl));
+            });
+
+        return fplus;
     }
 
     private Server createServer ()

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/main/Main.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/main/Main.java
@@ -95,14 +95,6 @@ public final class Main {
             }
         };
 
-        var v2app = new ResourceConfig()
-            .property(ServerProperties.PROCESSING_RESPONSE_ERRORS_ENABLED, true)
-            .packages("uk.co.amrc.factoryplus.providers")
-            .packages("uk.co.amrc.factoryplus.metadb.api")
-            .register(bindings);
-        var v2api = new ContextHandler(
-            ContainerFactory.createContainer(Handler.class, v2app), "/v2");
-
         var notify = model.metaNotify()
             .notifyV2()
             .contextHandlerFor(server);
@@ -111,12 +103,12 @@ public final class Main {
             .property(ServerProperties.PROCESSING_RESPONSE_ERRORS_ENABLED, true)
             .packages("uk.co.amrc.factoryplus.providers")
             .packages("uk.co.amrc.factoryplus.webapi")
+            .packages("uk.co.amrc.factoryplus.metadb.api")
             .register(bindings);
         var webapi = new ContextHandler(
             ContainerFactory.createContainer(Handler.class, webapp), "/");
 
         var coll = new ContextHandlerCollection();
-        coll.addHandler(v2api);
         coll.addHandler(notify);
         coll.addHandler(webapi);
 

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/main/Main.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/main/Main.java
@@ -8,7 +8,9 @@ package uk.co.amrc.factoryplus.metadb.main;
 
 import java.io.IOException;
 import java.net.URI;
+import java.time.Duration;
 import java.util.ServiceConfigurationError;
+import java.util.Set;
 import java.util.UUID;
 
 import org.eclipse.jetty.server.*;
@@ -85,6 +87,7 @@ public final class Main {
         var notify = model.metaNotify()
             .notifyV2()
             .contextHandlerFor(server);
+
         var webapp = new ResourceConfig()
             .property(ServerProperties.PROCESSING_RESPONSE_ERRORS_ENABLED, true)
             .packages("uk.co.amrc.factoryplus.providers")
@@ -98,7 +101,15 @@ public final class Main {
         coll.addHandler(notify);
         coll.addHandler(webapi);
 
-        server.setHandler(coll);
+        var cors = new CrossOriginHandler();
+        cors.setAllowedOriginPatterns(Set.of("*"));
+        cors.setAllowedMethods(Set.of("GET", "HEAD", "POST", "PUT", "DELETE", "PATCH"));
+        cors.setAllowedHeaders(Set.of("authorization"));
+        cors.setAllowCredentials(true);
+        cors.setPreflightMaxAge(Duration.ofDays(1));
+        cors.setHandler(coll);
+
+        server.setHandler(cors);
 
         return server;
     }

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/main/Main.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/main/Main.java
@@ -104,7 +104,7 @@ public final class Main {
         var cors = new CrossOriginHandler();
         cors.setAllowedOriginPatterns(Set.of("*"));
         cors.setAllowedMethods(Set.of("GET", "HEAD", "POST", "PUT", "DELETE", "PATCH"));
-        cors.setAllowedHeaders(Set.of("authorization"));
+        cors.setAllowedHeaders(Set.of("authorization","*"));
         cors.setAllowCredentials(true);
         cors.setPreflightMaxAge(Duration.ofDays(1));
         cors.setHandler(coll);

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/main/Main.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/metadb/main/Main.java
@@ -135,6 +135,7 @@ public final class Main {
     private void start () throws Throwable
     {
         fplus.start();
+        auth.start();
         model.start();
         server.start();
     }

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/notify/Filter.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/notify/Filter.java
@@ -49,9 +49,9 @@ interface Filter
     {
         private static final Logger log = LoggerFactory.getLogger(Watch.class);
         private Path path;
-        private Handler<Response> handler;
+        private Handler<Response<JsonValue>> handler;
 
-        public Watch (String path, Handler<Response> handler)
+        public Watch (String path, Handler<Response<JsonValue>> handler)
         {
             this.path = new Path(path);
             this.handler = handler;
@@ -67,7 +67,8 @@ interface Filter
                 .map(args -> buildWatch(this.handler.handle(sess, args)));
         }
 
-        private Observable<NotifyUpdate> buildWatch (Observable<Response> resps)
+        private Observable<NotifyUpdate> buildWatch (
+            Observable<Response<JsonValue>> resps)
         {
             return resps
                 .distinctUntilChanged()

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/notify/NotifyV2.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/notify/NotifyV2.java
@@ -43,7 +43,7 @@ public class NotifyV2
             this.auth = auth;
         }
 
-        public Builder watch (String path, Handler<Response> handler)
+        public Builder watch (String path, Handler<Response<JsonValue>> handler)
         {
             filters = filters.prepend(new Filter.Watch(path, handler));
             return this;

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/notify/Session.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/notify/Session.java
@@ -198,24 +198,29 @@ public class Session
 
     /** Apply ACLs to a notify sequence.
      * Returns a function which can be applied with .compose. This will
-     * replace the Responses in the source sequence with 403s whenever
-     * permission is not granted.
+     * wrap the values from the source seq with Responses, or return 403
+     * Responses whenever permission is not granted.
      */
-    public <T> ObservableTransformer<Response<T>, Response<T>> applyACL (
+    public <T> ObservableTransformer<T, Response<T>> applyACL (
         UUID permission, UUID target)
     {
-        log.info("Applying notify ACLs for {}", upn);
-        /* For root requests we must not contact the Auth service. */
-        if (isRoot) {
-            log.info("Principal {} is root, skipping ACLs", upn);
-            return src -> src;
-        }
+        return src -> {
+            log.info("Applying notify ACLs for {}", upn);
 
-        return src -> Observable.combineLatest(
-                src, watchACL(permission, target),
-                (val, ok) -> ok.flatMap(u -> val))
-            /* This stops extra 403s when permission is denied */
-            .distinctUntilChanged();
+            var resps = src.map(Response::ok);
+
+            /* For root requests we must not contact the Auth service. */
+            if (isRoot) {
+                log.info("Principal {} is root, skipping ACLs", upn);
+                return resps;
+            }
+
+            return Observable.combineLatest(
+                    resps, watchACL(permission, target),
+                    (val, ok) -> ok.flatMap(u -> val))
+                /* This stops extra 403s when permission is denied */
+                .distinctUntilChanged();
+        };
     }
 }
 

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/notify/Session.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/notify/Session.java
@@ -34,7 +34,8 @@ public class Session
     private UUID            uuid;
 
     /* These are initialised by start() */
-    private String                  upn;
+    private String  upn;
+    private boolean isRoot = false;
 
     public Session (NotifyV2 notify)
     {
@@ -94,6 +95,8 @@ public class Session
                  * the only alternative is threading the UPN through the
                  * sequence and that's just messy. */
                 this.upn = upn;
+                if (auth.isRoot(upn))
+                    this.isRoot = true;
                 return recv;
             });
     }
@@ -201,6 +204,13 @@ public class Session
     public <T> ObservableTransformer<Response<T>, Response<T>> applyACL (
         UUID permission, UUID target)
     {
+        log.info("Applying notify ACLs for {}", upn);
+        /* For root requests we must not contact the Auth service. */
+        if (isRoot) {
+            log.info("Principal {} is root, skipping ACLs", upn);
+            return src -> src;
+        }
+
         return src -> Observable.combineLatest(
                 src, watchACL(permission, target),
                 (val, ok) -> ok.flatMap(u -> val))

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/providers/ApiLogger.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/providers/ApiLogger.java
@@ -20,7 +20,7 @@ public class ApiLogger implements ContainerRequestFilter, ContainerResponseFilte
 
     public void filter (ContainerRequestContext req)
     {
-        log.info(">>> {} {}", req.getMethod(), req.getUriInfo().getRequestUri());
+        log.info(">>> {} {}", req.getMethod(), req.getUriInfo().getPath());
     }
 
     public void filter (ContainerRequestContext req, ContainerResponseContext res)

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/providers/AuthFilter.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/providers/AuthFilter.java
@@ -6,6 +6,8 @@
 
 package uk.co.amrc.factoryplus.providers;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.*;
 import java.util.Base64;
 import java.util.regex.Pattern;
 
@@ -14,6 +16,8 @@ import jakarta.ws.rs.*;
 import jakarta.ws.rs.container.*;
 import jakarta.ws.rs.core.*;
 import jakarta.ws.rs.ext.*;
+
+import io.vavr.control.Option;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,12 +29,13 @@ import org.slf4j.LoggerFactory;
  * side that doesn't load this filter? */
 
 @Provider @Priority(Priorities.AUTHENTICATION)
-public class AuthFilter implements ContainerRequestFilter
+public class AuthFilter implements ContainerRequestFilter, ContainerResponseFilter
 {
     private static final Logger log = LoggerFactory.getLogger(AuthFilter.class);
-    
+
     @Context private AuthProvider provider;
 
+    /* This is the request filter. */
     public void filter (ContainerRequestContext req)
     {
         var auth = req.getHeaderString("Authorization");
@@ -39,10 +44,21 @@ public class AuthFilter implements ContainerRequestFilter
          * exception coming from the Single. Otherwise the request
          * processing will continue before auth has been checked. */
         var ctx = provider.authenticate(auth)
-            .doOnSuccess(c -> log.info("Authenticated {} using {}",
-                c.getUserPrincipal(), c.getAuthenticationScheme()))
             .doOnError(e -> log.info("Auth failed", e))
             .blockingGet();
+
         req.setSecurityContext(ctx);
+    }
+
+    /* This is the response filter. */
+    public void filter (ContainerRequestContext req, ContainerResponseContext res)
+    {
+        Option.of(req.getSecurityContext())
+            .filter(r -> r instanceof FPSecurityContext)
+            .flatMap(r -> ((FPSecurityContext)r).gssResult().gssToken())
+            .map(provider.b64e()::encode)
+            .map(StandardCharsets.US_ASCII::decode)
+            .map(b64 -> "Negotiate " + b64)
+            .peek(wwwa -> res.getHeaders().putSingle("WWW-Authenticate", wwwa));
     }
 }

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/providers/AuthFilter.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/providers/AuthFilter.java
@@ -44,7 +44,7 @@ public class AuthFilter implements ContainerRequestFilter, ContainerResponseFilt
          * exception coming from the Single. Otherwise the request
          * processing will continue before auth has been checked. */
         var ctx = provider.authenticate(auth)
-            .doOnError(e -> log.info("Auth failed", e))
+            .doOnError(e -> log.info("Auth failed: {}", e.toString()))
             .blockingGet();
 
         req.setSecurityContext(ctx);

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/providers/AuthProvider.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/providers/AuthProvider.java
@@ -15,13 +15,14 @@ import java.time.Instant;
 import java.util.Base64;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.core.*;
 import io.vavr.control.Option;
 
 import uk.co.amrc.factoryplus.client.FPServiceClient;
@@ -66,6 +67,19 @@ public class AuthProvider
 
     public FPServiceClient fplus () { return fplus; }
     public Base64.Encoder b64e () { return b64e; }
+
+    public void start ()
+    {
+        Observable.interval(6, TimeUnit.HOURS)
+            .subscribe(v -> {
+                log.info("Expiring old sessions");
+                sessions.forEach(Long.MAX_VALUE,
+                    (tok, sess) -> {
+                        if (sess.isExpired())
+                            sessions.remove(tok);
+                    });
+            });
+    }
 
     public Single<FPSecurityContext> authenticate (String auth)
     {

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/providers/AuthProvider.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/providers/AuthProvider.java
@@ -9,7 +9,6 @@ package uk.co.amrc.factoryplus.providers;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
-import java.security.Principal;
 import java.security.SecureRandom;
 import java.time.Instant;
 
@@ -18,8 +17,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.regex.Pattern;
-
-import jakarta.ws.rs.core.SecurityContext;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,21 +38,6 @@ public class AuthProvider
 
     private static final long EXPIRY = 3*3600;
 
-    private record Princ (String name) implements Principal
-    {
-        public String getName () { return name; }
-    }
-
-    private record Ctx (Principal principal, String scheme) implements SecurityContext 
-    {
-        public String getAuthenticationScheme () { return scheme; }
-        public Principal getUserPrincipal () { return principal; }
-        public boolean isSecure () { return true; }
-        public boolean isUserInRole (String role) { return false; }
-
-        public String upn () { return principal().getName(); }
-    }
-
     public record Session (String token, String upn, Instant expiry)
     {
         public boolean isExpired ()
@@ -71,8 +53,9 @@ public class AuthProvider
     private Base64.Encoder b64e = Base64.getEncoder();
 
     private Map<String, Function<String, Single<FPGssResult>>> schemes = Map.of(
-        "basic",    this::basicAuth,
-        "bearer",   this::bearerAuth);
+        "negotiate",    this::gssapiAuth,
+        "basic",        this::basicAuth,
+        "bearer",       this::bearerAuth);
 
     private ConcurrentHashMap<String, Session> sessions = new ConcurrentHashMap<>();
 
@@ -82,8 +65,9 @@ public class AuthProvider
     }
 
     public FPServiceClient fplus () { return fplus; }
+    public Base64.Encoder b64e () { return b64e; }
 
-    public Single<SecurityContext> authenticate (String auth)
+    public Single<FPSecurityContext> authenticate (String auth)
     {
         if (auth == null)
             throw new SvcErr.AuthFailed("No auth supplied");
@@ -100,10 +84,12 @@ public class AuthProvider
         var creds = auth_m.group(2);
 
         return handler.apply(creds)
-            .<SecurityContext>map(res -> new Ctx(new Princ(res.upn()), scheme))
+            .doOnSuccess(r -> log.info("Authenticated {} using {}", r.upn(), scheme))
+            .map(r -> new FPSecurityContext(scheme, r))
             .onErrorResumeNext(e -> {
                 if (e instanceof SvcErr.AuthFailed)
                     return Single.error(e);
+                log.info("Authentication failed ({}): {}", scheme, e.toString());
                 return Single.error(new SvcErr.AuthFailed("Authentication failure"));
             });
     }
@@ -118,6 +104,14 @@ public class AuthProvider
         sessions.put(token, sess);
 
         return sess;
+    }
+
+    public Single<FPGssResult> gssapiAuth (String creds)
+    {
+        return Single.just(creds)
+            .map(b64d::decode)
+            .map(ByteBuffer::wrap)
+            .flatMap(fplus.gss()::verifyGSSAPI);
     }
 
     public Single<FPGssResult> basicAuth (String creds)

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/providers/FPSecurityContext.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/providers/FPSecurityContext.java
@@ -1,0 +1,35 @@
+/*
+ * Factory+ service api
+ * F+ SecurityContext implementation
+ * Copyright 2026 University of Sheffield AMRC
+ */
+
+package uk.co.amrc.factoryplus.providers;
+
+import java.nio.ByteBuffer;
+import java.security.Principal;
+
+import jakarta.ws.rs.core.*;
+import jakarta.ws.rs.ext.*;
+
+import uk.co.amrc.factoryplus.gss.FPGssResult;
+
+public record FPSecurityContext (String scheme, FPGssResult gssResult)
+    implements SecurityContext 
+{
+    /* XXX intern this? */
+    private record Princ (String name) implements Principal
+    {
+        public String getName () { return name; }
+    }
+
+    public String getAuthenticationScheme () { return scheme; }
+    public Principal getUserPrincipal () { return new Princ(upn()); }
+
+    /* Don't know about these, and don't care. */
+    public boolean isSecure () { return true; }
+    public boolean isUserInRole (String role) { return false; }
+
+    public String upn () { return gssResult.upn(); }
+}
+

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/service/SvcErr.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/service/SvcErr.java
@@ -91,4 +91,9 @@ public class SvcErr extends Error
 
         public int statusCode () { return 422; }
     }
+    public static class Timeout extends Client
+    {
+        public Timeout () { super("Upstream timeout"); }
+        public int statusCode () { return 503; }
+    }
 }

--- a/acs-metadb/src/main/java/uk/co/amrc/factoryplus/webapi/WebAPI.java
+++ b/acs-metadb/src/main/java/uk/co/amrc/factoryplus/webapi/WebAPI.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
 
 import uk.co.amrc.factoryplus.providers.*;
 
-@Singleton @Path("")
+@Path("")
 public class WebAPI
 {
     private static final Logger log = LoggerFactory.getLogger(WebAPI.class);
@@ -39,7 +39,7 @@ public class WebAPI
     public JsonValue token ()
     {
         /* We do not allow refreshing a token from a token. */
-        if (auth.getAuthenticationScheme().equals("token"))
+        if (auth.getAuthenticationScheme().equals("bearer"))
             throw new WebApplicationException(403);
 
         var upn = auth.getUserPrincipal().getName();

--- a/acs-metadb/ttl/core.ttl
+++ b/acs-metadb/ttl/core.ttl
@@ -316,7 +316,7 @@
     :name "Permission group".
 <authz/ServicePerms> a :R2Class; :primary :R2Class;
     rdfs:subClassOf <authz/PermissionGroup>;
-    :uuid "c43c7157-a50b-4d2a-ac1a-86ff8e8e88c1";
+    :uuid "b7f0c2f4-ccf5-11ef-be77-777cd4e8cb41";
     :name "Service permission set".
 
 <git/Repo> a :R1Class, <git/RepoGroup>; :primary :R1Class;
@@ -433,6 +433,6 @@
     :name "Write RDF".
 
 <metadb/ServiceRole> a <authn/ServiceRole>; :primary <authn/ServiceRole>;
-    rdfs:subClassOf <authn/CentralService>;
+    rdfs:subClassOf <authn/Principal>;
     :uuid "bf59ab10-3738-11f1-894f-cb07fd5bf02f";
     :name "MetaDB".

--- a/acs-metadb/ttl/core.ttl
+++ b/acs-metadb/ttl/core.ttl
@@ -258,9 +258,10 @@
     :uuid "11614546-b6d7-11ef-aebd-8fbb45451d7c";
     :name "Principal".
 <authn/PrincipalGroup> a :R2Class; :primary :R2Class;
-    rdfs:subClassOf :R1Class; :powersetOf :Principal;
+    rdfs:subClassOf :R1Class; :powersetOf <authn/Principal>;
     :uuid "c0157038-ccff-11ef-a4db-63c6212e998f";
     :name "Principal group".
+
 <authn/PrincipalType> a :R2Class; :primary :R2Class;
     rdfs:subClassOf <authn/PrincipalGroup>;
     :uuid "ae17afe0-ccff-11ef-bb70-67807cb4a9df";
@@ -269,11 +270,141 @@
     rdfs:subClassOf <authn/Principal>;
     :uuid "e463b4ae-a322-46cc-8976-4ba76838e908";
     :name "Central service".
+<authn/HumanUser> a <authn/PrincipalType>; :primary <authn/PrincipalType>;
+    rdfs:subClassOf <authn/Principal>;
+    :uuid "8b3e8f35-78e5-4f93-bf21-7238bcb2ba9d";
+    :name "Human user".
 
-<authn/ConfigDB> a <authn/CentralService>, <sparkplug/Entity>, <service/Provider>;
+<authn/Role> a :R2Class; :primary :R2Class;
+    rdfs:subClassOf <authn/PrincipalGroup>;
+    :uuid "f1fabdd1-de90-4399-b3da-ccf6c2b2c08b";
+    :name "Role".
+<authn/ServiceRole> a :R2Class; :primary :R2Class;
+    rdfs:subClassOf <authn/Role>;
+    :uuid "b419cbc2-ab0f-4311-bd9e-f0591f7e88cb";
+    :name "Service role".
+<authn/EdgeRole> a :R2Class; :primary :R2Class;
+    rdfs:subClassOf <authn/Role>;
+    :uuid "3ba1d68e-ccf5-11ef-82d9-ef32470538b1";
+    :name "Edge role".
+<authn/ClientRole> a :R2Class; :primary :R2Class;
+    rdfs:subClassOf <authn/Role>;
+    :uuid "b2053a3e-bdf8-11ef-9423-771a19e4a8a4";
+    :name "Client role".
+:Administrator a <authn/ClientRole>; :primary <authn/ClientRole>;
+    :uuid "10fc06b7-02f5-45f1-b419-a486b6bc13ba";
+    :name "Administrator".
+
+# This should be R2, a Permission is a set of Grants
+<authz/Permission> a :R1Class; :primary :R1Class;
+    rdfs:subClassOf :Individual;
+    :uuid "8ae784bb-c4b5-4995-9bf6-799b3c7f21ad";
+    :name "Permission".
+<authz/PermissionGroup> a :R2Class; :primary :R2Class;
+    rdfs:subClassOf :R1Class; :powersetOf <authz/Permission>;
+    :uuid "ac0d5288-6136-4ced-a372-325fbbcdd70d";
+    :name "Permission group".
+<authz/ServicePerms> a :R2Class; :primary :R2Class;
+    rdfs:subClassOf <authz/PermissionGroup>;
+    :uuid "c43c7157-a50b-4d2a-ac1a-86ff8e8e88c1";
+    :name "Service permission set".
+
+<auth/perm/All> a <authz/ServicePerms>; :primary <authz/ServicePerms>;
+    rdfs:subClassOf <authz/Permission>;
+    :uuid "50b727d4-3faa-40dc-b347-01c99a226c58";
+    :name "Auth permissions".
+<auth/perm/ManageKerberos> a <auth/perm/All>; :primary <auth/perm/All>;
+    :uuid "327c4cc8-9c46-4e1e-bb6b-257ace37b0f6";
+    :name "ManageKerberos".
+<auth/perm/ReadEffective> a <auth/perm/All>; :primary <auth/perm/All>;
+    :uuid "35252562-51e5-4dd8-84cd-ba0fafa62669";
+    :name "ReadEffective".
+<auth/perm/ManageACL> a <auth/perm/All>; :primary <auth/perm/All>;
+    :uuid "3a41f5ce-fc08-4669-9762-ec9e71061168";
+    :name "ManageACL".
+<auth/perm/ReadACL> a <auth/perm/All>; :primary <auth/perm/All>;
+    :uuid "ba566181-0e8a-405b-b16e-3fb89130fbee";
+    :name "ReadACL".
+<auth/perm/ManageGroup> a <auth/perm/All>; :primary <auth/perm/All>;
+    :uuid "be9b6d47-c845-49b2-b9d5-d87b83f11c3b";
+    :name "ManageGroup".
+<auth/perm/ReadKerberos> a <auth/perm/All>; :primary <auth/perm/All>;
+    :uuid "e8c9c0f7-0d54-4db2-b8d6-cd80c45f6a5c";
+    :name "ReadKerberos".
+
+<configdb/perm/All> a <authz/ServicePerms>; :primary <authz/ServicePerms>;
+    rdfs:subClassOf <authz/Permission>;
+    :uuid "c43c7157-a50b-4d2a-ac1a-86ff8e8e88c1";
+    :name "ConfigDB permissions".
+<configdb/perm/ReadConfig> a <configdb/perm/All>; :primary <config/perm/All>;
+    :uuid "4a339562-cd57-408d-9d1a-6529a383ea4b";
+    :name "ReadConfig".
+<configdb/perm/WriteConfig> a <configdb/perm/All>; :primary <config/perm/All>;
+    :uuid "6c799ccb-d2ad-4715-a2a7-3c8728d6c0bf";
+    :name "WriteConfig".
+<configdb/perm/ListObjects> a <configdb/perm/All>; :primary <config/perm/All>;
+    :uuid "6b4d73ea-50f1-11f0-9333-132037a152a5";
+    :name "ListObjects".
+<configdb/perm/CreateObject> a <configdb/perm/All>; :primary <config/perm/All>;
+    :uuid "ae09e2ba-50ef-11f0-ac03-1f9f5e6548be";
+    :name "CreateObject".
+<configdb/perm/CreateSpecificObject> a <configdb/perm/All>; :primary <config/perm/All>;
+    :uuid "e3491b9c-50f1-11f0-8e16-e75c8f93227b";
+    :name "CreateSpecificObject".
+<configdb/perm/ReadMembers> a <configdb/perm/All>; :primary <config/perm/All>;
+    :uuid "d4fd61da-50ef-11f0-ad24-335234e4c8a2";
+    :name "ReadMembers".
+<configdb/perm/WriteMembers> a <configdb/perm/All>; :primary <config/perm/All>;
+    :uuid "c2759f6e-50ef-11f0-8730-ef0ba0514a0e";
+    :name "WriteMembers".
+<configdb/perm/WriteMemberships> a <configdb/perm/All>; :primary <config/perm/All>;
+    :uuid "e08d89bc-50ef-11f0-8352-83e3d3d35028";
+    :name "WriteMemberships".
+<configdb/perm/ReadSubclasses> a <configdb/perm/All>; :primary <config/perm/All>;
+    :uuid "e6bb9978-50ef-11f0-b3c2-b79b9f64d2ff";
+    :name "ReadSubclasses".
+<configdb/perm/WriteSubclasses> a <configdb/perm/All>; :primary <config/perm/All>;
+    :uuid "ed11bd2a-50ef-11f0-9f85-df13a1dff9e6";
+    :name "WriteSubclasses".
+<configdb/perm/WriteSuperclasses> a <configdb/perm/All>; :primary <config/perm/All>;
+    :uuid "fb8e5048-50ef-11f0-91c5-7fd3cb373fbb";
+    :name "WriteSuperclasses".
+<configdb/perm/ReadMemberships> a <configdb/perm/All>; :primary <config/perm/All>;
+    :uuid "db9f5dae-50ef-11f0-b846-8393c17d1574";
+    :name "ReadMemberships".
+<configdb/perm/ReadSuperclasses> a <configdb/perm/All>; :primary <config/perm/All>;
+    :uuid "f590e476-50ef-11f0-a120-e7c6d06d79ed";
+    :name "ReadSuperclasses".
+<configdb/perm/DeleteObject> a <configdb/perm/All>; :primary <config/perm/All>;
+    :uuid "6957174b-7b08-45ca-ac5c-c03ab6928a6e";
+    :name "DeleteObject".
+<configdb/perm/GiveTo> a <configdb/perm/All>; :primary <config/perm/All>;
+    :uuid "4eaab346-4d1e-11f0-800e-dfdc061c6a63";
+    :name "GiveTo".
+<configdb/perm/TakeFrom> a <configdb/perm/All>; :primary <config/perm/All>;
+    :uuid "6ad67652-5009-11f0-9404-73b79124c3d5";
+    :name "TakeFrom".
+
+<configdb/Account> a <authn/CentralService>, <sparkplug/Entity>, <service/Provider>;
     :primary <authn/CentralService>;
     :uuid "36861e8d-9152-40c4-8f08-f51c2d7e3c25";
     :name "ConfigDB";
     <service/provides> <service/ConfigDB>;
     <sparkplug/groupId> "AMRC-Service-Core";
     <sparkplug/nodeId> "ConfigDB".
+
+<metadb/perm/All> a <authz/ServicePerms>; :primary <authz/ServicePerms>;
+    rdfs:subClassOf <authz/Permission>;
+    :uuid "395756ce-3739-11f1-a752-338301d8dd19";
+    :name "MetaDB permissions".
+<metadb/perm/ReadRDF> a <metadb/perm/All>; :primary <metadb/perm/All>;
+    :uuid "d2b89414-3738-11f1-86d5-573f5f0cb628";
+    :name "Read RDF".
+<metadb/perm/WriteRDF> a <metadb/perm/All>; :primary <metadb/perm/All>;
+    :uuid "d92c30f8-3738-11f1-8daa-33e4253b6bac";
+    :name "Write RDF".
+
+<metadb/ServiceRole> a <authn/ServiceRole>; :primary <authn/ServiceRole>;
+    rdfs:subClassOf <authn/CentralService>;
+    :uuid "bf59ab10-3738-11f1-894f-cb07fd5bf02f";
+    :name "MetaDB".

--- a/acs-metadb/ttl/core.ttl
+++ b/acs-metadb/ttl/core.ttl
@@ -175,6 +175,10 @@
     :uuid "8e32801b-f35a-4cbf-a5c3-2af64d3debd7";
     :name "Sparkplug address";
     <app/appliesTo> <sparkplug/Entity>.
+<app/ServiceConfig> a <app/Application>; :primary <app/Application>;
+    rdfs:subClassOf <app/ConfigEntry>;
+    :uuid "5b47881c-b012-4040-945c-eacafca539b2";
+    :name "Service config".
 
 <uuid/beb7d97c-2c0a-11f1-97ae-9bf4285ba7b1> 
     a <app/ConfigSchema>; :primary <app/ConfigSchema>;
@@ -245,6 +249,12 @@
 <service/Auth> a <service/Service>; :primary <service/Service>;
     :uuid "cab2642a-f7d9-42e5-8845-8f35affe1fd4";
     :name "Auth service".
+<service/Clusters> a <service/Service>; :primary <service/Service>;
+    :uuid "2706aa43-a826-441e-9cec-cd3d4ce623c2";
+    :name "Cluster manager service".
+<service/Manager> a <service/Service>; :primary <service/Service>;
+    :uuid "619eecab-742d-4824-8b97-bcae472e5c04";
+    :name "Admin UI service".
 # These are for representing Directory information.
 <service/Provider> a :R1Class; :primary :R1Class;
     rdfs:subClassOf :Individual;
@@ -308,6 +318,24 @@
     rdfs:subClassOf <authz/PermissionGroup>;
     :uuid "c43c7157-a50b-4d2a-ac1a-86ff8e8e88c1";
     :name "Service permission set".
+
+<git/Repo> a :R1Class, <git/RepoGroup>; :primary :R1Class;
+    rdfs:subClassOf :Individual;
+    :uuid "d25f2afc-1ab8-4d27-b51b-d02314624e3e";
+    :name "Git repository".
+<git/RepoGroup> a :R2Class; :primary :R2Class;
+    rdfs:subClassOf :R1Class; :powersetOf <git/Repo>;
+    :uuid "b03d4dfe-7e78-4252-8e62-af594cf316c9";
+    :name "Git repository group".
+
+<edge/HelmChart> a :R1Class; :primary :R1Class;
+    rdfs:subClassOf :Individual;
+    :uuid "f9be0334-0ff7-43d3-9d8a-188d3e4d472b";
+    :name "Helm chart".
+<edge/SystemHelmChart> a :R1Class; :primary :R1Class;
+    rdfs:subClassOf <edge/HelmChart>;
+    :uuid "a5c54a2e-8f7b-4b2a-9e8d-3f7c9e7d1c6a";
+    :name "System Helm chart".
 
 <auth/perm/All> a <authz/ServicePerms>; :primary <authz/ServicePerms>;
     rdfs:subClassOf <authz/Permission>;

--- a/acs-service-setup/dumps/auth.yaml
+++ b/acs-service-setup/dumps/auth.yaml
@@ -1,14 +1,16 @@
 service: !u UUIDs.Service.ConfigDB
 version: 2
 objects:
+  # Some of these are commented out because, although they logically
+  # belong here, they are actually defined in service-setup.yaml because
+  # they are needed for local UUID generation.
   !u ConfigDB.Class.R2Class:
-    # Some of these are in service-setup
     #!u Auth.Class.PrincipalGroup:
     #  name: "Principal group"
-    !u Auth.Class.PrincipalType:
-      name: "Principal type"
-      subclassOf:
-        - !u Auth.Class.PrincipalGroup
+    #!u Auth.Class.PrincipalType:
+    #  name: "Principal type"
+    #  subclassOf:
+    #    - !u Auth.Class.PrincipalGroup
     #!u Auth.Class.Role:
     #  name: "Role"
     #  subclassOf:
@@ -38,10 +40,10 @@ objects:
         - !u Auth.Class.PermissionGroup
 
   !u UUIDs.Class.Class:
-    !u Auth.Class.Principal:
-      name: "Principal"
-      memberOf:
-        - !u Auth.Class.PrincipalGroup
+    #!u Auth.Class.Principal:
+    #  name: "Principal"
+    #  memberOf:
+    #    - !u Auth.Class.PrincipalGroup
     !u UUIDs.Class.Permission:
       name: "Permission"
       memberOf:
@@ -52,10 +54,10 @@ objects:
       name: "Human user"
       subclassOf:
         - !u Auth.Class.Principal
-    !u Auth.Class.CentralService:
-      name: "Central service"
-      subclassOf:
-        - !u Auth.Class.Principal
+    #!u Auth.Class.CentralService:
+    #  name: "Central service"
+    #  subclassOf:
+    #    - !u Auth.Class.Principal
     !u Auth.Class.EdgeService:
       name: "Edge service"
       subclassOf:

--- a/acs-service-setup/dumps/service-accounts.yaml
+++ b/acs-service-setup/dumps/service-accounts.yaml
@@ -1,7 +1,10 @@
+#-REQUIRE: auth sparkplug
+#
 # Create static service accounts.
 # XXX These should be created dynamically by krbkeys. But there are
-# some bootstrap issues, especially with KrbKeys itself.
-#-REQUIRE: auth sparkplug
+# some bootstrap issues, especially with KrbKeys itself. The MetaDB
+# account is now created as a Local UUID, this may be a better long-term
+# solution for central services.
 ---
 service: !u UUIDs.Service.ConfigDB
 version: 2
@@ -19,6 +22,12 @@ objects:
       memberOf:
         - !u Auth.Class.CentralService
         - !u ACS.Group.SparkplugNode
+    # Note this is a Local UUID
+    !u Local.Account.MetaDB:
+      name: "MetaDB server"
+      memberOf:
+        - !u Auth.Class.CentralService
+        - !u MetaDB.Role.MetaDB
     !u ACS.ServiceAccount.Directory:
       name: "Directory"
       memberOf:
@@ -54,6 +63,8 @@ identities:
     kerberos: sv1auth
   !u ACS.ServiceAccount.ConfigDB:
     kerberos: sv1configdb
+  !u Local.Account.MetaDB:
+    kerberos: sv1metadb
   !u ACS.ServiceAccount.Manager:
     kerberos: sv1manager
   !u ACS.ServiceAccount.CmdEsc:
@@ -65,6 +76,11 @@ identities:
   !u ACS.ServiceAccount.KrbKeys:
     kerberos: op1krbkeys
 grants:
+  # XXX All these explicit grants should be replaced with service roles.
+
+  # The sv1auth account has permissions granted on the ConfigDB/MetaDB
+  # via the bootstrap ACLs.
+
   !u ACS.ServiceAccount.Directory:
     !u MQTT.Perm.ReadWholeNamespace: null
     !u UUIDs.Permission.Auth.ReadACL:
@@ -85,6 +101,8 @@ grants:
     !u Auth.Perm.ReadACL:
       !u ACS.PermGroup.ConfigDB: true
     !u Auth.Perm.ReadKerberos: null
+
+  # MetaDB permissions are granted via a service role in metadb.yaml.
 
   !u ACS.ServiceAccount.KrbKeys:
     !u Auth.Perm.ReadKerberos: null
@@ -108,7 +126,6 @@ grants:
     # XXX Do we still need this? KrbKeys sealed to edge clusters have been
     # replaced with krbkeys generated on the edge.
     !u Clusters.Perm.Secrets: null
-
 
   # This is the account for the old V2 Manager. It is redundant now so
   # revoke all its permissions.

--- a/acs-service-setup/dumps/service-setup.yaml
+++ b/acs-service-setup/dumps/service-setup.yaml
@@ -8,6 +8,10 @@ objects:
   !u ConfigDB.Class.R2Class:
     !u Auth.Class.PrincipalGroup:
       name: "Principal group"
+    !u Auth.Class.PrincipalType:
+      name: "Principal type"
+      subclassOf:
+        - !u Auth.Class.PrincipalGroup
     !u Auth.Class.Role:
       name: "Role"
       subclassOf:
@@ -20,6 +24,10 @@ objects:
         name: "Git repository group"
 
   !u ConfigDB.Class.R1Class:
+    !u Auth.Class.Principal:
+      name: "Principal"
+      memberOf:
+        - !u Auth.Class.PrincipalGroup
     !u Clusters.Class.HelmChart:
       name: "Helm chart"
     !u Clusters.Class.SystemHelmChart:
@@ -30,6 +38,12 @@ objects:
       name: "Git repository"
       memberOf:
         - !u Git.Class.Group
+
+  !u Auth.Class.PrincipalType:
+    !u Auth.Class.CentralService:
+      name: "Central service"
+      subclassOf:
+        - !u Auth.Class.Principal
 
   !u UUIDs.Class.App:
     !u UUIDs.App.ServiceConfig:

--- a/acs-service-setup/lib/local-uuids.js
+++ b/acs-service-setup/lib/local-uuids.js
@@ -133,6 +133,9 @@ class LocalUUIDs {
                 "MetaDB"],
         );
 
+        /* XXX We should use a service function UUID for service-setup
+         * here. Then ServiceConfig has a meaningful domain of service
+         * functions. */
         await this.put_conf(ServiceConfig, this.local);
         await this.put_service_configs();
 

--- a/acs-service-setup/lib/local-uuids.js
+++ b/acs-service-setup/lib/local-uuids.js
@@ -129,6 +129,8 @@ class LocalUUIDs {
             ["Role", Auth.Class.EdgeRole,
                 "EdgeAgent", "EdgeFlux", "EdgeKrbkeys", "EdgeMonitor", "EdgeSync",
                 "UNSBridge", "OPCUAServer"],
+            ["Account", Auth.Class.CentralService,
+                "MetaDB"],
         );
 
         await this.put_conf(ServiceConfig, this.local);

--- a/deploy/templates/auth/auth.yaml
+++ b/deploy/templates/auth/auth.yaml
@@ -121,12 +121,6 @@ spec:
             - name: VERBOSE
               value: {{.Values.auth.verbosity | quote | required "values.auth.verbosity is required!"}}
 {{ include "amrc-connectivity-stack.cache-max-age" (list . "auth") | indent 12 }}
-            # These are currently only used for the editor. They need to be resolvable by the
-            # user's browser, so in-cluster names will not work.
-            - name: HTTP_API_URL
-              value: "{{ .Values.acs.secure | ternary "https://" "http://" }}auth.{{.Values.acs.baseUrl | required "values.acs.baseUrl is required"}}"
-            - name: CONFIGDB_URL
-              value: "{{ .Values.acs.secure | ternary "https://" "http://" }}configdb.{{.Values.acs.baseUrl | required "values.acs.baseUrl is required"}}"
             # This principal, if configured, bypasses all ACLs. This is important for
             # bootstrapping but perhaps shouldn't be left in place once we can bootstrap without
             # manual intervention.

--- a/deploy/templates/auth/auth.yaml
+++ b/deploy/templates/auth/auth.yaml
@@ -121,6 +121,8 @@ spec:
             - name: VERBOSE
               value: {{.Values.auth.verbosity | quote | required "values.auth.verbosity is required!"}}
 {{ include "amrc-connectivity-stack.cache-max-age" (list . "auth") | indent 12 }}
+            - name: DIRECTORY_URL
+              value: http://directory.{{ .Release.Namespace }}.svc.cluster.local
             # This principal, if configured, bypasses all ACLs. This is important for
             # bootstrapping but perhaps shouldn't be left in place once we can bootstrap without
             # manual intervention.

--- a/deploy/templates/auth/principals/service-clients.yaml
+++ b/deploy/templates/auth/principals/service-clients.yaml
@@ -67,11 +67,6 @@ spec:
   type: Random
   principal: sv1metadb@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
   secret: metadb-keytabs/client
-  account:
-    class: e463b4ae-a322-46cc-8976-4ba76838e908
-    name: MetaDB server
-    groups:
-      - bf59ab10-3738-11f1-894f-cb07fd5bf02f
 {{- end }}
 ---
 {{- if .Values.mqtt.enabled }}

--- a/deploy/templates/metadb/metadb.yaml
+++ b/deploy/templates/metadb/metadb.yaml
@@ -74,6 +74,14 @@ spec:
               value: HTTP/metadb.{{ .Release.Namespace }}.svc.cluster.local
             - name: DIRECTORY_URL
               value: http://directory.{{ .Release.Namespace }}.svc.cluster.local
+            - name: BOOTSTRAP_ACL
+              value: |
+                sv1auth:Perm.ReadApp:App.Registration
+                sv1auth:Perm.ReadApp:App.SparkplugAddress
+                sv1auth:Perm.ReadMembers:SpecialObj.Wildcard
+                sv1auth:Perm.ReadSubclasses:SpecialObj.Wildcard
+            - name: ROOT_PRINCIPAL
+              value: admin@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
           volumeMounts:
             - mountPath: /etc/krb5.conf
               name: krb5-conf

--- a/deploy/templates/metadb/metadb.yaml
+++ b/deploy/templates/metadb/metadb.yaml
@@ -69,19 +69,17 @@ spec:
               value: sv1metadb@{{ .Values.identity.realm }}
             - name: SERVER_KEYTAB
               value: /keytabs/server
-            # This needs to name a principal available in the keytab, used for verifying passwords.
+            # This needs to name a principal available in the keytab, 
+            # used for verifying passwords.
             - name: SERVER_PRINCIPAL
               value: HTTP/metadb.{{ .Release.Namespace }}.svc.cluster.local
             - name: DIRECTORY_URL
               value: http://directory.{{ .Release.Namespace }}.svc.cluster.local
-            - name: BOOTSTRAP_ACL
-              value: |
-                sv1auth:Perm.ReadApp:App.Registration
-                sv1auth:Perm.ReadApp:App.SparkplugAddress
-                sv1auth:Perm.ReadMembers:SpecialObj.Wildcard
-                sv1auth:Perm.ReadSubclasses:SpecialObj.Wildcard
             - name: ROOT_PRINCIPAL
               value: admin@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
+            # This principal has hardcoded permissions.
+            - name: AUTH_PRINCIPAL
+              value: sv1auth@{{ .Values.identity.realm }}
           volumeMounts:
             - mountPath: /etc/krb5.conf
               name: krb5-conf

--- a/deploy/templates/metadb/metadb.yaml
+++ b/deploy/templates/metadb/metadb.yaml
@@ -74,8 +74,6 @@ spec:
               value: HTTP/metadb.{{ .Release.Namespace }}.svc.cluster.local
             - name: DIRECTORY_URL
               value: http://directory.{{ .Release.Namespace }}.svc.cluster.local
-            - name: VERBOSE
-              value: {{.Values.metadb.verbosity | quote | required "values.metadb.verbosity is required!"}}
           volumeMounts:
             - mountPath: /etc/krb5.conf
               name: krb5-conf

--- a/lib/java-service-client/src/main/java/uk/co/amrc/factoryplus/client/FPAuth.java
+++ b/lib/java-service-client/src/main/java/uk/co/amrc/factoryplus/client/FPAuth.java
@@ -72,6 +72,13 @@ public class FPAuth {
             .build();
     }
 
+    public boolean isRoot (String upn)
+    {
+        return root_principal
+            .filter(upn::equals)
+            .isPresent();
+    }
+
     /* XXX We have no BOOTSTRAP_ACL handling. This will be needed for a
      * ConfigDB implementation. */
 
@@ -151,7 +158,7 @@ public class FPAuth {
      */
     public Observable<Response<Boolean>> watchPermitted (String upn, UUID perm, UUID targ)
     {
-        if (root_principal.filter(upn::equals).isPresent())
+        if (isRoot(upn))
             return Observable.just(Response.ok(true))
                 .concatWith(Observable.never());
 

--- a/lib/java-service-client/src/main/java/uk/co/amrc/factoryplus/client/FPAuth.java
+++ b/lib/java-service-client/src/main/java/uk/co/amrc/factoryplus/client/FPAuth.java
@@ -52,6 +52,32 @@ public class FPAuth {
         }
     }
 
+    /** Allows checking for a particular permission */
+    public interface Checker
+    {
+        /** Check if a permission is granted.
+         * This will always allow a wildcard target.
+         */
+        boolean check (UUID perm, UUID targ);
+
+        record ACL (List<Grant> acl) implements Checker
+        {
+            public boolean check (UUID perm, UUID targ)
+            {
+                return acl.exists(
+                    g -> g.permission.equals(perm) &&
+                        (g.target.equals(targ) || g.target.equals(FPUuid.Null)));
+            }
+        }
+
+        /** A Checker which always succeeds. */
+        static final Checker PASS = (p, t) -> true;
+        /** A Checker which always fails. */
+        static final Checker FAIL = (p, t) -> false;
+        /** A Checker based on a list of Grants. */
+        static Checker ofACL (List<Grant> acl) { return new ACL(acl); }
+    }
+
     private FPServiceClient fplus;
     private FPNotifyV2 notify;
 
@@ -166,6 +192,35 @@ public class FPAuth {
                     .map(Grant::fromJSON)));
     }
 
+    /** Map the ACL for a principal to a Checker.
+     * Where the Auth service will not respond a failure Response will
+     * be emitted.
+     */
+    public Observable<Response<Checker>> watchChecker (String upn)
+    {
+        if (isRoot(upn))
+            return fixedResponse(Checker.PASS);
+
+        return watchACL(upn)
+            .map(res -> res.map(Checker::ofACL));
+    }
+
+    /** Fetch a Checker for a principal.
+     * The Single will emit an error if the Auth service can't be
+     * contacted. A timeout of 10s is applied if the Auth service does
+     * not respond.
+     */
+    public Single<Checker> fetchChecker (String upn)
+    {
+        return watchChecker(upn)
+            .firstElement()
+            .flatMap(r -> r.toMaybe(st ->
+                new FPServiceException(SERVICE, st, "Fetching ACL")))
+            .switchIfEmpty(Single.just(Checker.FAIL))
+            .timeout(10, TimeUnit.SECONDS, Single.error(
+                () -> new FPServiceException(SERVICE, 502, "Timeout fetching ACL")));
+    }
+
     /** Watch a specific permission check.
      * This handles wildcard matches.
      * @param upn The Kerberos UPN.
@@ -174,28 +229,7 @@ public class FPAuth {
      */
     public Observable<Response<Boolean>> watchPermitted (String upn, UUID perm, UUID targ)
     {
-        if (isRoot(upn))
-            return fixedResponse(true);
-
-        return watchACL(upn)
-            .map(res -> res
-                .map(gs -> gs.exists(
-                    g -> g.permission.equals(perm) &&
-                        (g.target.equals(targ) || g.target.equals(FPUuid.Null)))));
-    }
-
-    /** Check a specific permission.
-     * The Single will emit an error if the Auth service can't be
-     * contacted.
-     */
-    public Single<Boolean> fetchPermitted (String upn, UUID perm, UUID targ)
-    {
-        return watchPermitted(upn, perm, targ)
-            .firstElement()
-            .flatMap(r -> r.toMaybe(st ->
-                new FPServiceException(SERVICE, st, "Fetching ACL")))
-            .switchIfEmpty(Single.just(false))
-            .timeout(10, TimeUnit.SECONDS, Single.error(
-                () -> new FPServiceException(SERVICE, 502, "Timeout fetching ACL")));
+        return watchChecker(upn)
+            .map(r -> r.map(c -> c.check(perm, targ)));
     }
 }

--- a/lib/java-service-client/src/main/java/uk/co/amrc/factoryplus/client/FPAuth.java
+++ b/lib/java-service-client/src/main/java/uk/co/amrc/factoryplus/client/FPAuth.java
@@ -179,6 +179,8 @@ public class FPAuth {
             .firstElement()
             .flatMap(r -> r.toMaybe(st ->
                 new FPServiceException(SERVICE, st, "Fetching ACL")))
-            .switchIfEmpty(Single.just(false));
+            .switchIfEmpty(Single.just(false))
+            .timeout(10, TimeUnit.SECONDS, Single.error(
+                () -> new FPServiceException(SERVICE, 502, "Timeout fetching ACL")));
     }
 }

--- a/lib/java-service-client/src/main/java/uk/co/amrc/factoryplus/client/FPAuth.java
+++ b/lib/java-service-client/src/main/java/uk/co/amrc/factoryplus/client/FPAuth.java
@@ -7,7 +7,6 @@
 package uk.co.amrc.factoryplus.client;
 
 import java.net.*;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -21,8 +20,8 @@ import org.json.*;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import io.reactivex.rxjava3.core.*;
 
-import io.vavr.collection.List;
-import io.vavr.collection.Set;
+import io.vavr.collection.*;
+import io.vavr.control.Option;
 
 import uk.co.amrc.factoryplus.http.*;
 import uk.co.amrc.factoryplus.util.*;
@@ -56,14 +55,16 @@ public class FPAuth {
     private FPServiceClient fplus;
     private FPNotifyV2 notify;
 
-    private Optional<String> root_principal;
+    private Option<String> root_principal;
+    private Map<String, List<Grant>> bootstrap_acls;
     private CacheSeq<String, Response<List<Grant>>> acl_cache;
 
     public FPAuth (FPServiceClient fplus)
     {
         this.fplus = fplus;
 
-        this.root_principal = fplus.getOptionalConf("root_principal");
+        this.root_principal = fplus.getOptionConf("root_principal");
+        this.bootstrap_acls = HashMap.empty();
 
         this.notify = new FPNotifyV2(fplus, SERVICE);
         this.acl_cache = CacheSeq.builder(this::_watchACL)
@@ -72,15 +73,21 @@ public class FPAuth {
             .build();
     }
 
+    /** Set the bootstrap ACLs.
+     * This must be called before the FPServiceClient.start to avoid
+     * problems with multithreaded access.
+     */
+    public void setBootstrapACLs (Map<String, List<Grant>> bsACLs)
+    {
+        this.bootstrap_acls = bsACLs;
+    }
+
     public boolean isRoot (String upn)
     {
         return root_principal
             .filter(upn::equals)
-            .isPresent();
+            .isDefined();
     }
-
-    /* XXX We have no BOOTSTRAP_ACL handling. This will be needed for a
-     * ConfigDB implementation. */
 
     /**
      * Fetches an ACL over HTTP.
@@ -91,7 +98,8 @@ public class FPAuth {
      *
      * This uses the HTTP API and makes a fresh request every time.
      * Where the HTTP backend supports a client-side cache a response
-     * may come from the cache.
+     * may come from the cache. This method does not honour bootstrap
+     * ACLs or the root principal setting.
      *
      * Note the return value uses Java rather than Vavr types, for
      * compatibility. This is used by the HiveMQ plugin; once that has
@@ -121,6 +129,12 @@ public class FPAuth {
                 .map(o -> (java.util.Map)o));
     }
 
+    private <T> Observable<Response<T>> fixedResponse (T value)
+    {
+        return Observable.just(Response.ok(value))
+            .concatWith(Observable.never());
+    }
+
     /** Watch a principal's ACL over notify.
      *
      * The ACLs are wrapped in Responses to allow for error handling.
@@ -130,7 +144,9 @@ public class FPAuth {
      */
     public Observable<Response<List<Grant>>> watchACL (String upn)
     {
-        /* XXX Bootstrap handling should go here. */
+        var bs = bootstrap_acls.get(upn);
+        if (bs.isDefined())
+            return fixedResponse(bs.get());
 
         return this.acl_cache.get(
             UrlPath.join("v2", "acl", "kerberos", upn));
@@ -159,8 +175,7 @@ public class FPAuth {
     public Observable<Response<Boolean>> watchPermitted (String upn, UUID perm, UUID targ)
     {
         if (isRoot(upn))
-            return Observable.just(Response.ok(true))
-                .concatWith(Observable.never());
+            return fixedResponse(true);
 
         return watchACL(upn)
             .map(res -> res

--- a/lib/java-service-client/src/main/java/uk/co/amrc/factoryplus/client/FPDirectory.java
+++ b/lib/java-service-client/src/main/java/uk/co/amrc/factoryplus/client/FPDirectory.java
@@ -60,7 +60,7 @@ public class FPDirectory {
                 }))
             .cast(JSONArray.class)
             .flatMapObservable(Observable::fromIterable)
-            //.doOnNext(o -> log.info("Service URL: {}", o))
+            .doOnNext(o -> log.info("Service URL: {}", o))
             .cast(JSONObject.class)
             .map(o -> o.getString("url"))
             .map(URI::new)

--- a/lib/java-service-client/src/main/java/uk/co/amrc/factoryplus/client/FPServiceClient.java
+++ b/lib/java-service-client/src/main/java/uk/co/amrc/factoryplus/client/FPServiceClient.java
@@ -27,6 +27,8 @@ import org.json.*;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import io.reactivex.rxjava3.core.*;
 
+import io.vavr.control.Option;
+
 import uk.co.amrc.factoryplus.gss.*;
 import uk.co.amrc.factoryplus.http.*;
 
@@ -117,6 +119,15 @@ public class FPServiceClient {
             return Optional.<String>empty();
 
         return Optional.of(val);
+    }
+
+    /** Get a config parameter as a Vavr Option.
+     *
+     * @param key The config parameter.
+     */
+    public Option<String> getOptionConf (String key)
+    {
+        return Option.ofOptional(getOptionalConf(key));
     }
 
     /** Get a config parameter which is a URL.

--- a/lib/java-service-client/src/main/java/uk/co/amrc/factoryplus/client/FPServiceException.java
+++ b/lib/java-service-client/src/main/java/uk/co/amrc/factoryplus/client/FPServiceException.java
@@ -7,7 +7,7 @@ package uk.co.amrc.factoryplus.client;
 
 import java.util.UUID;
 
-public class FPServiceException extends Exception
+public class FPServiceException extends RuntimeException
 {
     private UUID service;
     private int status;

--- a/lib/java-service-client/src/main/java/uk/co/amrc/factoryplus/http/FPHttpClient.java
+++ b/lib/java-service-client/src/main/java/uk/co/amrc/factoryplus/http/FPHttpClient.java
@@ -209,29 +209,35 @@ public class FPHttpClient {
             this.execute(new WsRequest(service, path)));
     }
 
+    private static String reqURI (SimpleHttpRequest req)
+    {
+        try { return req.getUri().toString(); }
+        catch (Throwable e) { return "???"; }
+    }
+
     public Single<SimpleHttpResponse> fetch (SimpleHttpRequest req)
     {
-        //FPThreadUtil.logId("fetch called");
+        log.info("[<[ Fetch: {}", reqURI(req));
         return Single.<SimpleHttpResponse>create(obs -> {
             //final var context = HttpCacheContext.create();
             async_client.execute(req, //context,
                 new FutureCallback<SimpleHttpResponse>() {
                     public void completed (SimpleHttpResponse res) {
                         //FPThreadUtil.logId("fetch success");
-                        String uri = "???";
-                        try { uri = req.getUri().toString(); }
-                        catch (Exception e) { }
                         //log.info("Cache {} ({}) for {}",
                         //    context.getCacheResponseStatus(), res.getCode(), uri);
+                        log.info("]>] {} {}", res.getCode(), reqURI(req));
                         obs.onSuccess(res);
                     }
 
                     public void failed (Exception ex) {
                         //FPThreadUtil.logId("fetch failure");
+                        log.info("]>] {} failed: {}", reqURI(req), ex.toString());
                         obs.onError(ex);
                     }
 
                     public void cancelled () {
+                        log.info("]>] {} cancelled", reqURI(req));
                         obs.onError(new Exception("HTTP future cancelled"));
                     }
                 });

--- a/lib/js-service-api/lib/notify-v2.js
+++ b/lib/js-service-api/lib/notify-v2.js
@@ -325,7 +325,6 @@ export class Notify {
 
     run () {
         this.log("Starting WS server on /notify/v2");
-        this.log("Using HTTP server %o", this.api.http);
         this.wss = new WebSocketServer({ 
             server: this.api.http, 
             path:   "/notify/v2",

--- a/lib/js-service-client/lib/service/fetch.js
+++ b/lib/js-service-client/lib/service/fetch.js
@@ -164,6 +164,7 @@ prevent non-root service registrations from working correctly.
         const base = opts.service_url
             ?? await this.fplus.service_url(opts.service);
         const url = new URL(opts.url, base);
+        this.debug.log("fetch", "Opening WebSocket to %s", url);
 
         const ws = new WebSocket(url);
         await new Promise((resolve, reject) => {


### PR DESCRIPTION
This does not yet get to the point where ACS is functional, but it's a start. The most important missing feature is the MetaDB cannot yet load ConfigDB dumps; there is a dummy endpoint that returns 204, so that service-setup doesn't fall over, but it doesn't load the data.

The admin UI is functional and can be used to view the MetaDB entries. The other services are correctly contacting the MetaDB; mostly they are getting 403s as the accounts and roles are not loaded in correctly yet. Bootstrap ACL support is implemented to allow the Auth service to contact the MetaDB; without this we have a dependency loop and both services hang.

Important changes:
- Support GSSAPI auth in the service-api.
- Support bootstrap ACLs in the Java service-client and use them in the MetaDB.
- Additional HTTP and notify endpoints as needed to make things work.
- CORS support, needed for the admin UI and any other web UI.
- Verbose logging option in the admin UI.
- Create the MetaDB service account using the Local UUID mechanism rather than via krbkeys.
- Move ACL lookups out of the Jena transactions to avoid txns staying open too long.

Closes: #567 