### PR TITLE
Document core JS/TS code style conventions in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,99 @@ npm run test   # Run Jest tests
 - Edge agents publish Sparkplug B messages to the MQTT broker
 - The `@amrc-factoryplus/service-client` library provides `ServiceClient` class for accessing Factory+ services
 
+## Code Style (JS / TS)
+
+The canonical style for new code is the style used in the core services
+written by Ben Morrow: `acs-configdb`, `acs-directory`, `acs-files`, `acs-auth`,
+`acs-cmdesc`, and the `lib/js-*` libraries. When writing or modifying code,
+match those services - do not invent your own style. Read an existing file
+before adding new ones so the style stays consistent.
+
+### Language and modules
+- ES modules. JavaScript or TypeScript are both fine - match the existing
+  service. Most core services (`acs-configdb`, `acs-auth`, `acs-directory`,
+  `acs-files`, `acs-cmdesc`) are plain JS; `acs-edge` is TS.
+- `"type": "module"` in package.json. All imports use explicit `.js`
+  extensions, including for relative imports (`./foo.js`, not `./foo`) -
+  this also applies to TS source, where the import specifier is still `.js`.
+- Local libs are pulled in via `file:../lib/js-*` paths.
+- If using TS, keep the same shape as the JS services (bin/lib layout,
+  same naming conventions, same bootstrap pattern). TS is a tool, not an
+  excuse to restructure.
+
+### Formatting
+- 4-space indentation. No tabs.
+- Double-quoted strings.
+- Semicolons **are** used (ASI is not relied on). Look at
+  `acs-configdb/lib/api-v1.js` and `lib/notify.js` - statements end with `;`.
+- Imports are often visually aligned with extra spaces between the import
+  clause and the `from` (e.g. `import * as rx         from "rxjs";`). Match
+  the surrounding file - don't reformat existing alignment.
+- Space before parens in function/method declarations is common
+  (`constructor (opts) {`, `function entry_response (entry) {`). Match the
+  file you are editing.
+- Single-line `if`/`for` bodies without braces are accepted when the body is a
+  single statement; don't add braces just to add them.
+
+### Naming
+- `PascalCase` for classes and exported constant maps (`Class`, `Perm`,
+  `App`, `BootstrapUUIDs`).
+- `snake_case` for methods, functions, locals, and properties
+  (`setup_routes`, `fetch_acl`, `is_root`, `resolve_upn`, `mk_res`,
+  `entry_response`). Do **not** use `camelCase` for methods - this is the
+  most common deviation to avoid.
+- `SCREAMING_SNAKE_CASE` for module-level scalar constants
+  (`GIT_VERSION`, `Null_UUID`).
+- File names are `kebab-case.js` (`api-v1.js`, `git-version.js`,
+  `rx-util.js`).
+
+### Service shape
+- Layout: `bin/api.js` is the entrypoint, implementation lives in `lib/`.
+  No `src/`, no compiled `dist/`.
+- Bootstrap pattern (see `acs-configdb/bin/api.js`):
+  - top-level `await new RxClient({ env, bootstrap_uuids }).init()`
+  - construct collaborators with `new Class({ fplus, ... })`, awaiting
+    `.init()` on those that need it
+  - hand `routes()` to `new WebAPI({...}).init()` from
+    `@amrc-factoryplus/service-api`
+  - call `.run()` on the long-running components at the bottom of the file
+- Constructors take a single `opts` object and pull fields off it:
+  `this.fplus = opts.fplus`. Don't use positional args.
+- Loggers come from `opts.fplus.debug.bound("module-name")` (or
+  `opts.debug.bound(...)` when fplus isn't passed). Store as `this.log` and
+  call as `this.log("message %s %o", a, b)` with printf-style format
+  strings.
+- Auth: use `fplus.Auth` and `fetch_acl` / `check_acl` patterns from
+  `acs-configdb/lib/auth.js`. Do not roll your own.
+- Errors inside route handlers: throw `APIError` from
+  `@amrc-factoryplus/service-api`; let WebAPI handle the response. Do not
+  hand-roll async-handler wrappers.
+- UUIDs and other protocol constants live in `lib/constants.js` as
+  PascalCase grouped objects, exported individually.
+
+### Reactive code
+- `rxjs` is the standard tool for streams and change-notify. Import as
+  `import * as rx from "rxjs"` and use `rx.pipe`, `rx.map`, etc. See
+  `acs-configdb/lib/notify.js` for the canonical shape.
+- `@amrc-factoryplus/rx-util` provides shared operators - prefer these over
+  reinventing them.
+
+### Headers
+- Each source file starts with a short comment block:
+  ```
+  /*
+   * ACS ConfigDB
+   * <one-line file purpose>
+   * Copyright <year> University of Sheffield
+   */
+  ```
+  Older files say `Copyright <year> AMRC.` - match the surrounding service.
+
+### When in doubt
+Read `acs-configdb/lib/api-v1.js`, `acs-configdb/lib/auth.js`,
+`acs-configdb/lib/notify.js`, and `acs-configdb/bin/api.js` before writing a
+new service. Copy the shape; do not improvise.
+
 ## Contributing
 
 - Branch naming: `initials/branch-description` or `feature/xxx` for long-running branches


### PR DESCRIPTION
## Summary
- Adds a "Code Style (JS / TS)" section to CLAUDE.md anchored on the core services written by Ben (`acs-configdb`, `acs-directory`, `acs-files`, `acs-auth`, `acs-cmdesc`, `lib/js-*`).
- Covers language choice (JS or TS), formatting, naming (notably `snake_case` methods, `PascalCase` classes/constant maps, `kebab-case.js` filenames), service layout (`bin/` + `lib/`), the standard `RxClient` -> collaborators -> `WebAPI` -> `.run()` bootstrap, logging via `fplus.debug.bound`, error handling via `APIError`, and rxjs usage.
- Motivation: the recently-built `acs-i3x` service drifted from house style (TS-only, `camelCase` methods, `src/dist`, hand-rolled async handler). This gives future agent-written code a clear reference so it copies the established shape instead of improvising.

## Test plan
- [ ] No code changes; docs only.
- [ ] Skim the rendered CLAUDE.md in GitHub to confirm formatting.