### PR TITLE
Fix empty schema in acs-i3x /v1/objecttypes response

### DIFF
--- a/acs-i3x/lib/constants.ts
+++ b/acs-i3x/lib/constants.ts
@@ -14,6 +14,6 @@ export const RelType = {
 
 // ConfigDB UUIDs consumed by the object tree loader and notify subscriptions.
 export const DEVICE_CLASS_UUID            = "18773d6d-a70d-443a-b29a-3f1583195290";
-export const CONFIG_SCHEMA_APP_UUID       = "dbd8a535-52ba-4f6e-b4f8-9b71aefe09d3";
+export const SCHEMA_APP_UUID              = "b16e85fb-53c2-49f9-8d83-cdf6763304ba";
 export const INFO_APP_UUID                = "64a8bfa9-7772-45c4-9d1a-9e6290690957";
 export const DEVICE_INFORMATION_APP_UUID  = "a98ffed5-c613-4e70-bfd3-efeee250ade5";

--- a/acs-i3x/lib/object-tree.ts
+++ b/acs-i3x/lib/object-tree.ts
@@ -22,7 +22,7 @@ import {
     RelType,
     HIERARCHY_SCHEMA_UUID,
     DEVICE_CLASS_UUID,
-    CONFIG_SCHEMA_APP_UUID,
+    SCHEMA_APP_UUID,
     INFO_APP_UUID,
     DEVICE_INFORMATION_APP_UUID,
 } from "./constants.js";
@@ -887,7 +887,7 @@ export class ObjectTree {
 
             this.log("loadDevices: fetching schema definition %s", schemaUuid);
             const [schema, info] = await Promise.all([
-                this.fplus.ConfigDB.get_config(CONFIG_SCHEMA_APP_UUID, schemaUuid).catch(() => null),
+                this.fplus.ConfigDB.get_config(SCHEMA_APP_UUID, schemaUuid).catch(() => null),
                 this.fplus.ConfigDB.get_config(INFO_APP_UUID, schemaUuid).catch(() => null),
             ]);
             this.buildObjectTypeInSnapshot(schemaUuid, schema, info, target);
@@ -956,7 +956,7 @@ export class ObjectTree {
 
     /**
      * Create or replace an ObjectType in `target` from a pre-fetched
-     * ConfigSchema + Info config. Idempotent: a second call with the
+     * Schema + Info config. Idempotent: a second call with the
      * same schemaUuid replaces the entry.
      */
     private buildObjectTypeInSnapshot(

--- a/acs-i3x/lib/refresh.ts
+++ b/acs-i3x/lib/refresh.ts
@@ -6,7 +6,7 @@
  * ObjectTree refresh — reactive pipeline driven by ConfigDB notify-v2.
  *
  * Subscribes to: the Device class members, each device's DeviceInformation
- * and Info configs, and each referenced schema's ConfigSchema and Info
+ * and Info configs, and each referenced schema's Schema and Info
  * configs. Combines them into a single emission stream and asks
  * ObjectTree to rebuild from that pre-fetched state. notify-v2 multiplexes
  * all WATCH requests over one shared WebSocket, and the per-config watch
@@ -22,7 +22,7 @@ import {
     DEVICE_INFORMATION_APP_UUID,
     DEVICE_CLASS_UUID,
     INFO_APP_UUID,
-    CONFIG_SCHEMA_APP_UUID,
+    SCHEMA_APP_UUID,
 } from "./constants.js";
 import { ObjectTree, PipelineSnapshot } from "./object-tree.js";
 import { I3xRag } from "./rag/i3x-rag.js";
@@ -74,7 +74,7 @@ export class ObjectTreeRefresh {
 
         const watch_schema = (uuid: string): rx.Observable<{ uuid: string; schema: any; info: any }> =>
             rx.combineLatest([
-                watch_config(`${CONFIG_SCHEMA_APP_UUID}:${uuid}`) as rx.Observable<any>,
+                watch_config(`${SCHEMA_APP_UUID}:${uuid}`) as rx.Observable<any>,
                 watch_config(`${INFO_APP_UUID}:${uuid}`) as rx.Observable<any>,
             ]).pipe(rx.map(([schema, info]) => ({ uuid, schema, info })));
 

--- a/acs-i3x/test/object-tree.test.ts
+++ b/acs-i3x/test/object-tree.test.ts
@@ -10,7 +10,7 @@ import { createMockFplus } from "./helpers/mock-services.js";
 const DEVICE_CLASS_UUID = "18773d6d-a70d-443a-b29a-3f1583195290";
 const DEVICE_INFORMATION_APP_UUID = "a98ffed5-c613-4e70-bfd3-efeee250ade5";
 const INFO_APP_UUID = "64a8bfa9-7772-45c4-9d1a-9e6290690957";
-const CONFIG_SCHEMA_APP_UUID = "dbd8a535-52ba-4f6e-b4f8-9b71aefe09d3";
+const SCHEMA_APP_UUID = "b16e85fb-53c2-49f9-8d83-cdf6763304ba";
 const HIERARCHY_SCHEMA_UUID = "84ac3397-f3a2-440a-99e5-5bb9f6a75091";
 
 const NS_NAME = "Factory+";
@@ -81,8 +81,8 @@ function setupMockDevices(fplus: ReturnType<typeof createMockFplus>) {
                 if (objectUuid === dev1) return Promise.resolve({ name: "Device 1" });
                 if (objectUuid === dev2) return Promise.resolve({ name: "Device 2" });
             }
-            // ConfigSchema app — JSON schema definitions
-            if (appUuid === CONFIG_SCHEMA_APP_UUID) {
+            // Schema app — JSON schema definitions
+            if (appUuid === SCHEMA_APP_UUID) {
                 if (objectUuid === schema1uuid) return Promise.resolve(schema1);
                 if (objectUuid === schema2uuid) return Promise.resolve(schema2);
             }
@@ -304,7 +304,7 @@ describe("ObjectTree", () => {
                                 },
                             },
                         });
-                    if (appUuid === CONFIG_SCHEMA_APP_UUID && objectUuid === schemaA)
+                    if (appUuid === SCHEMA_APP_UUID && objectUuid === schemaA)
                         return Promise.resolve(schemaDef);
                     return Promise.resolve(null);
                 },
@@ -636,7 +636,7 @@ describe("ObjectTree", () => {
                                 },
                             },
                         });
-                    if (appUuid === CONFIG_SCHEMA_APP_UUID && objectUuid === schemaA)
+                    if (appUuid === SCHEMA_APP_UUID && objectUuid === schemaA)
                         return Promise.resolve({ type: "object" });
                     return Promise.resolve(null);
                 },

