### PR TITLE
acs-krb-keys-operator: make LocalSecret format=Password idempotent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ spirit-schemas/
 
 node_modules/
 .worktrees/
+/.claude/worktrees/
+/.claude/scheduled_tasks.lock

--- a/acs-krb-keys-operator/lib/amrc/factoryplus/krbkeys/event.py
+++ b/acs-krb-keys-operator/lib/amrc/factoryplus/krbkeys/event.py
@@ -194,8 +194,8 @@ class LocalSecret (KrbKeyEvent):
         # consumer that has hashed it server-side (e.g. Keycloak's
         # admin user). `update()` is now idempotent so the no-op path
         # is just two reads.
-        old_dest = self.old.map(lambda s: s.secret).or_else(None)
-        new_dest = self.new.map(lambda s: s.secret).or_else(None)
+        old_dest = self.old.map(lambda s: s.secret).get_or_default(None)
+        new_dest = self.new.map(lambda s: s.secret).get_or_default(None)
         if old_dest is not None and old_dest != new_dest:
             self.old.if_present(lambda s: s.remove())
 

--- a/acs-krb-keys-operator/lib/amrc/factoryplus/krbkeys/event.py
+++ b/acs-krb-keys-operator/lib/amrc/factoryplus/krbkeys/event.py
@@ -186,6 +186,18 @@ class LocalSecret (KrbKeyEvent):
     def process (self):
         log(f"Process LocalSecret {self.old} -> {self.new}")
 
-        self.old.if_present(lambda s: s.remove())
+        # Only remove the old target when it's actually going away or
+        # moving. On a Resume event (operator pod restart) kopf passes
+        # the same spec as both old and new, so an unconditional remove
+        # here would clear the live key and let `update()` write a
+        # fresh password on every restart - rotating the value for any
+        # consumer that has hashed it server-side (e.g. Keycloak's
+        # admin user). `update()` is now idempotent so the no-op path
+        # is just two reads.
+        old_dest = self.old.map(lambda s: s.secret).or_else(None)
+        new_dest = self.new.map(lambda s: s.secret).or_else(None)
+        if old_dest is not None and old_dest != new_dest:
+            self.old.if_present(lambda s: s.remove())
+
         self.new.if_present(lambda s: s.update())
 

--- a/acs-krb-keys-operator/lib/amrc/factoryplus/krbkeys/spec.py
+++ b/acs-krb-keys-operator/lib/amrc/factoryplus/krbkeys/spec.py
@@ -129,6 +129,13 @@ class LocalSpec:
                 format=spec.get("format", "Password")))
 
     def update (self):
+        # Idempotent: only generate when the target key has no value
+        # yet. The kopf Resume handler fires on every operator pod
+        # start and previously rotated the password each time. To force
+        # a rotation, delete the key from the underlying Secret and
+        # the next reconcile will regenerate.
+        if self.secret.maybe_read() is not None:
+            return
         passwd = secrets.token_urlsafe().encode()
         self.secret.write(passwd)
 


### PR DESCRIPTION
## Summary

`LocalSecret` resources with `format: Password` are rotated by the operator on every Resume event - i.e. every operator pod restart, including every helm upgrade and every OOM-recovery. `LocalSpec.update()` generates a fresh `secrets.token_urlsafe()` and writes it back to the target Secret unconditionally; `LocalSecret.process()` calls `remove(); update()` on every dispatch including Resume.

## Reproduction on a stable release

Confirmed on a fresh install of the latest stable ACS chart (no OAuth/`dn/oAuth` branch involved), using the `opcua-server` edge chart which generates a LocalSecret for the OPC UA server's UserNameIdentityToken password. The edge cluster has its own `krb-keys` operator deployment in the edge namespace.

