### PR TITLE
update fetch in service-interface.js

### DIFF
--- a/lib/js-service-client/lib/service/service-interface.js
+++ b/lib/js-service-client/lib/service/service-interface.js
@@ -95,10 +95,13 @@ This calls Fetch.fetch with some additional functionality.
         if (typeof opts == "string")
             opts = { url: opts };
         let body;
-        if("body" in opts && opts.content_type === "raw") {
-            body = opts.body;
-        }else {
-            body = JSON.stringify(opts.body);
+
+        if ("body" in opts) {
+            if (opts.content_type === "raw") {
+                body = opts.body;
+            } else {
+                body = JSON.stringify(opts.body);
+            }
         }
 
         const headers = { ...opts.headers };
@@ -122,20 +125,34 @@ This calls Fetch.fetch with some additional functionality.
             .map(m => m[1])
             .orElse(undefined);
 
-        if(res.headers.get("Content-Type") === "application/octet-stream"){
-            return [res.status, res.body, etag]
-        }else{
-            /* ?? here because Optional.or doesn't work properly */
-            const json = Optional.of(opts.method ?? "GET")
-                .filter(m => m != "HEAD")
-                .map(_ => res.headers.get("Content-Type"))
-                .map(content_type.parse)
-                .filter(ct => ct.type == "application/json")
-                .map(_ => res.json())
-                .orElse(undefined);
-            return [res.status, await json, etag];
-
+        /**
+         * Explicit opt-in stream support.
+         */
+        if (opts.response_type === "stream") {
+            return [res.status, res.body, etag, res.headers];
         }
+
+        /**
+         * Existing binary handling
+         */
+        const ct = res.headers.get("Content-Type") ?? "";
+
+        if (ct.startsWith("application/octet-stream")) {
+            return [res.status, res.body, etag];
+        }
+
+        /**
+         * Only parse JSON if response actually is JSON.
+         */
+        const json = Optional.of(opts.method ?? "GET")
+            .filter(m => m != "HEAD")
+            .map(_ => res.headers.get("Content-Type"))
+            .map(content_type.parse)
+            .filter(ct => ct.type == "application/json")
+            .map(_ => res.json())
+            .orElse(undefined);
+
+        return [res.status, await json, etag];
     }
 
     /** Call /ping and return the result. */


### PR DESCRIPTION
Adds optional support for streaming responses in `fetch` via a new `response_type: "stream"` flag.
When enabled, the `raw `response `body `stream and `headers `are returned without any automatic parsing, allowing callers to consume large or continuous payloads (e.g. CSV exports) efficiently.
Existing behaviour is unchanged for all other response types, preserving full backward compatibility.