--- a/acs-service-setup/dumps/i3x.yaml
+++ b/acs-service-setup/dumps/i3x.yaml
@@ -28,7 +28,7 @@ grants:
     # Read ConfigDB: object registration (class membership) and schemas
     !u ConfigDB.Perm.ReadConfig:
       !u UUIDs.App.Registration: false
-      !u UUIDs.App.ConfigSchema: false
+      !u UUIDs.App.Schema: false
       !u UUIDs.App.Info: false
       # Device originMap (Schema_UUID, Instance_UUID, ISA-95 hierarchy,
       # metric tree) — i3x reads this for every device in the Device


### PR DESCRIPTION
## Summary

  `GET /v1/objecttypes` was returning `schema: {}` for every ObjectType
  because the loader was reading from the wrong ConfigDB application.
  This fixes the lookup and grants the service principal read access
  to the correct app.

  ## What was wrong

  acs-i3x was calling `get_config(App.ConfigSchema, schemaUuid)` to                                                                                                                                                                 
  fetch the JSON Schema body for each Sparkplug device schema
  (Common/Hierarchy, Common/Device_Information, Power/Phase, etc.).
  `App.ConfigSchema` is the app that validates *application configs* —
  it is not where Sparkplug device schemas live. Those are stored under
  `App.Schema` (`b16e85fb-53c2-49f9-8d83-cdf6763304ba`), populated by
  acs-git's schema hook (`acs-git/lib/hooks/schemas.js:133`).

  The wrong call silently returned null (swallowed by
  `.catch(() => null)`) and the `schema ?? {}` fallback in
  `buildObjectTypeInSnapshot` produced the empty object the client saw.
  `displayName` came through correctly because that reads `App.Info` on
  the same object — same code path, different (correctly-named) app —
  which is why the bug wasn't obvious from the output.

  ## Changes

  **acs-i3x source**
  - `lib/constants.ts` — renamed `CONFIG_SCHEMA_APP_UUID` → `SCHEMA_APP_UUID`
    and pointed it at `App.Schema` (`b16e85fb-…`).
  - `lib/object-tree.ts` — bootstrap loader (`loadDevices`) now fetches
    schemas from `App.Schema`.
  - `lib/refresh.ts` — notify-v2 reactive pipeline watches `App.Schema`
    per schema UUID.
  - `test/object-tree.test.ts` — mock keys updated so tests exercise
    the real call shape.

  **Deploy**
  - `acs-service-setup/dumps/i3x.yaml` — the `I3X.Requirement.ServiceRole`
    ACL grants `ReadConfig` on `App.Schema`; the previous
    `App.ConfigSchema` grant is dropped (no longer read).

  Spec note: with the fix the response now matches the i3X v1
  `ObjectTypeResponse` schema — all five required fields populated,
  including a real JSON Schema body in `schema`.

  ## How to test

  1. Deploy this branch.                                                                                                                                                                                                            
  2. **Re-run acs-service-setup** so the ACL update lands. This step
     is load-bearing — the code change alone still yields `schema: {}`
     if the principal lacks `ReadConfig` on `App.Schema`, because
     `get_config` returns 403 and the `.catch` swallows it.
  3. `curl https://<i3x-host>/v1/objecttypes` — every entry should
     now have a populated `schema` object containing the JSON Schema
     for that device type (look for `properties`, `$id`, `type`).
  4. Spot-check a specific schema:
     `curl https://<i3x-host>/v1/objecttypes/84ac3397-f3a2-440a-99e5-5bb9f6a75091`
     should return the Common/Hierarchy v1 schema body.
  5. Check acs-i3x startup logs for
     `loadDevices: loading N schemas for unique device types`
     followed by `buildObjectType: <uuid> (<name>)` lines — no
     "schema fetch failed" or similar.

  ## Release notes
  
  Fixed `GET /v1/objecttypes` returning empty `schema` objects.
  ObjectTypes now contain the JSON Schema definition for each
  device type as required by the i3X spec.