### PR TITLE
configdb: fix 500s on class_info and config_class_list

### DIFF
--- a/acs-configdb/lib/api-v2.js
+++ b/acs-configdb/lib/api-v2.js
@@ -150,11 +150,11 @@ export class APIv2 {
             .every(p => acl(p, klass, true));
         if (!ok) return res.status(403).end();
 
-        const members = await this.model.class_lookup(klass, "membership");
-        const subclasses = await this.model.class_lookup(klass, "subclasses");
+        const members = await this.model.class_lookup(klass, "all_membership");
+        const subclasses = await this.model.class_lookup(klass, "all_subclass");
 
         if (!members && !subclasses)
-            return res.status(404);
+            return res.status(404).end();
 
         return res.status(200).json({ members, subclasses });
     }

--- a/acs-configdb/lib/model.js
+++ b/acs-configdb/lib/model.js
@@ -646,7 +646,7 @@ export default class Model extends EventEmitter {
                     join all_membership m on m.id = c.object
                 where c.app = $1
                     and m.class = $2
-            `, [app_id, klass]);
+            `, [app_id, class_id]);
         });
     }
 


### PR DESCRIPTION
## Summary

Two pre-existing bugs in acs-configdb make `/v2/class/:class` and
`/v2/app/:app/class/:class` return 500 on every call. Observed live on
the fpd-ago dev cluster (image `v5.2.0-i3x.9`) using real UUIDs taken
from the corresponding list endpoints.

### Bug 1: `class_info` queries non-existent tables

`acs-configdb/lib/api-v2.js` `class_info` calls:

```
this.model.class_lookup(klass, "membership")
this.model.class_lookup(klass, "subclasses")
```

`class_lookup` interpolates the second argument straight into a `from`
clause. `subclasses` is not a table - the real view is `all_subclass`.
And `membership` is the *direct* membership table, but the documented
behaviour (and every sibling endpoint) returns effective membership, so
the correct view here is `all_membership`.

Stack trace from configdb on the cluster:

```
Error: relation "subclasses" does not exist
    at /home/node/app/node_modules/pg/lib/native/client.js:183:15
    at async DB.txn (.../pg-client/lib/index.js:96:26)
    at async APIv2.class_info (.../lib/api-v2.js:154:28)
```

Also flushed the missing `.end()` on the 404 branch while in there - it
was returning `res.status(404)` without ending the response.

### Bug 2: `config_class_list` binds a UUID into an integer column

`acs-configdb/lib/model.js` `config_class_list` looks up `class_id` from
the UUID, then binds the *UUID string* into `$2`, where the query
filters `all_membership.class` (an integer FK):

```
where c.app = $1 and m.class = $2
```

Stack trace:

```
Error: invalid input syntax for type integer:
       "00da3c0b-f62b-4761-a689-39ad0c33f864"
    at /home/node/app/node_modules/pg/lib/native/client.js:183:15
    at async DB.txn (.../pg-client/lib/index.js:96:26)
    at async APIv2.config_list (.../lib/api-v2.js:204:15)
```

Fix is to pass `class_id` (already in scope, looked up two lines above).

## Provenance

Both bugs predate the JWT/i3x work on this codebase:

- `class_info` table-name bug introduced in `05309d7d` ("Implement
  granular ConfigDB object permissions") when the handler stopped doing
  a single permission check and started returning members + subclasses.
- `config_class_list` UUID-vs-int bug introduced in `18570d2f` ("Model
  method to query all configs for an app") - the `class_id` variable
  was added but the bind parameter wasn't updated to use it.

Branched off `origin/main` so it can land independently of the JWT
branch.

## How to test

1. Pick any class UUID `C` and app UUID `A` from `/v2/class` and `/v2/app`.
2. `GET /v2/class/$C` - returns `{ members: [...], subclasses: [...] }`
   with status 200.
3. `GET /v2/app/$A/class/$C` - returns the array of object UUIDs that
   have a config for app `A` *and* are effective members of class `C`,
   with status 200.
4. Sanity check against the sibling endpoints:
   - `members` matches `GET /v2/class/$C/member`
   - `subclasses` matches `GET /v2/class/$C/subclass`
   - The result of step 3 is a subset of both `GET /v2/app/$A/object`
     and `GET /v2/class/$C/member`.

## Release notes

- Fix HTTP 500 on `GET /v2/class/:class` (the `class_info` endpoint).
- Fix HTTP 500 on `GET /v2/app/:app/class/:class` (the per-class config
  list endpoint).

## Files of note

- `acs-configdb/lib/api-v2.js` - `class_info` handler
- `acs-configdb/lib/model.js` - `config_class_list`