### PR TITLE
acs-keycloak-spi: refresh Kerberos credentials on expiry; delegate to lib

### DIFF
--- a/acs-keycloak-spi/pom.xml
+++ b/acs-keycloak-spi/pom.xml
@@ -74,10 +74,12 @@
         <!-- F+ service client. Pin to the in-tree publication version
              (0.0.0-intree); the docker build installs lib/java-service-client
              into Maven's local cache so this resolves without needing
-             a pre-staged lib/mvn directory. The current SPI doesn't
-             import this jar yet (Phase 2 uses bare java.net.http);
-             keeping the dep declared so Phase 4's FPGssClientKeytab
-             work has a one-line wiring path. -->
+             a pre-staged lib/mvn directory.
+             JaasKerberosAuthenticator delegates Kerberos/GSS to this
+             jar's FPGssClientKeytab; the shade plugin (below) bundles
+             this jar plus its transitive runtime deps (RxJava, vavr,
+             org.json, jakarta.json, httpclient5, jetty-client, ...) so
+             they are visible to Keycloak's provider classloader. -->
         <dependency>
             <groupId>io.github.amrc-factoryplus</groupId>
             <artifactId>java-service-client</artifactId>
@@ -166,6 +168,61 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.2.5</version>
+            </plugin>
+            <plugin>
+                <!-- Bundle java-service-client and its runtime deps into
+                     the SPI jar so Keycloak's provider classloader can
+                     resolve them. Keycloak ships slf4j-api, so we leave
+                     that alone; everything else (RxJava, vavr, org.json,
+                     jakarta.json, commons-lang3, httpclient5, jetty-*) is
+                     not on Keycloak's classpath and must travel with us.
+
+                     We do NOT relocate (rename) packages. Keycloak does
+                     not use RxJava or vavr internally; org.json is not
+                     on Keycloak 26's classpath either (Keycloak uses
+                     Jackson). The provider classloader is isolated from
+                     Keycloak's core, so even were there a collision the
+                     SPI would see its own copies. Relocation would only
+                     bloat the jar and obscure stack traces. -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals><goal>shade</goal></goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <shadedArtifactAttached>false</shadedArtifactAttached>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <!-- Drop signed-jar metadata that
+                                             would otherwise make the JVM
+                                             reject the shaded uber-jar. -->
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>module-info.class</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <artifactSet>
+                                <excludes>
+                                    <!-- Provided by Keycloak at runtime;
+                                         no need (and risky) to bundle. -->
+                                    <exclude>org.slf4j:*</exclude>
+                                    <exclude>com.fasterxml.jackson.core:*</exclude>
+                                    <exclude>org.keycloak:*</exclude>
+                                </excludes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <!-- Failsafe runs *IT.java in the verify phase, AFTER

--- a/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/JaasKerberosAuthenticator.java
+++ b/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/JaasKerberosAuthenticator.java
@@ -1,17 +1,23 @@
 /* ACS Keycloak SPI
- * Production KerberosAuthenticator: JAAS Krb5LoginModule + JGSS.
+ * Production KerberosAuthenticator: thin sync wrapper around the
+ * Factory+ Java service client's FPGssClientKeytab.
  *
- * Logs in via JAAS with the configured principal and keytab to obtain a
- * TGT, then caches a GSSCredential built from the resulting Subject.
- * Before every SPNEGO token request the cached credential's remaining
- * lifetime is checked; when it is close to expiry (or any GSSException
- * is raised during context initiation) the credential and Subject are
- * dropped and a fresh JAAS login is performed. This is the same shape
- * lib/java-service-client uses (see FPGssPrincipal).
+ * lib/java-service-client already implements the keytab login,
+ * GSSCredential caching, lifetime-aware refresh and retry-on-fault
+ * pattern (see FPGssPrincipal._withCreds). We delegate to it rather
+ * than duplicating the logic in the SPI - this is the wiring the
+ * original "Phase 4" TODOs in the SPI source point at.
  *
- * Thread-safety: credential management is synchronized on this.
- * Subject.doAs is itself thread-safe; the wrapping synchronized block
- * just protects the cached references.
+ * The lib API is RxJava-based; the SPI surface is plain synchronous
+ * method calls. We bridge with Single.blockingGet(). Each SPNEGO
+ * token request mints one fresh GSSContext (one-shot SPNEGO), which
+ * is correct for the HTTP "Authorization: Negotiate <token>" flow.
+ *
+ * FPGssProvider's constructor parameter is an FPServiceClient that is
+ * only consulted by the verify*() server-side paths (which we never
+ * exercise from this SPI), so we pass null. If a future change starts
+ * using the verify paths from here it will NPE loudly rather than
+ * silently misbehaving.
  *
  * Copyright 2026 University of Sheffield AMRC
  */
