### PR TITLE
Small visualiser BIRTH optimisations

### DIFF
--- a/acs-visualiser/public/index.js
+++ b/acs-visualiser/public/index.js
@@ -37,7 +37,7 @@ class FPlusVis {
         vis.run();
         for (const { mqtt } of clients) {
             mqtt.on("packet", vis.make_active.bind(vis));
-            mqtt.on("graph", vis.reset_graph.bind(vis));
+            mqtt.on("graph", vis.reset_soon.bind(vis));
             mqtt.on("schema", u => icons.request_icon(u));
             mqtt.run();
         }

--- a/acs-visualiser/public/mqttclient.js
+++ b/acs-visualiser/public/mqttclient.js
@@ -122,6 +122,10 @@ export default class MQTTClient extends EventEmitter {
     check_for_schema (message, node) {
         node.seen_birth = true;
 
+        /* Decoding a BIRTH payload is expensive, and the schema is
+         * not expected to change across rebirths. */
+        if (node.schema) return;
+
         const payload = SpB.decodePayload(message);
         if (payload.uuid != FactoryPlus)
             return;

--- a/acs-visualiser/public/vis.js
+++ b/acs-visualiser/public/vis.js
@@ -11,6 +11,7 @@ const TURN = 2*Math.PI;
 const HALF = Math.PI;
 const QUARTER = Math.PI/2;
 const FADEOUT = 15000;
+const RESET_DELAY = 250;
 
 function fade (expires, now) {
     const rv = 0.2 + Math.min(0.8, Math.max(0, (expires - now)/FADEOUT));
@@ -155,10 +156,9 @@ export default class Vis {
         const ctx = this.ctx;
 
         for (const n of graph.children) {
-            if (!n.centre) {
-                console.log("No centre for %o", n);
+            /* Nodes added since the last re-layout have no position yet. */
+            if (!n.centre)
                 continue;
-            }
             if (n.is_cmd) 
                 ctx.strokeStyle = Style.CMD;
             else 
@@ -281,6 +281,16 @@ export default class Vis {
         const segment = TURN / this.graph.leaves;
         const ring = this.radius * 0.8 / this.graph.maxdepth;
         this.pick_centres(this.graph, 0, 0, segment, ring);
+    }
+
+    /* A full re-layout per graph change is too expensive when a BIRTH
+     * storm adds many nodes at once; coalesce the requests instead. */
+    reset_soon () {
+        if (this.reset_timer) return;
+        this.reset_timer = setTimeout(() => {
+            this.reset_timer = null;
+            this.reset_graph();
+        }, RESET_DELAY);
     }
 
     make_active (path, style, stopping) {


### PR DESCRIPTION
# Summary

The visualiser stutters badly (and on slower machines freezes for seconds) when BIRTH messages come through, particularly when an edge node rebirths with many devices. Two causes, both fixed here:

1. Every BIRTH was getting a full protobuf decode just to pull out a Schema_UUID we usually already had. BIRTH payloads carry the device's whole metric tree so this is the most expensive decode there is, and rebirths arrive in bursts. We now skip the decode when the node already has a schema; the first BIRTH from a new device still decodes as before so icons are unaffected.
2. Each newly discovered node also triggered an immediate full re-layout of the graph, so one rebirthing edge node with 50 devices meant 50 re-layouts. These are now coalesced behind a 250ms timer. Side effect: new nodes have no position until that layout runs, so the render loop skips them quietly instead of logging every frame.