### PR TITLE
Fix ACS-Files Permissions

### DIFF
--- a/acs-service-setup/dumps/files.yaml
+++ b/acs-service-setup/dumps/files.yaml
@@ -70,4 +70,6 @@ grants:
       !u Files.App.Config: false
     !u ConfigDB.Perm.WriteConfig:
       !u Files.App.Config: false
+    !u ConfigDB.Perm.ReadMembers:
+      !u Files.Class.File: false
 

--- a/deploy/templates/files/files.yaml
+++ b/deploy/templates/files/files.yaml
@@ -21,6 +21,9 @@ spec:
         component: files
         factory-plus.service: files
     spec:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
       {{- with .Values.acs.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
- Add missing readMember permissions to sv1files
- **Fix insufficient volume permission when writing to ceph RBD volumes**
The container runs as USER node (UID/GID 1000) but the PVC mounts with
  /data owned by root:root 0755, so the node user can't create temp files
  during upload and PUTs fail with 500 (EACCES on fs.open).

  Setting fsGroup: 1000 on the pod tells kubelet to recursively chown the
  mount to GID 1000 on first start, after which the node user can write.
  fsGroupChangePolicy: OnRootMismatch skips the recursive chown on
  subsequent restarts when the root GID already matches, keeping pod
  startup fast as the volume grows.

  Storage classes that already provision world-writable directories
  (e.g. local-path-provisioner) are unaffected — the chown is a harmless
  no-op for write access.