@@ -19,48 +25,26 @@
 package uk.co.amrc.app.factoryplus.keycloak;
 
 import org.ietf.jgss.GSSContext;
-import org.ietf.jgss.GSSCredential;
 import org.ietf.jgss.GSSException;
-import org.ietf.jgss.GSSManager;
-import org.ietf.jgss.GSSName;
-import org.ietf.jgss.Oid;
 
-import javax.security.auth.Subject;
-import javax.security.auth.login.AppConfigurationEntry;
-import javax.security.auth.login.Configuration;
-import javax.security.auth.login.LoginContext;
-import javax.security.auth.login.LoginException;
 import java.net.URI;
-import java.security.PrivilegedAction;
 import java.util.Base64;
-import java.util.HashMap;
-import java.util.Map;
+
+import uk.co.amrc.factoryplus.gss.FPGssClient;
+import uk.co.amrc.factoryplus.gss.FPGssProvider;
 
 public class JaasKerberosAuthenticator implements KerberosAuthenticator {
 
-    private static final String SPNEGO_OID = "1.3.6.1.5.5.2";
-    private static final String JAAS_ENTRY = "factoryplus-spi-client-keytab";
-
-    /* Refresh when the cached TGT has less than this many seconds left.
-     * 60s is enough headroom for a slow round-trip to acs-auth without
-     * burning a re-login on every call. */
-    private static final int MIN_LIFETIME_SECONDS = 60;
-
-    private final String principal;
-    private final String keytabPath;
-
-    private Subject subject;
-    private GSSCredential creds;
+    private final FPGssClient client;
 
     public JaasKerberosAuthenticator(String principal, String keytabPath) {
-        this.principal = principal;
-        this.keytabPath = keytabPath;
-        /* Eagerly log in so misconfiguration surfaces at SPI bootstrap
-         * rather than on the first user login. */
-        ensureCreds();
+        FPGssProvider provider = new FPGssProvider(null);
+        this.client = provider.clientWithKeytab(principal, keytabPath);
+        /* Force the initial JAAS login to happen now so misconfiguration
+         * surfaces at SPI bootstrap, not on the first user sign-in. */
+        primeCredentials();
     }
 
-    @SuppressWarnings({"deprecation", "removal"}) // Subject.doAs deprecated in JDK 23+
     @Override
     public String spnegoTokenFor(URI target) {
         String host = target.getHost();
@@ -72,139 +56,61 @@ public class JaasKerberosAuthenticator implements KerberosAuthenticator {
         String hostbasedService = "HTTP@" + host;
 
         try {
-            return doSpnego(hostbasedService);
+            return client.createContextHB(hostbasedService)
+                .map(JaasKerberosAuthenticator::oneShotSpnego)
+                .blockingGet();
         }
-        catch (GSSException first) {
-            /* The cached TGT may have expired or been revoked; drop
-             * cached state and try one fresh login before giving up. */
-            invalidate();
-            try {
-                return doSpnego(hostbasedService);
-            }
-            catch (GSSException retry) {
+        catch (RuntimeException e) {
+            Throwable cause = unwrap(e);
+            throw new FactoryPlusAuthException(
+                "SPNEGO token generation failed for " + hostbasedService, cause);
+        }
+    }
+
+    /* Build a SPNEGO initial token from a freshly-created GSSContext.
+     * The context is one-shot: Kerberos completes in a single
+     * initSecContext call so we never need to round-trip with the
+     * server. The context is disposed before we return. */
+    private static String oneShotSpnego(GSSContext ctx) throws GSSException {
+        try {
+            byte[] token = ctx.initSecContext(new byte[0], 0, 0);
+            return Base64.getEncoder().encodeToString(token);
+        }
+        finally {
+            ctx.dispose();
+        }
+    }
+
+    /* Trigger the lib's lazy login at construction time, so a bad
+     * principal/keytab fails the SPI bootstrap rather than the first
+     * end-user request. We deliberately throw a clear exception type. */
+    private void primeCredentials() {
+        try {
+            client.createContextHB("HTTP@localhost")
+                .map(ctx -> { ctx.dispose(); return true; })
+                .blockingGet();
+        }
+        catch (RuntimeException e) {
+            /* A successful KDC interaction may still fail to issue a
+             * service ticket for HTTP/localhost because no such
+             * principal exists - that's fine, we just wanted the TGT.
+             * The lib will have cached the GSSCredential by now. Only
+             * re-throw if the TGT itself could not be obtained. */
+            Throwable cause = unwrap(e);
+            if (cause instanceof javax.security.auth.login.LoginException) {
                 throw new FactoryPlusAuthException(
-                    "SPNEGO token generation failed for " + hostbasedService
-                        + " (after re-login)", retry);
+                    "Kerberos login failed at SPI bootstrap", cause);
             }
+            /* Any GSSException at this stage is downstream of a
+             * successful login; swallow. */
         }
     }
 
-    @SuppressWarnings({"deprecation", "removal"})
-    private String doSpnego(String hostbasedService) throws GSSException {
-        GSSCredential cred = ensureCreds();
-        Subject subj;
-        synchronized (this) { subj = this.subject; }
-
-        PrivilegedAction<Object> action = () -> {
-            try {
-                GSSManager mgr = GSSManager.getInstance();
-                Oid spnego = new Oid(SPNEGO_OID);
-                GSSName serverName = mgr.createName(hostbasedService,
-                    GSSName.NT_HOSTBASED_SERVICE);
-                /* Pass the credential explicitly. JGSS then uses our
-                 * cached TGT directly and never falls back to default
-                 * JAAS lookup (which would otherwise try to prompt). */
-                GSSContext ctx = mgr.createContext(serverName, spnego, cred,
-                    GSSContext.DEFAULT_LIFETIME);
-                try {
-                    return Base64.getEncoder().encodeToString(
-                        ctx.initSecContext(new byte[0], 0, 0));
-                }
-                finally {
-                    ctx.dispose();
-                }
-            }
-            catch (GSSException e) {
-                return e;
-            }
-        };
-        Object result = Subject.doAs(subj, action);
-        if (result instanceof GSSException gss) throw gss;
-        return (String) result;
-    }
-
-    /* Returns a usable GSSCredential, refreshing the underlying JAAS
-     * login if the cached credential is missing or about to expire. */
-    private synchronized GSSCredential ensureCreds() {
-        if (creds != null) {
-            int lifetime;
-            try {
-                lifetime = creds.getRemainingLifetime();
-            }
-            catch (GSSException e) {
-                lifetime = 0;
-            }
-            if (lifetime >= MIN_LIFETIME_SECONDS) return creds;
-            invalidate();
-        }
-
-        Subject subj = new Subject();
-        try {
-            Configuration config = inlineKrb5Config(principal, keytabPath);
-            LoginContext ctx = new LoginContext(JAAS_ENTRY, subj, null, config);
-            ctx.login();
-        }
-        catch (LoginException e) {
-            throw new FactoryPlusAuthException(
-                "Kerberos login failed for " + principal
-                    + " with keytab " + keytabPath, e);
-        }
-
-        try {
-            this.subject = subj;
-            this.creds = buildCredential(subj);
-            return this.creds;
-        }
-        catch (GSSException e) {
-            invalidate();
-            throw new FactoryPlusAuthException(
-                "Failed to build GSS credential for " + principal, e);
-        }
-    }
-
-    @SuppressWarnings({"deprecation", "removal"})
-    private static GSSCredential buildCredential(Subject subj) throws GSSException {
-        PrivilegedAction<Object> action = () -> {
-            try {
-                return GSSManager.getInstance()
-                    .createCredential(GSSCredential.INITIATE_ONLY);
-            }
-            catch (GSSException e) {
-                return e;
-            }
-        };
-        Object result = Subject.doAs(subj, action);
-        if (result instanceof GSSException gss) throw gss;
-        return (GSSCredential) result;
-    }
-
-    private synchronized void invalidate() {
-        if (creds != null) {
-            try { creds.dispose(); } catch (GSSException ignored) {}
-            creds = null;
-        }
-        subject = null;
-    }
-
-    private static Configuration inlineKrb5Config(String principal, String keytab) {
-        return new Configuration() {
-            @Override
-            public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
-                if (!JAAS_ENTRY.equals(name)) return null;
-                Map<String, String> opts = new HashMap<>();
-                opts.put("doNotPrompt", "true");
-                opts.put("storeKey", "false");
-                opts.put("isInitiator", "true");
-                opts.put("principal", principal);
-                opts.put("useKeyTab", "true");
-                opts.put("keyTab", keytab);
-                return new AppConfigurationEntry[] {
-                    new AppConfigurationEntry(
-                        "com.sun.security.auth.module.Krb5LoginModule",
-                        AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
-                        opts)
-                };
-            }
-        };
+    /* The lib wraps checked exceptions inside RuntimeException via
+     * RxJava's Exceptions.propagate. Peel the wrapper off so callers
+     * see the real Kerberos/GSS cause. */
+    private static Throwable unwrap(Throwable t) {
+        Throwable cause = t.getCause();
+        return cause != null ? cause : t;
     }
 }

--- a/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/JaasKerberosAuthenticator.java
+++ b/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/JaasKerberosAuthenticator.java
@@ -1,12 +1,17 @@
 /* ACS Keycloak SPI
  * Production KerberosAuthenticator: JAAS Krb5LoginModule + JGSS.
  *
- * Logs in once at construction time with the configured principal and
- * keytab; reuses the resulting Subject for every subsequent SPNEGO
- * token generation. JAAS handles ticket renewal under the hood.
+ * Logs in via JAAS with the configured principal and keytab to obtain a
+ * TGT, then caches a GSSCredential built from the resulting Subject.
+ * Before every SPNEGO token request the cached credential's remaining
+ * lifetime is checked; when it is close to expiry (or any GSSException
+ * is raised during context initiation) the credential and Subject are
+ * dropped and a fresh JAAS login is performed. This is the same shape
+ * lib/java-service-client uses (see FPGssPrincipal).
  *
- * Thread-safety: each spnegoTokenFor call creates a fresh GSSContext
- * but reuses the immutable Subject; Subject.doAs is thread-safe.
+ * Thread-safety: credential management is synchronized on this.
+ * Subject.doAs is itself thread-safe; the wrapping synchronized block
+ * just protects the cached references.
  *
  * Copyright 2026 University of Sheffield AMRC
  */
@@ -14,6 +19,7 @@
 package uk.co.amrc.app.factoryplus.keycloak;
 
 import org.ietf.jgss.GSSContext;
+import org.ietf.jgss.GSSCredential;
 import org.ietf.jgss.GSSException;
 import org.ietf.jgss.GSSManager;
 import org.ietf.jgss.GSSName;
@@ -35,29 +41,23 @@ public class JaasKerberosAuthenticator implements KerberosAuthenticator {
     private static final String SPNEGO_OID = "1.3.6.1.5.5.2";
     private static final String JAAS_ENTRY = "factoryplus-spi-client-keytab";
 
+    /* Refresh when the cached TGT has less than this many seconds left.
+     * 60s is enough headroom for a slow round-trip to acs-auth without
+     * burning a re-login on every call. */
+    private static final int MIN_LIFETIME_SECONDS = 60;
+
     private final String principal;
     private final String keytabPath;
-    private final Subject subject;
+
+    private Subject subject;
+    private GSSCredential creds;
 
     public JaasKerberosAuthenticator(String principal, String keytabPath) {
         this.principal = principal;
         this.keytabPath = keytabPath;
-        this.subject = login();
-    }
-
-    private Subject login() {
-        Configuration config = inlineKrb5Config(principal, keytabPath);
-        Subject subj = new Subject();
-        try {
-            LoginContext ctx = new LoginContext(JAAS_ENTRY, subj, null, config);
-            ctx.login();
-        }
-        catch (LoginException e) {
-            throw new FactoryPlusAuthException(
-                "Kerberos login failed for " + principal
-                    + " with keytab " + keytabPath, e);
-        }
-        return subj;
+        /* Eagerly log in so misconfiguration surfaces at SPI bootstrap
+         * rather than on the first user login. */
+        ensureCreds();
     }
 
     @SuppressWarnings({"deprecation", "removal"}) // Subject.doAs deprecated in JDK 23+
@@ -71,28 +71,119 @@ public class JaasKerberosAuthenticator implements KerberosAuthenticator {
         }
         String hostbasedService = "HTTP@" + host;
 
-        PrivilegedAction<String> action = () -> {
+        try {
+            return doSpnego(hostbasedService);
+        }
+        catch (GSSException first) {
+            /* The cached TGT may have expired or been revoked; drop
+             * cached state and try one fresh login before giving up. */
+            invalidate();
+            try {
+                return doSpnego(hostbasedService);
+            }
+            catch (GSSException retry) {
+                throw new FactoryPlusAuthException(
+                    "SPNEGO token generation failed for " + hostbasedService
+                        + " (after re-login)", retry);
+            }
+        }
+    }
+
+    @SuppressWarnings({"deprecation", "removal"})
+    private String doSpnego(String hostbasedService) throws GSSException {
+        GSSCredential cred = ensureCreds();
+        Subject subj;
+        synchronized (this) { subj = this.subject; }
+
+        PrivilegedAction<Object> action = () -> {
             try {
                 GSSManager mgr = GSSManager.getInstance();
                 Oid spnego = new Oid(SPNEGO_OID);
                 GSSName serverName = mgr.createName(hostbasedService,
                     GSSName.NT_HOSTBASED_SERVICE);
-                GSSContext ctx = mgr.createContext(serverName, spnego, null,
+                /* Pass the credential explicitly. JGSS then uses our
+                 * cached TGT directly and never falls back to default
+                 * JAAS lookup (which would otherwise try to prompt). */
+                GSSContext ctx = mgr.createContext(serverName, spnego, cred,
                     GSSContext.DEFAULT_LIFETIME);
                 try {
-                    byte[] token = ctx.initSecContext(new byte[0], 0, 0);
-                    return Base64.getEncoder().encodeToString(token);
+                    return Base64.getEncoder().encodeToString(
+                        ctx.initSecContext(new byte[0], 0, 0));
                 }
                 finally {
                     ctx.dispose();
                 }
             }
             catch (GSSException e) {
-                throw new FactoryPlusAuthException(
-                    "SPNEGO token generation failed for " + hostbasedService, e);
+                return e;
             }
         };
-        return Subject.doAs(subject, action);
+        Object result = Subject.doAs(subj, action);
+        if (result instanceof GSSException gss) throw gss;
+        return (String) result;
+    }
+
+    /* Returns a usable GSSCredential, refreshing the underlying JAAS
+     * login if the cached credential is missing or about to expire. */
+    private synchronized GSSCredential ensureCreds() {
+        if (creds != null) {
+            int lifetime;
+            try {
+                lifetime = creds.getRemainingLifetime();
+            }
+            catch (GSSException e) {
+                lifetime = 0;
+            }
+            if (lifetime >= MIN_LIFETIME_SECONDS) return creds;
+            invalidate();
+        }
+
+        Subject subj = new Subject();
+        try {
+            Configuration config = inlineKrb5Config(principal, keytabPath);
+            LoginContext ctx = new LoginContext(JAAS_ENTRY, subj, null, config);
+            ctx.login();
+        }
+        catch (LoginException e) {
+            throw new FactoryPlusAuthException(
+                "Kerberos login failed for " + principal
+                    + " with keytab " + keytabPath, e);
+        }
+
+        try {
+            this.subject = subj;
+            this.creds = buildCredential(subj);
+            return this.creds;
+        }
+        catch (GSSException e) {
+            invalidate();
+            throw new FactoryPlusAuthException(
+                "Failed to build GSS credential for " + principal, e);
+        }
+    }
+
+    @SuppressWarnings({"deprecation", "removal"})
+    private static GSSCredential buildCredential(Subject subj) throws GSSException {
+        PrivilegedAction<Object> action = () -> {
+            try {
+                return GSSManager.getInstance()
+                    .createCredential(GSSCredential.INITIATE_ONLY);
+            }
+            catch (GSSException e) {
+                return e;
+            }
+        };
+        Object result = Subject.doAs(subj, action);
+        if (result instanceof GSSException gss) throw gss;
+        return (GSSCredential) result;
+    }
+
+    private synchronized void invalidate() {
+        if (creds != null) {
+            try { creds.dispose(); } catch (GSSException ignored) {}
+            creds = null;
+        }
+        subject = null;
     }
 
     private static Configuration inlineKrb5Config(String principal, String keytab) {


### PR DESCRIPTION
## Summary

OAuth sign-in via the Keycloak SPI breaks ~24 hours after the openid pod starts. Two clusters (AGO + the other one) went down over the weekend with the same `Cannot read from System.in` chain. Root cause: the SPI's `JaasKerberosAuthenticator` logged in via JAAS once at construction and never refreshed the resulting `Subject`. When the TGT aged out, JGSS (with `-Djavax.security.auth.useSubjectCredsOnly=false` set on the pod for the pgjdbc path) fell back to a default JAAS login, found no matching entry in `/etc/jaas/login.conf`, and landed in `Krb5LoginModule.promptForName()` — which then read `System.in`. Only a pod restart could recover.

This PR is **two commits**:

1. **`refresh Kerberos credentials on expiry`** — a self-contained fix that copies the credential-lifecycle pattern (cache `GSSCredential`, check `getRemainingLifetime()`, drop and re-login when low, one-shot retry on `GSSException`) directly into the SPI. Safe to land alone.
2. **`delegate Kerberos to lib/java-service-client`** — the proper Phase 4 wiring. Retires the duplicate by delegating to `FPGssClientKeytab` (which already implements the same renewal pattern in `FPGssPrincipal._withCreds`). The lib API is RxJava, the SPI surface is sync; we bridge with `Single.blockingGet()`.

The two are split so reviewers can verify the fix logic against the prior code before evaluating the delegation. Land them together.

## Packaging change

The second commit adds `maven-shade-plugin` to `acs-keycloak-spi/pom.xml`. The lib + its transitive runtime deps (RxJava, vavr, org.json, jakarta.json, commons-lang3, httpclient5, jetty-*) now travel in the SPI provider jar — these aren't on Keycloak's classpath. slf4j-api and Jackson stay `provided`. Final jar: ~9MB (was ~40KB).

No package relocation. Keycloak doesn't use RxJava/vavr/org.json internally, and provider classloaders are isolated from Keycloak's core anyway. Relocation would only bloat the jar and obscure stack traces.

## Release notes

`acs-keycloak-spi` &mdash; OAuth sign-in no longer fails after the openid pod's Kerberos ticket expires. Previously the pod needed a manual restart every ~24 hours; now the SPI transparently refreshes its credential.

## How to test

1. Bring up an ACS cluster on this branch. The custom openid image is built from `acs-keycloak/` with the SPI jar baked in.
2. Wait until the cached TGT has expired (default krbtgt lifetime, typically 24h). If you don't want to wait: shorten `ticket_lifetime` in the cluster `krb5.conf` ConfigMap, or revoke + re-issue the `sv1openid` principal in the KDC.
3. Attempt an OAuth login (Postman, the CLI, any device-code or browser flow that triggers `FPAuthBackedUserStore.findByUsername` &mdash; i.e. anything that uses a password/username rather than SPNEGO directly).
4. The login should succeed without a pod restart. The Keycloak log should show no `Cannot read from System.in` and no `SPNEGO token generation failed`.
5. Concurrent-load smoke: hit several logins in parallel as the credential is mid-refresh, confirm no AssertionError / classloader-init failures from the shaded lib.

## What it does NOT change

- `-Djavax.security.auth.useSubjectCredsOnly=false` stays on the pod (pgjdbc still needs it; the new SPI passes its credential to JGSS explicitly so the flag is irrelevant for the SPI path).
- `/etc/jaas/login.conf` is unchanged. The lib's inline `KrbConfiguration` is authoritative for SPI logins.
- The KerberosAuthenticator interface and its callers are unchanged. Only the implementation moved.

## Notes for reviewers

- `docs/kerberos-tgt-renewal-explainer.html` is a teaching artifact for the team explaining the Kerberos behaviour and the trap. It's tied to the first commit's diff for pedagogical reasons; the second commit shrinks the actual implementation to a thin RxJava bridge but the lesson is the same.
- `FPGssProvider(null)` is intentional. The constructor parameter is only read by the `verify*()` server-side paths, which the SPI never invokes. A future change that does would NPE loudly rather than silently misbehave.
