### PR TITLE
Add nanosecond timestamp support

### DIFF
--- a/acs-edge/lib/device.ts
+++ b/acs-edge/lib/device.ts
@@ -6,6 +6,7 @@ import { log } from "./helpers/log.js";
 import { SparkplugNode } from "./sparkplugNode.js";
 import {
     Metrics,
+    parseNsTimestampFromPayload,
     parseTimeStampFromPayload,
     parseValueFromPayload,
     processJSONBatchedPayload,
@@ -420,11 +421,17 @@ export class Device {
                                 (newVal || newVal == 0)
                                 && (metric.value !== newVal)
                             ) {
-                                // If timestamp is provided in data package
+                                // Extract timestamps from the payload if provided.
+                                // timestampNs takes precedence for sub-ms precision;
+                                // timestamp is the ms fallback.
                                 const timestamp = parseTimeStampFromPayload(obj[addr],
                                     metric,
                                     this._payloadFormat,
                                     this._delimiter
+                                );
+                                const timestampNs = parseNsTimestampFromPayload(obj[addr],
+                                    metric,
+                                    this._payloadFormat
                                 );
 
                                 // Update the metric value and push it to the array of changed metrics
@@ -432,7 +439,8 @@ export class Device {
                                     ...(this._metrics.setValueByAddrPath(addr,
                                         path,
                                         newVal,
-                                        timestamp))
+                                        timestamp,
+                                        timestampNs))
                                 });
                             }
                         }

--- a/acs-edge/lib/helpers/typeHandler.ts
+++ b/acs-edge/lib/helpers/typeHandler.ts
@@ -234,6 +234,16 @@ export interface nestedMetricIndex {
     [index: string]: metricIndex
 }
 