```sh
$ kubectl -n fplus-edge get secret opcua-server-opcua-password.opc-ua-server \
    -o jsonpath='{.data.password}' | base64 -d
A3WNYs4amxwQuLbBv2zUpHhV2ZWf0igOtwr4sQjjp-U

$ kubectl -n fplus-edge rollout restart deploy/krb-keys
$ kubectl -n fplus-edge rollout status  deploy/krb-keys --timeout=120s
deployment "krb-keys" successfully rolled out

# Wait for the operator to actually process the LocalSecret Resume.
$ kubectl -n fplus-edge logs -f deploy/krb-keys | \
    grep -m1 "opcua-server-opcua-password.*succeeded"
[2026-05-12 08:40:55,949] kopf.objects [INFO ] [fplus-edge/opcua-server-opcua-password.opc-ua-server.password] Handler 'local_secret' succeeded.

$ kubectl -n fplus-edge get secret opcua-server-opcua-password.opc-ua-server \
    -o jsonpath='{.data.password}' | base64 -d
6aGk0Lob_57AVvUs3OBnWP6hYUTkrXKMrSjfYDlgBNE
```

`ROTATED`. The Secret was deleted and re-created with a fresh `secrets.token_urlsafe()` value, even though no LocalSecret CRD or spec changed. (Note the cosmetic gotcha: the operator pod takes a few seconds to come up *and* kopf takes additional time to process the Resume queue; a naive `sleep 10` after rollout status will sample before kopf has fired the handler. Block on the log line instead.)

## Who's been bitten

LocalSecret-Password has been in the operator since 2024-07-22 (`4814a2f8`). Consumers in this repo:

| Consumer | Reads value… | Rotation safe? |
| --- | --- | --- |
| `edge-helm-charts/.../edge-agent/templates/local-secrets.yaml` (driver / driver-debug passwords) | Driver pods at startup; pods restart in lockstep with operator on helm upgrade | ✅ Yes - new value picked up automatically |
| `edge-helm-charts/.../opcua-server/templates/secret.yaml` (OPC UA server password) | Server reads via env on pod start, but **OPC UA clients are external** (SCADA / automation tools) and are configured with the password manually | ❌ No - external clients silently start getting auth-rejected after a rotation |
| `deploy/templates/openid/local-secrets.yaml` (Keycloak admin + per-client secrets, introduced for OAuth/OIDC sign-in - PR #646) | `KEYCLOAK_ADMIN_PASSWORD` on first install only; bcrypted into Postgres | ❌ No - rotation orphans the stored hash, locks out bootstrap admin, breaks service-setup |

The driver case has hidden the bug for ~10 months. OPC UA users have probably been hitting it silently since March 2026 (chart added in `07b25ab0`); Keycloak users on `dn/oAuth` (#646) hit it immediately.

## Fix

* `LocalSpec.update()` checks `secret.maybe_read()` and skips the write when a value already exists. To force a rotation, delete the key from the underlying Secret - the next reconcile will regenerate.
* `LocalSecret.process()` only removes the old target when the spec is actually moving (different Secret or key). Same-target Resume / no-op Update events become a pure no-op rather than `remove + regenerate`.

This mirrors the idempotency the `Rekey` handler already has via `rekey_needed()` for the `KerberosKey` CRD.

## Compatibility

No behaviour change for the historical driver-password consumers - they still get a fresh password generated on first install; the value is now preserved across restarts instead of rotating. If anyone was relying on rotation (no evidence anyone was), they can opt back in by deleting the key from the target Secret.

OPC UA and Keycloak users get the fix they didn't know they needed.

## Test plan

- [x] Reproduced on stable ACS + `opcua-server` chart: rollout restart of `krb-keys` rotates `opcua-server-opcua-password.<name>/password` even though the LocalSecret CRD is unchanged (transcript above).
- [x] After applying this PR, repeat the same test against a build of `acs-krb-keys-operator` from this branch; assert the password is preserved.
- [x] Apply a new `LocalSecret` of `format: Password`, observe a fresh value is generated on first reconcile.
- [x] Delete the key from the target Secret; verify the next reconcile regenerates a fresh value (opt-in rotation path).
- [ ] On a cluster running PR #646's OAuth/OIDC stack, verify `helm upgrade` no longer breaks the Keycloak bootstrap admin.
