### PR TITLE
acs-configdb: resolve_upn handles UUID principals (JWT callers)

### DIFF
--- a/acs-configdb/lib/auth.js
+++ b/acs-configdb/lib/auth.js
@@ -29,6 +29,9 @@ export class Auth {
     async resolve_upn (upn, maproot) {
         if (this.is_root(upn))
             return maproot;
-        return this.auth.resolve_identity("kerberos", upn);
+        /* resolve_principal handles both Kerberos UPNs (pre-JWT
+         * callers) and UUID-form principals (JWT callers) via
+         * decode_principal, returning the same UUID-or-null result. */
+        return this.auth.resolve_principal(upn);
     }
 }


### PR DESCRIPTION
## Summary

`resolve_upn` in `acs-configdb/lib/auth.js` hardcoded `"kerberos"` as the identity type when resolving the caller's principal. For JWT-authenticated callers, `req.auth` is a principal **UUID**, not a Kerberos UPN, so the lookup at acs-auth (`/v2/identity/kerberos/<uuid>`) returns 410 and the configdb caller (`object_create` in `api-v2.js`, plus `client_uuid` in `model.js`) then 503s the request.

This is pre-existing - the file was last touched 2025-06-24 (`05309d7d`) and the bug has been there the whole time. It only surfaces now because the `ag/acs-i3x` branch is shipping JWT auth, and any non-Kerberos caller will hit it.

Same family as the directory `acl()` and dataflow `track_targets` fixes already merged (PR #649 on `main`).

## Reproduction

Observed on `fpd-ago`, configdb image `v5.2.0-i3x.9`:

```
POST /v2/object   { "class": "<EdgeCluster-class-uuid>" }
 -> 503

configdb log:
  princ: Failed to resolve kerberos identity 3405600f-d9f9-499c-a875-d49810d57f41: 410
  http:  >>> POST /v2/object
  http:  Handling Bearer auth
  http:  Auth succeeded for [3405600f-d9f9-499c-a875-d49810d57f41]
  http:  <<< 503 undefined
```

## The fix

Replace `this.auth.resolve_identity("kerberos", upn)` with `this.auth.resolve_principal(upn)`. `resolve_principal` uses `decode_principal` to pick the identity type by shape: UUID-form strings become type `uuid` (returned unchanged), everything else falls back to `kerberos` (the pre-JWT default). The return contract is unchanged - UUID or null - so callers in `api-v2.js` and `model.js` are unaffected.

## Scope check

Grepped `acs-configdb/lib/` and `acs-configdb/bin/` for other hardcoded `"kerberos"` identity-type assumptions; this was the only one.

## How to test

1. Authenticate to configdb as a JWT caller (e.g. via the i3X shim) where `req.auth` is a UUID.
2. `POST /v2/object { "class": "<some-class-uuid>" }` with no explicit `owner`.
3. Expect a successful create (200/201) rather than 503. The configdb log should no longer contain `Failed to resolve kerberos identity <uuid>`.
4. As a regression check, the same operation from a Kerberos-authenticated client (where `req.auth` is a UPN) should still work as before.

## Release notes

- Fix `acs-configdb` 503s on object create when authenticated via JWT (caller principal arrived as a UUID, but `resolve_upn` always asked acs-auth for a Kerberos identity).

## Out of scope (noted)

`is_root(upn)` still compares the incoming principal against `this.root` (the Kerberos UPN of the root principal). A JWT caller acting as root would not match this. Deferring - not trivially correct without a UUID-form root identity to compare against, and root-via-JWT isn't the failing case here.