+/* Captured once at startup to align hrtime with wall clock.
+ * Date.now() is millisecond-precision so absolute accuracy is ±1ms,
+ * but relative precision between events is genuinely nanosecond.
+ * process.hrtime.bigint() is monotonic so timestamps never go backwards. */
+const HRTIME_OFFSET = BigInt(Date.now()) * 1_000_000n - process.hrtime.bigint();
+
+function now_ns(): bigint {
+    return process.hrtime.bigint() + HRTIME_OFFSET;
+}
+
 export class Metrics {
     #array: sparkplugMetric[]
     #addrIndex: metricArrIndex
@@ -302,7 +312,7 @@ export class Metrics {
     setValueByName(name: string, value: sparkplugValue, timestamp?: number, timestampNs?: bigint) {
         this.#array[this.#nameIndex[name]].value = value;
         this.#array[this.#nameIndex[name]].timestamp = timestamp || Date.now();
-        this.#array[this.#nameIndex[name]].timestampNs = timestampNs;
+        this.#array[this.#nameIndex[name]].timestampNs = timestampNs ?? (timestamp ? undefined : now_ns());
         this.#array[this.#nameIndex[name]].isNull = (value === null);
         return this.#array[this.#nameIndex[name]]
     }
@@ -310,7 +320,7 @@ export class Metrics {
     setValueByIndex(index: number, value: sparkplugValue, timestamp?: number, timestampNs?: bigint) {
         this.#array[index].value = value;
         this.#array[index].timestamp = timestamp || Date.now();
-        this.#array[index].timestampNs = timestampNs;
+        this.#array[index].timestampNs = timestampNs ?? (timestamp ? undefined : now_ns());
         this.#array[index].isNull = (value === null);
         return this.#array[index];
     }
@@ -328,7 +338,7 @@ export class Metrics {
     setValueByAlias(alias: number, value: sparkplugValue, timestamp?: number, timestampNs?: bigint) {
         this.#array[this.#aliasIndex[alias]].value = value;
         this.#array[this.#aliasIndex[alias]].timestamp = timestamp || Date.now();
-        this.#array[this.#aliasIndex[alias]].timestampNs = timestampNs;
+        this.#array[this.#aliasIndex[alias]].timestampNs = timestampNs ?? (timestamp ? undefined : now_ns());
         this.#array[this.#aliasIndex[alias]].isNull = (value === null)
         return this.#array[this.#aliasIndex[alias]];
     }
@@ -352,7 +362,7 @@ export class Metrics {
     setValueByAddrPath(addr: string, path: string, value: sparkplugValue, timestamp?: number, timestampNs?: bigint) {
         this.#array[this.#addrPathIndex[addr][path]].value = value;
         this.#array[this.#addrPathIndex[addr][path]].timestamp = timestamp || Date.now();
-        this.#array[this.#addrPathIndex[addr][path]].timestampNs = timestampNs;
+        this.#array[this.#addrPathIndex[addr][path]].timestampNs = timestampNs ?? (timestamp ? undefined : now_ns());
         this.#array[this.#addrPathIndex[addr][path]].isNull = (value === null)
         return this.#array[this.#addrPathIndex[addr][path]];
     }
@@ -620,6 +630,43 @@ export function parseTimeStampFromPayload(msg: any, metric: sparkplugMetric, pay
 
         default:
             return undefined;
+    }
+}
+
+/**
+ * Extracts a nanosecond-precision timestamp from a JSON payload.
+ * The field must be named "timestampNs" and must be a numeric string
+ * (not a number) to avoid float64 precision loss — nanosecond epoch
+ * values exceed Number.MAX_SAFE_INTEGER.
+ * Currently only supports JSON payloads; other formats return undefined.
+ * @param msg Raw message from device connection
+ * @param metric The metric being processed
+ * @param payloadFormat Payload format string
+ */
+export function parseNsTimestampFromPayload(msg: any, metric: sparkplugMetric, payloadFormat: serialisationType | string): bigint | undefined {
+    if (payloadFormat !== serialisationType.JSON) return undefined;
+
+    let payload: any;
+    try {
+        if (typeof msg == "string") {
+            payload = JSON.parse(msg);
+        } else if (Buffer.isBuffer(msg)) {
+            payload = JSON.parse(msg.toString());
+        } else {
+            payload = msg;
+        }
+    } catch (e: any) {
+        return undefined;
+    }
+
+    const raw = payload?.timestampNs;
+    if (raw == null) return undefined;
+
+    try {
+        return BigInt(raw);
+    } catch {
+        log(`Failed to parse timestampNs value as BigInt: ${raw}`);
+        return undefined;
     }
 }
 

--- a/acs-edge/lib/helpers/typeHandler.ts
+++ b/acs-edge/lib/helpers/typeHandler.ts
@@ -119,7 +119,7 @@ export interface sparkplugConfig {
 }
 
 export interface sparkplugPayload {
-    timestamp: number,
+    timestamp: number | Long,
     metrics: sparkplugMetric[],
     seq?: number,
     uuid?: string,
@@ -146,7 +146,12 @@ export interface sparkplugMetric {
     isTransient?: boolean,
     isNull?: boolean,
     metadata?: sparkplugMetricMetadata,
-    timestamp?: number,
+    /** Millisecond timestamp, or a Long encoding nanoseconds when set by
+     *  SparkplugNode for wire encoding. Prefer timestampNs for precision. */
+    timestamp?: number | Long,
+    /** Nanoseconds since epoch. When present, takes precedence over
+     *  timestamp for encoding. Set by drivers that supply sub-ms precision. */
+    timestampNs?: bigint,
     properties?: sparkplugMetricProperties,
 }
 
@@ -294,16 +299,18 @@ export class Metrics {
         return this.#array[this.#nameIndex[name]];
     }
 
-    setValueByName(name: string, value: sparkplugValue, timestamp?: number) {
+    setValueByName(name: string, value: sparkplugValue, timestamp?: number, timestampNs?: bigint) {
         this.#array[this.#nameIndex[name]].value = value;
         this.#array[this.#nameIndex[name]].timestamp = timestamp || Date.now();
+        this.#array[this.#nameIndex[name]].timestampNs = timestampNs;
         this.#array[this.#nameIndex[name]].isNull = (value === null);
         return this.#array[this.#nameIndex[name]]
     }
 
-    setValueByIndex(index: number, value: sparkplugValue, timestamp?: number) {
+    setValueByIndex(index: number, value: sparkplugValue, timestamp?: number, timestampNs?: bigint) {
         this.#array[index].value = value;
         this.#array[index].timestamp = timestamp || Date.now();
+        this.#array[index].timestampNs = timestampNs;
         this.#array[index].isNull = (value === null);
         return this.#array[index];
     }
@@ -318,9 +325,10 @@ export class Metrics {
         return this.#array[this.#aliasIndex[alias]];
     }
 
-    setValueByAlias(alias: number, value: sparkplugValue, timestamp?: number) {
+    setValueByAlias(alias: number, value: sparkplugValue, timestamp?: number, timestampNs?: bigint) {
         this.#array[this.#aliasIndex[alias]].value = value;
         this.#array[this.#aliasIndex[alias]].timestamp = timestamp || Date.now();
+        this.#array[this.#aliasIndex[alias]].timestampNs = timestampNs;
         this.#array[this.#aliasIndex[alias]].isNull = (value === null)
         return this.#array[this.#aliasIndex[alias]];
     }
@@ -341,9 +349,10 @@ export class Metrics {
         return this.#array[this.#addrPathIndex[addr][path]];
     }
 
-    setValueByAddrPath(addr: string, path: string, value: sparkplugValue, timestamp?: number) {
+    setValueByAddrPath(addr: string, path: string, value: sparkplugValue, timestamp?: number, timestampNs?: bigint) {
         this.#array[this.#addrPathIndex[addr][path]].value = value;
         this.#array[this.#addrPathIndex[addr][path]].timestamp = timestamp || Date.now();
+        this.#array[this.#addrPathIndex[addr][path]].timestampNs = timestampNs;
         this.#array[this.#addrPathIndex[addr][path]].isNull = (value === null)
         return this.#array[this.#addrPathIndex[addr][path]];
     }

--- a/acs-edge/lib/sparkplugNode.ts
+++ b/acs-edge/lib/sparkplugNode.ts
@@ -4,12 +4,30 @@
 
 import {EventEmitter} from "events";
 import {v5 as uuidv5} from "uuid";
+import Long from "long";
 
 import {ServiceClient} from "@amrc-factoryplus/utilities";
 
 import {log, logf} from "./helpers/log.js";
 import {metricIndex, Metrics, sparkplugConfig, sparkplugDataType, sparkplugMetric, sparkplugPayload,} from "./helpers/typeHandler.js";
 import * as UUIDs from "./uuids.js";
+
+/* Timestamps below this value are treated as milliseconds and converted
+ * to nanoseconds. Mirrors the same threshold in js-service-client. */
+const NS_THRESHOLD = 1_000_000_000_000_000n;
+const MS_TO_NS     = 1_000_000n;
+
+/* Normalise a ms or ns number/bigint to nanoseconds as a BigInt. */
+function normalizeToNanos(ts: number | bigint): bigint {
+    const n = BigInt(ts);
+    return n < NS_THRESHOLD ? n * MS_TO_NS : n;
+}
+
+/* Convert a nanosecond BigInt to an unsigned Long for the Sparkplug
+ * protobuf encoder, which uses Long for uint64 fields. */
+function ns_to_long(ns: bigint): Long {
+    return Long.fromString(ns.toString(), true);
+}
 
 class InstanceBuilder {
     #uuid: string
@@ -198,11 +216,18 @@ export class SparkplugNode extends (
                         metric.isNull = true;
                     }
 
-                    if (metric.timestamp === undefined) metric.timestamp = Date.now();
+                    // Resolve to nanoseconds. Use timestampNs when the driver
+                    // has supplied sub-ms precision; otherwise normalise the
+                    // ms timestamp (or fall back to now). Encode as an
+                    // unsigned Long so the protobuf encoder writes a full
+                    // uint64 without precision loss.
+                    const ns = metric.timestampNs
+                        ?? normalizeToNanos(metric.timestamp ?? Date.now());
 
                     // Create basic metric object
                     const newMetric: sparkplugMetric = {
-                        timestamp: metric.timestamp,
+                        timestamp: ns_to_long(ns),
+                        timestampNs: ns,
                         value: metric.value,
                         alias: metric.alias,
                         type: metric.type,
@@ -224,7 +249,7 @@ export class SparkplugNode extends (
             })
         );
         const payload: sparkplugPayload = {
-            timestamp: Date.now(),
+            timestamp: ns_to_long(normalizeToNanos(Date.now())),
             metrics: newMetrics,
         };
         if (birth) payload.uuid = UUIDs.Special.FactoryPlus;
@@ -299,7 +324,7 @@ export class SparkplugNode extends (
      * @param {string} deviceId The name of the device we are publishing on behalf of
      */
     async publishDDeath(deviceId: string) {
-        this.#client.publishDeviceDeath(deviceId, {timestamp: Date.now()});
+        this.#client.publishDeviceDeath(deviceId, {timestamp: ns_to_long(normalizeToNanos(Date.now()))});
         log(`💀 DDEATH published for ${deviceId}`);
     }
 
@@ -310,7 +335,7 @@ export class SparkplugNode extends (
     async #publishNData(metrics: sparkplugMetric | sparkplugMetric[]) {
         // Create payload
         let payload = {
-            timestamp: Date.now(),
+            timestamp: ns_to_long(normalizeToNanos(Date.now())),
             metrics: (Array.isArray(metrics) ? metrics : [metrics])
         };
         // Publish NDATA

--- a/acs-edge/lib/sparkplugNode.ts
+++ b/acs-edge/lib/sparkplugNode.ts
@@ -221,8 +221,11 @@ export class SparkplugNode extends (
                     // ms timestamp (or fall back to now). Encode as an
                     // unsigned Long so the protobuf encoder writes a full
                     // uint64 without precision loss.
-                    const ns = metric.timestampNs
-                        ?? normalizeToNanos(metric.timestamp ?? Date.now());
+                    const rawTs = metric.timestamp;
+                    const msTs = Long.isLong(rawTs)
+                        ? BigInt((rawTs as Long).toString())
+                        : (rawTs ?? Date.now());
+                    const ns = metric.timestampNs ?? normalizeToNanos(msTs);
 
                     // Create basic metric object
                     const newMetric: sparkplugMetric = {

--- a/acs-edge/tsconfig.json
+++ b/acs-edge/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "moduleResolution": "Node",
-    "target": "ES6",
+    "target": "ES2020",
     "allowJs": true,
     "noImplicitAny": false,
     "removeComments": true,

--- a/historian-sparkplug/lib/mqttclient.ts
+++ b/historian-sparkplug/lib/mqttclient.ts
@@ -398,7 +398,10 @@ export default class MQTTClient {
                 logger.error(`Metric ${metric.alias} is unknown for ${topic.address.group}/${topic.address.node}/${topic.address.device}`);
             }
 
-            const metricTimestamp = metric.timestamp ?? payload.timestamp;
+            // Prefer nanosecond precision when available, falling back to the
+            // millisecond Date for sources that have not yet been updated.
+            const metricTimestamp = metric.timestampNs ?? payload.timestampNs
+                ?? metric.timestamp ?? payload.timestamp;
             // Send each metric to InfluxDB
             this.writeToInfluxDB(birth, topic, metric.value, metricTimestamp)
         });
@@ -409,14 +412,21 @@ export default class MQTTClient {
      * @param birth Birth certificate for device.
      * @param topic Topic the metric was published on.
      * @param value Metric value to write to InfluxDB.
-     * @param timestamp Timestamp from the metric to write to influx.
+     * @param timestamp Timestamp from the metric. Either a BigInt of
+     *     nanoseconds since epoch, or a Date for ms-precision sources.
      */
-    writeToInfluxDB(birth, topic: Topic, value, timestamp: Date) {
+    writeToInfluxDB(birth, topic: Topic, value, timestamp: Date | bigint) {
         if (value === null) return;
         if (birth.transient) {
             logger.debug(`Metric ${birth.name} is transient, not writing to InfluxDB`);
             return;
         }
+
+        // InfluxDB client accepts string timestamps in line protocol format,
+        // which handles nanosecond values that exceed Number.MAX_SAFE_INTEGER.
+        const influxTimestamp = typeof timestamp === "bigint"
+            ? timestamp.toString()
+            : timestamp;
 
         // Get the value after the last /
         let metricName = birth.name.split('/').pop();
@@ -454,7 +464,7 @@ export default class MQTTClient {
                 writeApi.writePoint(
                     new Point(`${metricName}:i`)
                         .intField('value', numVal)
-                        .timestamp(timestamp)
+                        .timestamp(influxTimestamp)
                 );
                 break;
             case "UInt8":
@@ -470,7 +480,7 @@ export default class MQTTClient {
                 writeApi.writePoint(
                     new Point(`${metricName}:u`)
                         .uintField('value', numVal)
-                        .timestamp(timestamp)
+                        .timestamp(influxTimestamp)
                 );
                 break;
             case "Float":
@@ -484,7 +494,7 @@ export default class MQTTClient {
                 writeApi.writePoint(
                     new Point(`${metricName}:d`)
                         .floatField('value', numVal)
-                        .timestamp(timestamp)
+                        .timestamp(influxTimestamp)
                 );
                 break;
             case "Boolean":
@@ -495,13 +505,13 @@ export default class MQTTClient {
                 writeApi.writePoint(
                     new Point(`${metricName}:b`)
                         .booleanField('value', value)
-                        .timestamp(timestamp));
+                        .timestamp(influxTimestamp));
                 break;
             default:
                 writeApi.writePoint(
                     new Point(`${metricName}:s`)
                         .stringField('value', value)
-                        .timestamp(timestamp));
+                        .timestamp(influxTimestamp));
                 break;
 
         }

--- a/historian-uns/src/Types/index.d.ts
+++ b/historian-uns/src/Types/index.d.ts
@@ -3,7 +3,6 @@
  */
 interface MetricPayload {
     timestamp: string,
-    timestampNs?: string,
     value: string
     batch?: MetricPayload[]
 }

--- a/historian-uns/src/Types/index.d.ts
+++ b/historian-uns/src/Types/index.d.ts
@@ -3,6 +3,7 @@
  */
 interface MetricPayload {
     timestamp: string,
+    timestampNs?: string,
     value: string
     batch?: MetricPayload[]
 }

--- a/historian-uns/src/mqttclient.ts
+++ b/historian-uns/src/mqttclient.ts
@@ -178,31 +178,26 @@ export default class MQTTClient {
      */
     private writeMetrics(payload: MetricPayload, topic: string, customProperties: UnsMetricCustomProperties) {
         const unsTopic = new UnsTopic(topic, customProperties);
-        let metricTimestamp: Date
-        if (payload.timestamp) {
-            metricTimestamp = new Date(payload.timestamp);
-        } else if (payload.timestamp) {
-            // Metrics might not have a timestamp so use the packet timestamp if we have it.
-            metricTimestamp = new Date(payload.timestamp);
-        } else {
-            // No timestamp can be found on the metric or the payload, just use the current time instead.
-            metricTimestamp = new Date();
-        }
 
-        this.writeToInfluxDB(unsTopic, payload.value, metricTimestamp, customProperties.Unit, customProperties.Type);
+        // Prefer nanosecond precision when available. timestampNs is a numeric
+        // string (JSON has no bigint) set by the UNS ingester for sources that
+        // supply sub-millisecond timestamps. Fall back to the millisecond Date
+        // for sources that have not yet been updated.
+        const payloadTimestamp: Date | bigint = payload.timestampNs != null
+            ? BigInt(payload.timestampNs)
+            : payload.timestamp
+                ? new Date(payload.timestamp)
+                : new Date();
+
+        this.writeToInfluxDB(unsTopic, payload.value, payloadTimestamp, customProperties.Unit, customProperties.Type);
 
         // Handle the batched metrics
         payload.batch?.forEach((metric) => {
-            let metricTimestamp: Date
-            if (metric.timestamp) {
-                metricTimestamp = new Date(metric.timestamp);
-            } else if (payload.timestamp) {
-                // Metrics might not have a timestamp so use the packet timestamp if we have it.
-                metricTimestamp = new Date(payload.timestamp);
-            } else {
-                // No timestamp can be found on the metric or the payload, just use the current time instead.
-                metricTimestamp = new Date();
-            }
+            const metricTimestamp: Date | bigint = metric.timestampNs != null
+                ? BigInt(metric.timestampNs)
+                : metric.timestamp
+                    ? new Date(metric.timestamp)
+                    : payloadTimestamp;
             // Send each metric to InfluxDB
             this.writeToInfluxDB(unsTopic, metric.value, metricTimestamp, customProperties.Unit, customProperties.Type);
         });
@@ -212,14 +207,21 @@ export default class MQTTClient {
      * Writes metric values to InfluxDB using the metric timestamp.
      * @param topic Topic the metric was published on.
      * @param value Metric value to write to InfluxDB.
-     * @param timestamp Timestamp from the metric to write to influx.
+     * @param timestamp Timestamp from the metric. Either a BigInt of
+     *     nanoseconds since epoch, or a Date for ms-precision sources.
      * @param unit The metric unit from the MQTTv5 custom properties.
      * @param type The Metric type from the MQTTv5 custom properties.
      */
-    writeToInfluxDB(topic: UnsTopic, value: string, timestamp: Date, unit: string, type: string) {
+    writeToInfluxDB(topic: UnsTopic, value: string, timestamp: Date | bigint, unit: string, type: string) {
         if (value === null) {
             return;
         }
+
+        // InfluxDB client accepts string timestamps in line protocol format,
+        // which handles nanosecond values that exceed Number.MAX_SAFE_INTEGER.
+        const influxTimestamp = typeof timestamp === "bigint"
+            ? timestamp.toString()
+            : timestamp;
 
         writeApi.useDefaultTags({
             topLevelInstance: topic.GetTopLevelInstance(),
@@ -253,7 +255,7 @@ export default class MQTTClient {
                 writeApi.writePoint(
                     new Point(`${topic.GetMetricName()}:i`)
                         .intField('value', numVal)
-                        .timestamp(timestamp)
+                        .timestamp(influxTimestamp)
                 );
                 break;
             case "UInt8":
@@ -269,7 +271,7 @@ export default class MQTTClient {
                 writeApi.writePoint(
                     new Point(`${topic.GetMetricName()}:u`)
                         .uintField('value', numVal)
-                        .timestamp(timestamp)
+                        .timestamp(influxTimestamp)
                 );
                 break;
             case "Float":
@@ -283,7 +285,7 @@ export default class MQTTClient {
                 writeApi.writePoint(
                     new Point(`${topic.GetMetricName()}:d`)
                         .floatField('value', numVal)
-                        .timestamp(timestamp)
+                        .timestamp(influxTimestamp)
                 );
                 break;
             case "Boolean":
@@ -294,13 +296,13 @@ export default class MQTTClient {
                 writeApi.writePoint(
                     new Point(`${topic.GetMetricName()}:b`)
                         .booleanField('value', value)
-                        .timestamp(timestamp));
+                        .timestamp(influxTimestamp));
                 break;
             default:
                 writeApi.writePoint(
                     new Point(`${topic.GetMetricName()}:s`)
                         .stringField('value', value)
-                        .timestamp(timestamp));
+                        .timestamp(influxTimestamp));
                 break;
 
         }

--- a/historian-uns/src/mqttclient.ts
+++ b/historian-uns/src/mqttclient.ts
@@ -171,6 +171,23 @@ export default class MQTTClient {
     }
 
     /**
+     * Parse an ISO 8601 timestamp string to nanoseconds since epoch.
+     * Handles both standard millisecond precision ("...56.100Z") and
+     * nanosecond precision ("...56.100923659Z") produced by the UNS ingester.
+     */
+    private parse_iso_ns(iso: string): bigint {
+        const match = iso.match(/^(.+)\.(\d+)Z$/);
+        if (!match) {
+            return BigInt(new Date(iso).getTime()) * 1_000_000n;
+        }
+        const [, base, frac] = match;
+        const secMs = new Date(base + 'Z').getTime();
+        // Pad or truncate fractional digits to exactly 9 (nanoseconds within second)
+        const fracNs = BigInt(frac.padEnd(9, '0').slice(0, 9));
+        return BigInt(secMs / 1000) * 1_000_000_000n + fracNs;
+    }
+
+    /**
      * Writes all metrics in a UNS MQTT payload to InfluxDB
      * @param payload The payload from the MQTT packet.
      * @param topic The topic the payload was received on.
@@ -179,25 +196,17 @@ export default class MQTTClient {
     private writeMetrics(payload: MetricPayload, topic: string, customProperties: UnsMetricCustomProperties) {
         const unsTopic = new UnsTopic(topic, customProperties);
 
-        // Prefer nanosecond precision when available. timestampNs is a numeric
-        // string (JSON has no bigint) set by the UNS ingester for sources that
-        // supply sub-millisecond timestamps. Fall back to the millisecond Date
-        // for sources that have not yet been updated.
-        const payloadTimestamp: Date | bigint = payload.timestampNs != null
-            ? BigInt(payload.timestampNs)
-            : payload.timestamp
-                ? new Date(payload.timestamp)
-                : new Date();
+        const payloadTimestamp: bigint = payload.timestamp
+            ? this.parse_iso_ns(payload.timestamp)
+            : BigInt(Date.now()) * 1_000_000n;
 
         this.writeToInfluxDB(unsTopic, payload.value, payloadTimestamp, customProperties.Unit, customProperties.Type);
 
         // Handle the batched metrics
         payload.batch?.forEach((metric) => {
-            const metricTimestamp: Date | bigint = metric.timestampNs != null
-                ? BigInt(metric.timestampNs)
-                : metric.timestamp
-                    ? new Date(metric.timestamp)
-                    : payloadTimestamp;
+            const metricTimestamp: bigint = metric.timestamp
+                ? this.parse_iso_ns(metric.timestamp)
+                : payloadTimestamp;
             // Send each metric to InfluxDB
             this.writeToInfluxDB(unsTopic, metric.value, metricTimestamp, customProperties.Unit, customProperties.Type);
         });
@@ -207,21 +216,18 @@ export default class MQTTClient {
      * Writes metric values to InfluxDB using the metric timestamp.
      * @param topic Topic the metric was published on.
      * @param value Metric value to write to InfluxDB.
-     * @param timestamp Timestamp from the metric. Either a BigInt of
-     *     nanoseconds since epoch, or a Date for ms-precision sources.
+     * @param timestamp Nanoseconds since epoch as a BigInt.
      * @param unit The metric unit from the MQTTv5 custom properties.
      * @param type The Metric type from the MQTTv5 custom properties.
      */
-    writeToInfluxDB(topic: UnsTopic, value: string, timestamp: Date | bigint, unit: string, type: string) {
+    writeToInfluxDB(topic: UnsTopic, value: string, timestamp: bigint, unit: string, type: string) {
         if (value === null) {
             return;
         }
 
         // InfluxDB client accepts string timestamps in line protocol format,
         // which handles nanosecond values that exceed Number.MAX_SAFE_INTEGER.
-        const influxTimestamp = typeof timestamp === "bigint"
-            ? timestamp.toString()
-            : timestamp;
+        const influxTimestamp = timestamp.toString();
 
         writeApi.useDefaultTags({
             topLevelInstance: topic.GetTopLevelInstance(),

--- a/historian-uns/tsconfig.json
+++ b/historian-uns/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "target": "es2017",
+    "target": "es2020",
     "lib": [
-      "es2017",
+      "es2020",
       "esnext.asynciterable",
       "dom"
     ],

--- a/lib/js-service-client/lib/sparkplug/util.js
+++ b/lib/js-service-client/lib/sparkplug/util.js
@@ -4,11 +4,28 @@
 
 import Long from 'long'
 
-/* Number.MAX_SAFE_INTEGER is well above the input Date will accept;
- * this is past the year 100000. */
+/* Timestamps below this value are treated as milliseconds and converted
+ * to nanoseconds. This threshold is 10^15, which as milliseconds is the
+ * year ~33700 CE — safely beyond any real date we would encounter. As
+ * nanoseconds it is about 11.5 days after the Unix epoch, also safely
+ * in the past. */
+const NS_THRESHOLD = 1_000_000_000_000_000n;
+const MS_TO_NS     = 1_000_000n;
+
+/* Convert a Long or number/bigint timestamp to a BigInt in nanoseconds.
+ * Uses Long.toString() rather than toNumber() to avoid precision loss
+ * for large nanosecond values (which exceed Number.MAX_SAFE_INTEGER). */
+export function long_to_ns (ts) {
+    const val = Long.isLong(ts) ? BigInt(ts.toString()) : BigInt(ts);
+    return val < NS_THRESHOLD ? val * MS_TO_NS : val;
+}
+
+/* Convert a Long or number/bigint timestamp to a Date.
+ * The Date is always millisecond-precision; use long_to_ns if you need
+ * the full nanosecond value. */
 export function long_to_date (ts) {
-    const val = Long.isLong(ts) ? ts.toNumber() : ts;
-    return new Date(val);
+    const ns = long_to_ns(ts);
+    return new Date(Number(ns / MS_TO_NS));
 }
 
 /** Remove Longs from a decoded Sparkplug packet.
@@ -17,16 +34,26 @@ export function long_to_date (ts) {
  * does not attempt to handle templates or properties as we don't
  * currently use these.
  *
+ * Each timestamp is decoded into two fields:
+ *   - `timestamp`   Date (millisecond precision, for backward compat)
+ *   - `timestampNs` BigInt nanoseconds since epoch (full precision)
+ *
  * Edits `packet` in place and returns the result.
  */
 export function sp_remove_longs (packet) {
-    if ("timestamp" in packet)
-        packet.timestamp = long_to_date(packet.timestamp);
+    if ("timestamp" in packet) {
+        const ns = long_to_ns(packet.timestamp);
+        packet.timestampNs = ns;
+        packet.timestamp   = new Date(Number(ns / MS_TO_NS));
+    }
     for (const m of packet.metrics ?? []) {
         if ("alias" in m)
             m.alias = BigInt(m.alias);
-        if ("timestamp" in m)
-            m.timestamp = long_to_date(m.timestamp);
+        if ("timestamp" in m) {
+            const ns = long_to_ns(m.timestamp);
+            m.timestampNs = ns;
+            m.timestamp   = new Date(Number(ns / MS_TO_NS));
+        }
         if (Long.isLong(m.value))
             m.value = BigInt(m.value);
     }

--- a/uns-ingester-sparkplug/lib/mqttclient.ts
+++ b/uns-ingester-sparkplug/lib/mqttclient.ts
@@ -10,11 +10,20 @@ import Long from "long";
 
 interface UnsMetric {
     value: string,
-    timestamp: Date,
-    /** Nanoseconds since epoch as a numeric string. JSON has no bigint, so
-     *  this is serialised as a string for the historian to parse back. */
-    timestampNs?: string,
+    timestamp: string,
     batch?: UnsMetric[]
+}
+
+/**
+ * Convert a nanosecond BigInt to an ISO 8601 string with nanosecond
+ * precision, e.g. "2026-05-28T15:46:56.100923659Z". Falls back to
+ * millisecond precision when no nanosecond value is available.
+ */
+function ns_to_iso(ns: bigint): string {
+    const ms = ns / 1_000_000n;
+    const subMs = ns % 1_000_000n;
+    const date = new Date(Number(ms));
+    return date.toISOString().slice(0, -1) + subMs.toString().padStart(6, '0') + 'Z';
 }
 
 interface UnsMetricCustomProperties {
@@ -465,8 +474,7 @@ export default class MQTTClient {
                     return aNs < bNs ? -1 : aNs > bNs ? 1 : 0;
                 });
                 payload = {
-                    timestamp: sortedMetricContainers[0].metric.timestamp,
-                    timestampNs: sortedMetricContainers[0].metric.timestampNs?.toString(),
+                    timestamp: ns_to_iso(sortedMetricContainers[0].metric.timestampNs ?? BigInt(sortedMetricContainers[0].metric.timestamp.getTime()) * 1_000_000n),
                     value: sortedMetricContainers[0].metric.value,
                     batch: []
                 }
@@ -474,15 +482,13 @@ export default class MQTTClient {
                 sortedMetricContainers.shift();
                 sortedMetricContainers.forEach(metricContainer => {
                     payload.batch.push({
-                        timestamp: metricContainer.metric.timestamp,
-                        timestampNs: metricContainer.metric.timestampNs?.toString(),
+                        timestamp: ns_to_iso(metricContainer.metric.timestampNs ?? BigInt(metricContainer.metric.timestamp.getTime()) * 1_000_000n),
                         value: metricContainer.metric.value
                     });
                 });
             } else {
                 payload = {
-                    timestamp: metricContainers[0].metric.timestamp,
-                    timestampNs: metricContainers[0].metric.timestampNs?.toString(),
+                    timestamp: ns_to_iso(metricContainers[0].metric.timestampNs ?? BigInt(metricContainers[0].metric.timestamp.getTime()) * 1_000_000n),
                     value: metricContainers[0].metric.value
                 };
             }

--- a/uns-ingester-sparkplug/lib/mqttclient.ts
+++ b/uns-ingester-sparkplug/lib/mqttclient.ts
@@ -11,6 +11,9 @@ import Long from "long";
 interface UnsMetric {
     value: string,
     timestamp: Date,
+    /** Nanoseconds since epoch as a numeric string. JSON has no bigint, so
+     *  this is serialised as a string for the historian to parse back. */
+    timestampNs?: string,
     batch?: UnsMetric[]
 }
 
@@ -453,9 +456,17 @@ export default class MQTTClient {
             let payload: UnsMetric;
             // if theirs more than one of the same metric from the same sparkplug payload, add the values to the batch array.
             if (metricContainers.length > 1) {
-                const sortedMetricContainers = metricContainers.sort((a, b) => a.metric.timestamp - b.metric.timestamp);
+                // Sort by nanosecond timestamp when available, falling back to
+                // the millisecond Date. BigInt comparison returns -1/0/1 to
+                // satisfy the sort comparator contract.
+                const sortedMetricContainers = metricContainers.sort((a, b) => {
+                    const aNs = a.metric.timestampNs ?? BigInt(a.metric.timestamp.getTime()) * 1_000_000n;
+                    const bNs = b.metric.timestampNs ?? BigInt(b.metric.timestamp.getTime()) * 1_000_000n;
+                    return aNs < bNs ? -1 : aNs > bNs ? 1 : 0;
+                });
                 payload = {
-                    timestamp: new Date(sortedMetricContainers[0].metric.timestamp),
+                    timestamp: sortedMetricContainers[0].metric.timestamp,
+                    timestampNs: sortedMetricContainers[0].metric.timestampNs?.toString(),
                     value: sortedMetricContainers[0].metric.value,
                     batch: []
                 }
@@ -463,13 +474,15 @@ export default class MQTTClient {
                 sortedMetricContainers.shift();
                 sortedMetricContainers.forEach(metricContainer => {
                     payload.batch.push({
-                        timestamp: new Date(metricContainer.metric.timestamp),
+                        timestamp: metricContainer.metric.timestamp,
+                        timestampNs: metricContainer.metric.timestampNs?.toString(),
                         value: metricContainer.metric.value
                     });
                 });
             } else {
                 payload = {
-                    timestamp: new Date(metricContainers[0].metric.timestamp),
+                    timestamp: metricContainers[0].metric.timestamp,
+                    timestampNs: metricContainers[0].metric.timestampNs?.toString(),
                     value: metricContainers[0].metric.value
                 };
             }

--- a/uns-ingester-sparkplug/tsconfig.json
+++ b/uns-ingester-sparkplug/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "target": "es2017",
-    "lib": ["es2017", "esnext.asynciterable", "dom"],
+    "target": "es2020",
+    "lib": ["es2020", "esnext.asynciterable", "dom"],
     "typeRoots": ["node_modules/@types"],
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
# Summary

Adds end-to-end nanosecond timestamp support throughout the ACS data pipeline, from edge agent to InfluxDB. Implements Option B from issue #652, repurposing the existing Sparkplug `uint64` timestamp field to carry nanoseconds rather than adding a new metric.

A value-check heuristic (`< 10¹⁵` = milliseconds, `≥ 10¹⁵` = nanoseconds) ensures backward compatibility during the transition period where old and new edge agents coexist.

- **`lib/js-service-client`** - decoder populates `timestampNs: bigint` alongside `timestamp: Date` on all decoded Sparkplug packets; existing consumers are unaffected
- **`acs-edge`** - encodes outgoing timestamps as nanoseconds; auto-stamps all incoming driver data at nanosecond precision via `process.hrtime.bigint()`; extracts `timestampNs` from JSON driver payloads
- **`uns-ingester-sparkplug`** - modifies UNS JSON payloads to reflect nanosecond precision in `timestamp`
- **`historian-sparkplug`** - writes nanosecond timestamps to InfluxDB at `ns` precision
- **`historian-uns`** - reads `timestamp` from UNS payloads and writes to InfluxDB at `ns` precision

# Driver usage

No changes required for existing drivers. To supply a source nanosecond timestamp from a new driver, include `timestampNs` as a numeric string in the JSON payload:

```json
{ "value": 123.45, "timestampNs": "1779983216100923659" }
```

If absent, the edge agent automatically stamps values using process.hrtime.bigint().

# How to test
1. Deploy updated images for acs-edge, uns-ingester-sparkplug, historian-sparkplug, historian-uns
2. Subscribe to UNS/v1/# - payloads should include a modified `timestamp` that now has nanosecond precision
3. Query InfluxDB with Flux, adding map(fn: (r) => ({r with ns: string(v: uint(v: r._time))})) - verify sub-millisecond digits are non-zero
4. Confirm existing millisecond-only drivers continue to work (no timestamp breakage)


<img width="1556" height="581" alt="image" src="https://github.com/user-attachments/assets/bab42883-fbdf-4294-900c-336dc7943d4a" />



# Known gaps
- Tests in acs-edge/tests/lib/helpers/typeHandler.test.ts need updating for new timestampNs parameter in setValueBy* signatures
- Individual driver updates to surface actual source nanosecond timestamps are deferred
- Subscription-based drivers using emit('data', ...) with non-JSON payloads fall back to now_ns() auto-stamping

Closes #652 