### PR TITLE
ISA-95 hierarchy editor and device import

### DIFF
--- a/acs-admin/src/App.vue
+++ b/acs-admin/src/App.vue
@@ -76,6 +76,7 @@
         <NewConnectionDialog/>
         <NewBridgeDialog/>
         <NewISA95NodeDialog/>
+        <ImportISA95Dialog/>
         <MonitorDialog/>
         <RouterView/>
       </main>
@@ -103,6 +104,7 @@ import NewConnectionDialog from '@components/EdgeManager/Connections/NewConnecti
 import NewDeviceDialog from '@components/EdgeManager/Devices/NewDeviceDialog.vue'
 import NewBridgeDialog from '@components/Bridges/NewBridgeDialog.vue'
 import NewISA95NodeDialog from '@components/ISA95/NewISA95NodeDialog.vue'
+import ImportISA95Dialog from '@components/ISA95/ImportISA95Dialog.vue'
 import MonitorButton from '@components/MonitorButton.vue'
 import MonitorDialog from '@components/MonitorDialog.vue'
 import { useMonitorStore } from '@store/useMonitorStore.js'
@@ -163,6 +165,7 @@ export default {
     NewConnectionDialog,
     NewBridgeDialog,
     NewISA95NodeDialog,
+    ImportISA95Dialog,
     MonitorButton,
     MonitorDialog,
   },

--- a/acs-admin/src/App.vue
+++ b/acs-admin/src/App.vue
@@ -75,6 +75,7 @@
         <NewDeviceDialog/>
         <NewConnectionDialog/>
         <NewBridgeDialog/>
+        <NewISA95NodeDialog/>
         <MonitorDialog/>
         <RouterView/>
       </main>
@@ -101,6 +102,7 @@ import NewEdgeDeploymentDialog from '@components/EdgeManager/Nodes/NewEdgeDeploy
 import NewConnectionDialog from '@components/EdgeManager/Connections/NewConnectionDialog.vue'
 import NewDeviceDialog from '@components/EdgeManager/Devices/NewDeviceDialog.vue'
 import NewBridgeDialog from '@components/Bridges/NewBridgeDialog.vue'
+import NewISA95NodeDialog from '@components/ISA95/NewISA95NodeDialog.vue'
 import MonitorButton from '@components/MonitorButton.vue'
 import MonitorDialog from '@components/MonitorDialog.vue'
 import { useMonitorStore } from '@store/useMonitorStore.js'
@@ -160,6 +162,7 @@ export default {
     Toaster,
     NewConnectionDialog,
     NewBridgeDialog,
+    NewISA95NodeDialog,
     MonitorButton,
     MonitorDialog,
   },

--- a/acs-admin/src/components/ISA95/ImportISA95Dialog.vue
+++ b/acs-admin/src/components/ISA95/ImportISA95Dialog.vue
@@ -1,0 +1,204 @@
+<!--
+  - Copyright (c) University of Sheffield AMRC 2026.
+  -->
+
+<template>
+  <Dialog :open="isOpen" @update:open="handleOpen">
+    <DialogContent class="sm:max-w-[700px] overflow-y-auto max-h-[80vh]">
+      <DialogHeader>
+        <DialogTitle>Import ISA-95 Hierarchy from Devices</DialogTitle>
+        <DialogDescription>
+          Build the vocabulary from the hierarchy values already saved on your
+          devices. Matching values are linked to existing nodes; new values
+          become new nodes, which you can rename or prune afterwards.
+        </DialogDescription>
+      </DialogHeader>
+
+      <!-- Scanning -->
+      <div v-if="scanning" class="flex items-center justify-center gap-3 py-10 text-gray-500">
+        <i class="fa-solid fa-circle-notch animate-spin"></i>
+        <span>Scanning devices...</span>
+      </div>
+
+      <!-- Preview -->
+      <div v-else-if="plan" class="flex flex-col gap-4">
+        <div class="text-sm text-gray-500">
+          Scanned {{ deviceCount }} device{{ deviceCount === 1 ? '' : 's' }}:
+          {{ plan.stats.imported }} with a hierarchy,
+          {{ plan.stats.no_hierarchy }} without.
+        </div>
+
+        <Alert v-if="plan.stats.ignored_tails > 0">
+          <AlertTitle>Some values cannot be placed</AlertTitle>
+          <AlertDescription>
+            {{ plan.stats.ignored_tails }} device{{ plan.stats.ignored_tails === 1 ? ' has' : 's have' }}
+            hierarchy values below a missing level (for example an Area with no
+            Site). Those values are left on the device but not imported.
+          </AlertDescription>
+        </Alert>
+
+        <div v-if="plan.creates.length === 0 && plan.aliases.length === 0"
+            class="text-center py-6 text-gray-500">
+          <i class="fa-solid fa-check text-green-500 mr-2"></i>
+          Every device hierarchy already matches the vocabulary. Nothing to import.
+        </div>
+
+        <template v-else>
+          <div v-if="plan.creates.length > 0" class="flex flex-col gap-1">
+            <div class="text-sm font-medium">
+              {{ plan.creates.length }} new node{{ plan.creates.length === 1 ? '' : 's' }}
+            </div>
+            <div class="rounded-lg border divide-y max-h-64 overflow-y-auto">
+              <div v-for="c in previewRows" :key="c.key" class="flex items-center gap-2 px-3 py-2 text-sm">
+                <span class="text-gray-400 text-xs uppercase tracking-wide w-24 shrink-0">{{ c.level }}</span>
+                <span class="font-medium">{{ c.name }}</span>
+                <span v-if="c.parent" class="text-gray-400 truncate">under {{ c.parent }}</span>
+              </div>
+            </div>
+          </div>
+
+          <div v-if="plan.aliases.length > 0" class="flex flex-col gap-1">
+            <div class="text-sm font-medium">
+              {{ plan.aliases.length }} alias{{ plan.aliases.length === 1 ? '' : 'es' }} for existing nodes
+            </div>
+            <div class="rounded-lg border divide-y max-h-40 overflow-y-auto">
+              <div v-for="(a, i) in plan.aliases" :key="i" class="flex items-center gap-2 px-3 py-2 text-sm">
+                <span class="font-medium">{{ isa95.by_uuid(a.uuid)?.name ?? a.uuid }}</span>
+                <span class="text-gray-400">also known as</span>
+                <span>{{ a.alias }}</span>
+              </div>
+            </div>
+          </div>
+        </template>
+      </div>
+
+      <DialogFooter>
+        <Button v-if="hasWork" :disabled="scanning || isSubmitting" @click="apply">
+          <div class="flex items-center justify-center gap-2">
+            <i :class="{'fa-solid': true, 'fa-file-import': !isSubmitting, 'fa-circle-notch animate-spin': isSubmitting}"></i>
+            <div>{{ isSubmitting ? 'Importing...' : 'Import' }}</div>
+          </div>
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+</template>
+
+<script>
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@components/ui/dialog'
+import { Button } from '@components/ui/button'
+import { Alert, AlertDescription, AlertTitle } from '@components/ui/alert'
+import { useServiceClientStore } from '@store/serviceClientStore.js'
+import { useDeviceStore } from '@store/useDeviceStore.js'
+import { ISA95_LEVELS, useISA95Store } from '@store/useISA95Store.js'
+import { plan_import, apply_plan } from '@/composables/useISA95Migration.js'
+import { toast } from 'vue-sonner'
+
+export default {
+  setup() {
+    return {
+      s: useServiceClientStore(),
+      device: useDeviceStore(),
+      isa95: useISA95Store(),
+    }
+  },
+
+  components: {
+    Button,
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    Alert,
+    AlertDescription,
+    AlertTitle,
+  },
+
+  async mounted() {
+    window.events.on('show-isa95-import-dialog', () => {
+      this.isOpen = true
+      this.scan()
+    })
+  },
+
+  data() {
+    return {
+      isOpen: false,
+      scanning: false,
+      isSubmitting: false,
+      plan: null,
+      deviceCount: 0,
+    }
+  },
+
+  computed: {
+    hasWork() {
+      return this.plan &&
+        (this.plan.creates.length > 0 || this.plan.aliases.length > 0)
+    },
+    /* Creates in level order, with the parent name resolved for display. */
+    previewRows() {
+      const by_key = new Map(this.plan.creates.map(c => [c.key, c]))
+      const parent_of = new Map()
+      for (const c of this.plan.creates)
+        for (const k of c.children) parent_of.set(k, c.name)
+      for (const l of this.plan.links)
+        parent_of.set(l.child_key, this.isa95.by_uuid(l.parent_uuid)?.name)
+
+      return [...this.plan.creates]
+        .sort((a, b) => ISA95_LEVELS.indexOf(a.level) - ISA95_LEVELS.indexOf(b.level))
+        .map(c => ({ ...c, parent: parent_of.get(c.key) ?? null }))
+    },
+  },
+
+  methods: {
+    handleOpen(open) {
+      this.isOpen = open
+      if (!open) {
+        this.plan = null
+      }
+    },
+
+    async scan() {
+      this.scanning = true
+      this.plan = null
+      try {
+        await this.isa95.start()
+        await this.device.start()
+        await this.device.storeReady()
+        this.deviceCount = this.device.data.length
+        this.plan = plan_import(this.device.data, this.isa95.data)
+      } catch (err) {
+        console.error('Failed to scan devices:', err)
+        toast.error('Failed to scan devices', {
+          description: err.message || 'An unexpected error occurred'
+        })
+        this.isOpen = false
+      } finally {
+        this.scanning = false
+      }
+    },
+
+    async apply() {
+      this.isSubmitting = true
+      try {
+        const result = await apply_plan(this.s.client.ConfigDB, this.plan, this.isa95.data)
+        toast.success('Hierarchy imported', {
+          description: `${result.created} node${result.created === 1 ? '' : 's'} created, ${result.updated} existing node${result.updated === 1 ? '' : 's'} updated.`,
+        })
+        this.isOpen = false
+        this.plan = null
+      } catch (err) {
+        console.error('Failed to import hierarchy:', err)
+        toast.error('Failed to import hierarchy', {
+          description: err.message || 'An unexpected error occurred'
+        })
+      } finally {
+        this.isSubmitting = false
+      }
+    },
+  },
+}
+</script>

--- a/acs-admin/src/components/ISA95/NewISA95NodeDialog.vue
+++ b/acs-admin/src/components/ISA95/NewISA95NodeDialog.vue
@@ -1,0 +1,300 @@
+<!--
+  - Copyright (c) University of Sheffield AMRC 2026.
+  -->
+
+<template>
+  <Dialog :open="isOpen" @update:open="handleOpen">
+    <DialogContent class="sm:max-w-[600px] overflow-y-auto">
+      <DialogHeader>
+        <DialogTitle>{{ isEditMode ? 'Edit Node' : 'Create a New Node' }}</DialogTitle>
+        <DialogDescription>{{ isEditMode ? 'Update this ISA-95 hierarchy node' : 'Add a node to the ISA-95 hierarchy vocabulary' }}</DialogDescription>
+      </DialogHeader>
+      <div class="flex flex-col justify-center gap-4 flex-1 fix-inset">
+        <!-- Level -->
+        <div class="flex flex-col gap-2">
+          <label class="text-sm font-medium">Level <span class="text-red-500">*</span></label>
+          <Select v-model="level" :disabled="isEditMode">
+            <SelectTrigger>
+              <SelectValue>
+                {{ level ?? 'Select a level...' }}
+              </SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectItem v-for="l in ISA95_LEVELS" :value="l" :key="l">
+                  {{ l }}
+                </SelectItem>
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <!-- Name -->
+        <div class="flex flex-col gap-2">
+          <label class="text-sm font-medium">Name <span class="text-red-500">*</span></label>
+          <Input
+            :placeholder="level ? `e.g. ${namePlaceholder}` : 'Select a level first'"
+            v-model="v$.name.$model"
+            :v="v$.name"
+          />
+        </div>
+
+        <!-- Parent -->
+        <div v-if="level && level !== 'Enterprise'" class="flex flex-col gap-2">
+          <label class="text-sm font-medium">Parent {{ parentLevel }} <span class="text-red-500">*</span></label>
+          <Select v-model="parentUuid">
+            <SelectTrigger :class="{'border-red-500': v$.parentUuid.$error}">
+              <SelectValue>
+                {{ parentOptions.find(p => p.uuid === parentUuid)?.name ?? `Select ${parentLevel ? 'a ' + parentLevel : 'a parent'}...` }}
+              </SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectItem v-for="p in parentOptions" :value="p.uuid" :key="p.uuid">
+                  {{ p.name }}
+                </SelectItem>
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+          <p v-if="parentOptions.length === 0" class="text-xs text-gray-500">
+            No {{ parentLevel }} nodes exist yet. Create one first.
+          </p>
+        </div>
+
+        <!-- Aliases -->
+        <div class="flex flex-col gap-1">
+          <label class="text-sm font-medium">Aliases</label>
+          <p class="text-sm text-gray-500">
+            Alternative names that resolve to this node when searching
+          </p>
+          <div class="flex flex-col gap-2 mt-2">
+            <div v-for="(alias, index) in aliases" :key="index" class="flex gap-2">
+              <Input
+                v-model="aliases[index]"
+                placeholder="e.g. F2050"
+                class="flex-1"
+              />
+              <Button variant="ghost" size="icon" @click="removeAlias(index)">
+                <i class="fa-solid fa-trash text-gray-400"></i>
+              </Button>
+            </div>
+            <Button variant="outline" @click="addAlias" class="w-full">
+              <i class="fa-solid fa-plus mr-2"></i>
+              Add Alias
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <DialogFooter :title="v$?.$silentErrors[0]?.$message">
+        <Button :disabled="v$.$invalid || isSubmitting" @click="formSubmit">
+          <div class="flex items-center justify-center gap-2">
+            <i :class="{'fa-solid': true, 'fa-plus': !isEditMode && !isSubmitting, 'fa-save': isEditMode && !isSubmitting, 'fa-circle-notch animate-spin': isSubmitting}"></i>
+            <div>{{ isSubmitting ? (isEditMode ? 'Saving...' : 'Creating...') : (isEditMode ? 'Save Changes' : 'Create Node') }}</div>
+          </div>
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+</template>
+
+<script>
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@components/ui/dialog'
+import { Button } from '@components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { useServiceClientStore } from '@store/serviceClientStore.js'
+import { ISA95_LEVELS, ISA95_LEVEL_CLASSES, useISA95Store } from '@store/useISA95Store.js'
+import useVuelidate from '@vuelidate/core'
+import { helpers, required, requiredIf } from '@vuelidate/validators'
+import { toast } from 'vue-sonner'
+import { UUIDs } from '@amrc-factoryplus/service-client'
+
+const NAME_PLACEHOLDERS = {
+    'Enterprise':  'AMRC',
+    'Site':        'Factory 2050',
+    'Area':        'Machining',
+    'Work Center': 'Cell 3',
+    'Work Unit':   'Robot 1',
+}
+
+export default {
+  setup() {
+    return {
+      v$: useVuelidate(),
+      s: useServiceClientStore(),
+      isa95: useISA95Store(),
+      ISA95_LEVELS,
+    }
+  },
+
+  components: {
+    Button,
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    Input,
+    Select,
+    SelectContent,
+    SelectGroup,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+  },
+
+  async mounted() {
+    window.events.on('show-new-isa95-node-dialog', (node) => {
+      this.reset()
+      if (node) {
+        this.loadNode(node)
+      }
+      this.isa95.start()
+      this.isOpen = true
+    })
+  },
+
+  data() {
+    return {
+      isOpen: false,
+      isSubmitting: false,
+      editUuid: null,
+      originalParentUuid: null,
+      level: null,
+      name: '',
+      parentUuid: null,
+      aliases: [],
+    }
+  },
+
+  validations() {
+    return {
+      level: {
+        required: helpers.withMessage('Select a level', required),
+      },
+      name: {
+        required: helpers.withMessage('Enter a name for the node', required),
+      },
+      parentUuid: {
+        required: helpers.withMessage(
+          'Select a parent node',
+          requiredIf(() => this.level && this.level !== 'Enterprise')),
+      },
+    }
+  },
+
+  computed: {
+    isEditMode() {
+      return this.editUuid !== null
+    },
+    parentLevel() {
+      const index = ISA95_LEVELS.indexOf(this.level)
+      return index > 0 ? ISA95_LEVELS[index - 1] : null
+    },
+    parentOptions() {
+      if (!this.parentLevel) return []
+      return this.isa95.data.filter(n => n.level === this.parentLevel)
+    },
+    namePlaceholder() {
+      return NAME_PLACEHOLDERS[this.level] ?? ''
+    },
+  },
+
+  watch: {
+    level() {
+      /* A node at the old level's parent makes no sense at the new one. */
+      if (!this.isEditMode) this.parentUuid = null
+    },
+  },
+
+  methods: {
+    handleOpen(open) {
+      this.isOpen = open
+      if (!open) this.reset()
+    },
+
+    reset() {
+      this.editUuid = null
+      this.originalParentUuid = null
+      this.level = null
+      this.name = ''
+      this.parentUuid = null
+      this.aliases = []
+      this.v$.$reset()
+    },
+
+    loadNode(node) {
+      this.editUuid = node.uuid
+      this.level = node.level
+      this.name = node.name
+      this.aliases = [...node.aliases]
+      const parents = this.isa95.parents_of(node.uuid)
+      this.parentUuid = parents[0]?.uuid ?? null
+      this.originalParentUuid = this.parentUuid
+    },
+
+    addAlias() {
+      this.aliases.push('')
+    },
+
+    removeAlias(index) {
+      this.aliases.splice(index, 1)
+    },
+
+    async link(parentUuid, childUuid) {
+      const parent = this.isa95.by_uuid(parentUuid)
+      if (!parent || parent.children.includes(childUuid)) return
+      await this.s.client.ConfigDB.put_config(UUIDs.App.ISA95Vocabulary, parentUuid, {
+        aliases: parent.aliases,
+        children: [...parent.children, childUuid],
+      })
+    },
+
+    async unlink(parentUuid, childUuid) {
+      const parent = this.isa95.by_uuid(parentUuid)
+      if (!parent) return
+      await this.s.client.ConfigDB.put_config(UUIDs.App.ISA95Vocabulary, parentUuid, {
+        aliases: parent.aliases,
+        children: parent.children.filter(c => c !== childUuid),
+      })
+    },
+
+    async formSubmit() {
+      this.isSubmitting = true
+      try {
+        const cdb = this.s.client.ConfigDB
+        const aliases = this.aliases.map(a => a.trim()).filter(a => a !== '')
+
+        let uuid = this.editUuid
+        if (!this.isEditMode) {
+          uuid = await cdb.create_object(ISA95_LEVEL_CLASSES[this.level])
+        }
+
+        await cdb.put_config(UUIDs.App.Info, uuid, { name: this.name.trim() })
+        await cdb.put_config(UUIDs.App.ISA95Vocabulary, uuid, {
+          aliases,
+          children: this.isa95.by_uuid(uuid)?.children ?? [],
+        })
+
+        if (this.parentUuid !== this.originalParentUuid) {
+          if (this.originalParentUuid) await this.unlink(this.originalParentUuid, uuid)
+          if (this.parentUuid) await this.link(this.parentUuid, uuid)
+        }
+
+        toast.success(this.isEditMode ? 'Node updated successfully' : 'Node created successfully')
+        this.isOpen = false
+        this.reset()
+      } catch (err) {
+        console.error('Failed to save node:', err)
+        toast.error('Failed to save node', {
+          description: err.message || 'An unexpected error occurred'
+        })
+      } finally {
+        this.isSubmitting = false
+      }
+    },
+  },
+}
+</script>

--- a/acs-admin/src/components/Nav/Nav.vue
+++ b/acs-admin/src/components/Nav/Nav.vue
@@ -63,6 +63,12 @@ const sidebarNavItems: Item[] = [
     href: '/bridges',
     icon: 'arrow-down-up-across-line',
     auth: true
+  },
+  {
+    title: 'ISA-95',
+    href: '/isa95',
+    icon: 'sitemap',
+    auth: true
   }
 ]
 </script>

--- a/acs-admin/src/composables/useISA95Migration.js
+++ b/acs-admin/src/composables/useISA95Migration.js
@@ -1,0 +1,190 @@
+/*
+ * ACS Admin
+ * Build ISA-95 vocabulary nodes from the free-text hierarchy values saved
+ * on existing devices, so an installation can adopt the controlled
+ * vocabulary without retyping its site structure.
+ * Copyright 2026 University of Sheffield AMRC
+ */
+
+import { UUIDs } from '@amrc-factoryplus/service-client'
+
+import { ISA95_LEVELS, ISA95_LEVEL_CLASSES, ISA95_HIERARCHY_KEY }
+    from '@/store/useISA95Store.js'
+
+/* Pull the free-text hierarchy off a device store entry. Returns null when
+ * the device has no hierarchy at all. `chain` is the contiguous run of
+ * values from Enterprise down; `ignored_tail` is true when values exist
+ * below a gap (e.g. an Area with no Site), which cannot be placed in the
+ * tree and are left alone. */
+export function extract_hierarchy (device) {
+    const h = device.deviceInformation?.originMap
+        ?.Device_Information?.[ISA95_HIERARCHY_KEY]
+    if (!h || typeof h !== 'object') return null
+
+    const values = ISA95_LEVELS.map(l => String(h[l]?.Value ?? '').trim())
+    let gap = values.findIndex(v => v === '')
+    if (gap === -1) gap = values.length
+
+    const chain = values.slice(0, gap)
+    if (chain.length === 0) return null
+
+    return {
+        chain,
+        ignored_tail: values.slice(gap).some(v => v !== ''),
+    }
+}
+
+const fold = s => s.trim().toLowerCase()
+
+/* Work out what vocabulary changes are needed to make every device's
+ * hierarchy valid. Pure: takes the device store data and the ISA-95 store
+ * data, touches nothing.
+ *
+ * Matching is scoped to the parent: a device value only matches an
+ * existing node that is a child of the node matched at the level above
+ * (or, for Enterprise, any root). Matching is case-insensitive against
+ * canonical names and aliases. When the typed string differs from the
+ * canonical name, it is recorded as an alias so the device's exact text
+ * resolves to the node.
+ *
+ * Returns:
+ *   creates:  [{ key, level, name, aliases: [], children: [key] }]
+ *             new nodes; children only ever reference other new nodes
+ *   links:    [{ parent_uuid, child_key }]
+ *             new nodes to append to an existing node's children
+ *   aliases:  [{ uuid, alias }]
+ *             aliases to append to existing nodes
+ *   stats:    { imported, no_hierarchy, ignored_tails }
+ */
+export function plan_import (devices, nodes) {
+    const creates = new Map()
+    const links   = []
+    const aliases = []
+    const stats   = { imported: 0, no_hierarchy: 0, ignored_tails: 0 }
+
+    const existing_alias_adds = new Map()
+
+    const match = (scope, value) => scope.find(n =>
+        fold(n.name) === fold(value) ||
+        n.aliases.some(a => fold(a) === fold(value)))
+
+    const ensure_alias = (node, value) => {
+        if (node.name === value) return
+        if (node.aliases.includes(value)) return
+        if (node.key !== undefined) {
+            if (!node.aliases.includes(value)) node.aliases.push(value)
+            return
+        }
+        const pending = existing_alias_adds.get(node.uuid) ?? []
+        if (!pending.includes(value)) {
+            pending.push(value)
+            existing_alias_adds.set(node.uuid, pending)
+        }
+    }
+
+    for (const device of devices) {
+        const h = extract_hierarchy(device)
+        if (!h) {
+            stats.no_hierarchy++
+            continue
+        }
+        if (h.ignored_tail) stats.ignored_tails++
+
+        let parent = null
+        for (let i = 0; i < h.chain.length; i++) {
+            const value = h.chain[i]
+            const level = ISA95_LEVELS[i]
+
+            /* Candidate nodes: children of the matched parent, or roots.
+             * Existing children come from the vocabulary; pending children
+             * come from this plan. */
+            const scope = []
+            if (parent === null) {
+                scope.push(...nodes.filter(n => n.level === level))
+                for (const c of creates.values())
+                    if (c.level === level && c.root) scope.push(c)
+            } else if (parent.key !== undefined) {
+                for (const k of parent.children) scope.push(creates.get(k))
+            } else {
+                for (const uuid of parent.children) {
+                    const n = nodes.find(n => n.uuid === uuid)
+                    if (n) scope.push(n)
+                }
+                for (const l of links)
+                    if (l.parent_uuid === parent.uuid)
+                        scope.push(creates.get(l.child_key))
+            }
+
+            /* Include aliases pending on existing nodes, so two devices
+             * with the same variant spelling match the same node. */
+            let node = match(scope.map(n => n.uuid && existing_alias_adds.has(n.uuid)
+                ? { ...n, aliases: [...n.aliases, ...existing_alias_adds.get(n.uuid)] }
+                : n), value)
+            if (node?.uuid) node = scope.find(n => n.uuid === node.uuid)
+
+            if (!node) {
+                const key = `${i}:${parent ? (parent.key ?? parent.uuid) : ''}:${fold(value)}`
+                node = { key, level, name: value, aliases: [], children: [], root: parent === null }
+                creates.set(key, node)
+                if (parent === null) {
+                    /* Root: nothing to link. */
+                } else if (parent.key !== undefined) {
+                    parent.children.push(key)
+                } else {
+                    links.push({ parent_uuid: parent.uuid, child_key: key })
+                }
+            } else {
+                ensure_alias(node, value)
+            }
+            parent = node
+        }
+        stats.imported++
+    }
+
+    for (const [uuid, add] of existing_alias_adds)
+        for (const alias of add) aliases.push({ uuid, alias })
+
+    return { creates: [...creates.values()], links, aliases, stats }
+}
+
+/* Apply a plan through the ConfigDB client. Creates the new objects first,
+ * then writes every vocabulary config with the real UUIDs resolved. */
+export async function apply_plan (cdb, plan, nodes) {
+    const uuid_of = new Map()
+
+    for (const c of plan.creates) {
+        const uuid = await cdb.create_object(ISA95_LEVEL_CLASSES[c.level])
+        uuid_of.set(c.key, uuid)
+        await cdb.put_config(UUIDs.App.Info, uuid, { name: c.name })
+    }
+
+    for (const c of plan.creates)
+        await cdb.put_config(UUIDs.App.ISA95Vocabulary, uuid_of.get(c.key), {
+            aliases:  c.aliases,
+            children: c.children.map(k => uuid_of.get(k)),
+        })
+
+    /* Merge new children and aliases into existing nodes' configs. */
+    const updates = new Map()
+    const base = uuid => {
+        if (!updates.has(uuid)) {
+            const n = nodes.find(n => n.uuid === uuid)
+            updates.set(uuid, {
+                aliases:  [...(n?.aliases ?? [])],
+                children: [...(n?.children ?? [])],
+            })
+        }
+        return updates.get(uuid)
+    }
+    for (const l of plan.links)
+        base(l.parent_uuid).children.push(uuid_of.get(l.child_key))
+    for (const a of plan.aliases) {
+        const u = base(a.uuid)
+        if (!u.aliases.includes(a.alias)) u.aliases.push(a.alias)
+    }
+
+    for (const [uuid, config] of updates)
+        await cdb.put_config(UUIDs.App.ISA95Vocabulary, uuid, config)
+
+    return { created: plan.creates.length, updated: updates.size }
+}

--- a/acs-admin/src/main.js
+++ b/acs-admin/src/main.js
@@ -27,6 +27,7 @@ import ApplicationObjectEditor from "@pages/ConfigDB/Applications/ApplicationObj
 import ObjectPage from "@pages/ConfigDB/Objects/ObjectPage.vue";
 import Files from "@pages/Files/Files.vue";
 import Bridges from "@pages/Bridges/Bridges.vue";
+import ISA95 from "@pages/ISA95/ISA95.vue";
 
 // Create an event bus
 window.events = mitt()
@@ -150,6 +151,14 @@ const routes = [
     meta: {
       name: 'Bridges',
       icon: 'arrow-down-up-across-line'
+    }
+  },
+  {
+    path: '/isa95',
+    component: ISA95,
+    meta: {
+      name: 'ISA-95',
+      icon: 'sitemap'
     }
   }
 ]

--- a/acs-admin/src/pages/ISA95/ISA95.vue
+++ b/acs-admin/src/pages/ISA95/ISA95.vue
@@ -1,0 +1,208 @@
+<!--
+  - Copyright (c) University of Sheffield AMRC 2026.
+  -->
+
+<template>
+  <BridgesContainer>
+    <Skeleton v-if="!isa95.ready" v-for="i in 10" class="h-16 rounded-lg mb-2"/>
+    <DataTableSearchable v-else
+      :columns="columns"
+      :data="rows"
+      :limit-height="false"
+      :clickable="true"
+      :filters="filters"
+      :selected-objects="[]"
+      :default-sort="initialSort"
+      @row-click="e => nodeClick(e.original)"
+    >
+      <template #toolbar-right>
+        <Button class="gap-2" @click="newNode">
+          <i class="fa-solid fa-plus"></i>
+          <span>New Node</span>
+        </Button>
+      </template>
+      <template #empty>
+        <EmptyState
+          title="No ISA-95 Hierarchy"
+          description="No ISA-95 hierarchy has been configured yet. Create an Enterprise to start building the hierarchy, or import it from the values already saved on your devices."
+          button-text="New Node"
+          button-icon="plus"
+          @button-click="newNode"/>
+      </template>
+    </DataTableSearchable>
+    <template v-slot:sidebar>
+      <!-- Sidebar -->
+      <div v-if="selectedNode" class="w-96 border-l border-border -mr-4">
+        <div class="flex justify-between items-center gap-1 w-full p-4 border-b">
+          <div class="flex items-center gap-2 w-full mr-3">
+            <div class="flex items-center gap-2">
+              <i class="fa-fw fa-solid fa-sitemap"></i>
+              <div class="font-semibold text-xl">Node Details</div>
+            </div>
+            <Button title="Edit Node" size="xs" class="flex gap-1 ml-auto" @click="editNode" variant="ghost">
+              <i class="fa-solid fa-pen text-gray-400"></i>
+            </Button>
+            <Button title="Delete Node" size="xs" class="flex gap-1" @click="deleteNode" variant="ghost">
+              <i class="fa-solid fa-trash text-red-400"></i>
+            </Button>
+          </div>
+        </div>
+        <div class="space-y-4 p-4">
+          <SidebarDetail
+            icon="key"
+            label="Node UUID"
+            :value="selectedNode.uuid"
+          />
+          <SidebarDetail
+            icon="tag"
+            label="Name"
+            :value="selectedNode.name"
+          />
+          <SidebarDetail
+            icon="layer-group"
+            label="Level"
+            :value="selectedNode.level"
+          />
+          <SidebarDetail
+            icon="turn-up"
+            label="Parent"
+            :value="parentNames"
+          />
+          <SidebarDetail
+            icon="tags"
+            label="Aliases"
+            :value="aliasNames"
+          />
+          <SidebarDetail
+            icon="turn-down"
+            label="Children"
+            :value="childNames"
+          />
+        </div>
+      </div>
+    </template>
+  </BridgesContainer>
+</template>
+
+<script>
+import { Button } from "@components/ui/button/index.js";
+import { Skeleton } from "@components/ui/skeleton/index.js";
+import DataTableSearchable from "@components/ui/data-table-searchable/DataTableSearchable.vue";
+import BridgesContainer from '@components/Containers/BridgesContainer.vue';
+import { isa95Columns } from "./isa95Columns.ts";
+import { ISA95_LEVELS, useISA95Store } from "@store/useISA95Store.js";
+import SidebarDetail from "@components/SidebarDetail.vue";
+import EmptyState from '@components/EmptyState.vue';
+import { ref } from "vue";
+import { UUIDs } from "@amrc-factoryplus/service-client";
+import { useDialog } from '@/composables/useDialog';
+import { useServiceClientStore } from "@store/serviceClientStore";
+import { toast } from "vue-sonner";
+
+export default {
+  name: 'ISA95',
+  components: { SidebarDetail, DataTableSearchable, Skeleton, Button, BridgesContainer, EmptyState },
+
+  setup() {
+    return {
+      selectedUuid: ref(null),
+      isa95: useISA95Store(),
+      columns: isa95Columns,
+      s: useServiceClientStore(),
+    }
+  },
+
+  async mounted() {
+    await this.isa95.start();
+  },
+
+  computed: {
+    rows() {
+      return this.isa95.data.map(n => ({
+        ...n,
+        parents: this.isa95.parents_of(n.uuid).map(p => p.name),
+      }));
+    },
+    filters() {
+      return [{
+        name: 'Level',
+        property: 'level',
+        options: ISA95_LEVELS.map(l => ({ label: l, value: l })),
+      }];
+    },
+    initialSort() {
+      return [{
+        id: 'level',
+        desc: false
+      }]
+    },
+    /* Resolve the selection from the store so it stays live after edits. */
+    selectedNode() {
+      if (!this.selectedUuid) return null;
+      return this.isa95.by_uuid(this.selectedUuid) ?? null;
+    },
+    parentNames() {
+      const parents = this.isa95.parents_of(this.selectedUuid).map(p => p.name);
+      return parents.length ? parents.join(', ') : 'None';
+    },
+    aliasNames() {
+      return this.selectedNode.aliases.length ? this.selectedNode.aliases.join(', ') : 'None';
+    },
+    childNames() {
+      const children = this.isa95.children_of(this.selectedUuid).map(c => c.name);
+      return children.length ? children.join(', ') : 'None';
+    },
+  },
+
+  methods: {
+    nodeClick(node) {
+      this.selectedUuid = node?.uuid ?? null;
+    },
+    newNode() {
+      window.events.emit('show-new-isa95-node-dialog')
+    },
+    editNode() {
+      window.events.emit('show-new-isa95-node-dialog', this.selectedNode)
+    },
+    deleteNode() {
+      const node = this.selectedNode;
+      if (node.children.length > 0) {
+        toast.error('This node has children', {
+          description: 'Delete or reassign its children first.',
+        });
+        return;
+      }
+      useDialog({
+        title: 'Delete Node',
+        message: `Are you sure you want to delete "${node.name}"? Devices using this value will no longer match the vocabulary. This action cannot be undone.`,
+        confirmText: 'Delete',
+        onConfirm: async () => {
+          try {
+            const cdb = this.s.client.ConfigDB;
+            /* Unlink from every parent before deleting, so no vocabulary
+             * config is left pointing at a dead UUID. */
+            for (const parent of this.isa95.parents_of(node.uuid)) {
+              await cdb.put_config(UUIDs.App.ISA95Vocabulary, parent.uuid, {
+                aliases: parent.aliases,
+                children: parent.children.filter(c => c !== node.uuid),
+              });
+            }
+            await cdb.delete_object(node.uuid);
+            toast.success('Node deleted successfully');
+            this.selectedUuid = null;
+          } catch (err) {
+            console.error('Failed to delete node:', err);
+            toast.error('Failed to delete node', {
+              description: err.message || 'An unexpected error occurred'
+            });
+          }
+        }
+      })
+    },
+  },
+
+  unmounted() {
+    this.isa95.stop();
+  }
+}
+</script>

--- a/acs-admin/src/pages/ISA95/ISA95.vue
+++ b/acs-admin/src/pages/ISA95/ISA95.vue
@@ -16,6 +16,10 @@
       @row-click="e => nodeClick(e.original)"
     >
       <template #toolbar-right>
+        <Button variant="outline" class="gap-2" @click="importFromDevices">
+          <i class="fa-solid fa-file-import"></i>
+          <span>Import from Devices</span>
+        </Button>
         <Button class="gap-2" @click="newNode">
           <i class="fa-solid fa-plus"></i>
           <span>New Node</span>
@@ -163,6 +167,9 @@ export default {
     },
     editNode() {
       window.events.emit('show-new-isa95-node-dialog', this.selectedNode)
+    },
+    importFromDevices() {
+      window.events.emit('show-isa95-import-dialog')
     },
     deleteNode() {
       const node = this.selectedNode;

--- a/acs-admin/src/pages/ISA95/isa95Columns.ts
+++ b/acs-admin/src/pages/ISA95/isa95Columns.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) University of Sheffield AMRC 2026.
+ */
+
+import type { ColumnDef } from '@tanstack/vue-table'
+import { h } from 'vue'
+
+import DataTableColumnHeader from '@/components/ui/data-table/DataTableColumnHeader.vue'
+
+export interface ISA95Node {
+    uuid: string,
+    name: string,
+    level: string,
+    aliases: string[],
+    children: string[],
+    parents: string[],   // parent names, resolved by the page
+}
+
+export const isa95Columns: ColumnDef<ISA95Node>[] = [
+    {
+        accessorKey: 'name',
+        accessorFn: (row) => row.name,
+        header: ({ column }) => h(DataTableColumnHeader, {
+            column,
+            title: 'Name'
+        }),
+        cell: ({ row }) => {
+            return h('div', { class: 'max-w-[500px] truncate' }, [
+                h('div', { class: 'max-w-[500px] truncate font-medium' }, row.getValue('name')),
+                h('div', { class: 'max-w-[500px] truncate text-gray-400' }, row.original.uuid)
+            ])
+        },
+        filterFn: (row, id, value) => {
+            return value.includes(row.getValue(id))
+        },
+    },
+    {
+        accessorKey: 'level',
+        accessorFn: (row) => row.level,
+        header: ({ column }) => h(DataTableColumnHeader, {
+            column,
+            title: 'Level'
+        }),
+        cell: ({ row }) => h('div', { class: 'truncate' }, row.getValue('level')),
+        filterFn: (row, id, value) => {
+            return value.includes(row.getValue(id))
+        },
+    },
+    {
+        accessorKey: 'parents',
+        accessorFn: (row) => row.parents.join(', ') || 'None',
+        header: ({ column }) => h(DataTableColumnHeader, {
+            column,
+            title: 'Parent'
+        }),
+        cell: ({ row }) => h('div', {
+            class: row.original.parents.length ? 'truncate' : 'truncate text-gray-400'
+        }, row.getValue('parents')),
+    },
+    {
+        accessorKey: 'aliases',
+        accessorFn: (row) => row.aliases.join(', '),
+        header: ({ column }) => h(DataTableColumnHeader, {
+            column,
+            title: 'Aliases'
+        }),
+        cell: ({ row }) => {
+            const aliases = row.original.aliases
+            return aliases.length
+                ? h('div', { class: 'max-w-[300px] truncate' }, aliases.join(', '))
+                : h('div', { class: 'text-gray-400' }, 'None')
+        },
+    },
+]

--- a/acs-admin/src/store/useISA95Store.js
+++ b/acs-admin/src/store/useISA95Store.js
@@ -27,6 +27,15 @@ export const ISA95_LEVELS = [
     'Work Unit',
 ]
 
+/* ConfigDB class holding the nodes at each level. */
+export const ISA95_LEVEL_CLASSES = {
+    'Enterprise':  UUIDs.Class.ISA95Enterprise,
+    'Site':        UUIDs.Class.ISA95Site,
+    'Area':        UUIDs.Class.ISA95Area,
+    'Work Center': UUIDs.Class.ISA95WorkCenter,
+    'Work Unit':   UUIDs.Class.ISA95WorkUnit,
+}
+
 export const useISA95Store = defineStore('isa95', {
     state: () => ({
         data:   [],
@@ -50,6 +59,10 @@ export const useISA95Store = defineStore('isa95', {
                 .filter(Boolean)
         },
 
+        /* Nodes whose children list includes the given UUID. */
+        parents_of: (state) => (uuid) =>
+            state.data.filter(n => n.children.includes(uuid)),
+
         /* Find a node at a given level by its canonical name or an alias. */
         find_by_name: (state) => (level, name) =>
             state.data.find(n =>
@@ -65,16 +78,8 @@ export const useISA95Store = defineStore('isa95', {
             await serviceClientReady()
             const cdb = useServiceClientStore().client.ConfigDB
 
-            const level_classes = {
-                'Enterprise':  UUIDs.Class.ISA95Enterprise,
-                'Site':        UUIDs.Class.ISA95Site,
-                'Area':        UUIDs.Class.ISA95Area,
-                'Work Center': UUIDs.Class.ISA95WorkCenter,
-                'Work Unit':   UUIDs.Class.ISA95WorkUnit,
-            }
-
             const member_obs = Object.fromEntries(
-                Object.entries(level_classes).map(([level, class_uuid]) => [
+                Object.entries(ISA95_LEVEL_CLASSES).map(([level, class_uuid]) => [
                     level,
                     cdb.watch_members(class_uuid),
                 ])


### PR DESCRIPTION
# ISA-95 hierarchy editor and device import

## Summary

Adds a first-party editor for the ISA-95 controlled vocabulary introduced by #663, plus a one-click migration that builds the vocabulary from the free-text hierarchy values already saved on devices.

Built on #663, which merged this morning.

## Changes

### ISA-95 page (`acs-admin/src/pages/ISA95/`)

A new top-level "ISA-95" nav entry, following the same shape as the Bridges page: searchable table of all vocabulary nodes (name, level, parent, aliases) with a Level filter, and a details sidebar with edit/delete actions.

- **Create/edit dialog**: level, name, parent (required for non-Enterprise levels so every node stays reachable from a root), and an alias list. Creates the ConfigDB object in the right level class, names it via the Info app, writes the `ISA95Vocabulary` config and links it into the parent's `children`.
- **Delete**: unlinks the node from every parent before deleting so no vocabulary config points at a dead UUID. Nodes with children can't be deleted - prune bottom-up instead of orphaning subtrees.

### Import from Devices (`useISA95Migration.js`, `ImportISA95Dialog.vue`)

Scans every device's origin map for `Device_Information.ISA95_Hierarchy` values, shows a preview (new nodes with their parents, aliases to add, devices skipped), then applies. Notable behaviour:

- **Scoped matching**: a value only matches a node that is a child of the node matched at the level above, so "Building 1" under two different enterprises stays two nodes - no cross-tree merging.
- **Case-insensitive with alias capture**: `amrc` matches canonical `AMRC`, and the typed variant is saved as an alias so the device's exact text resolves against the vocabulary.
- **Gaps**: values below a missing level (an Area with no Site) can't be placed in the tree; they're counted, reported in the preview, and left on the device untouched.
- The planning logic is a pure module with the ConfigDB writes confined to `apply_plan`, so it's testable without a browser.

### Store (`useISA95Store.js`)

Exports the level-to-class map and adds a `parents_of` getter alongside the existing `children_of`.

## How to test

1. Open the new **ISA-95** nav entry. With no vocabulary, you get an empty state.
2. Create an Enterprise, then a Site under it. The parent dropdown for a Site only offers Enterprises, and is required.
3. Open a device with hierarchy values typed in (or set some free text via the metric editor on a pre-#663 build), then use **Import from Devices**. The preview should show the chain of new nodes; import and check the Device page's ISA-95 panel now resolves those values.
4. Re-run the import: it should report nothing to do.
5. Save a device value differing only in case from a canonical name, re-import: no new node, the variant appears as an alias on the existing node.
6. Try to delete a node with children: refused with a toast. Delete a leaf: it disappears from its parent's children list in the sidebar.

## Testing done

- Migration planning/apply logic covered by a 20-case harness driven against the real module (scoped matching, alias capture and dedup, gap handling, existing-node merges, ConfigDB call contents via a mock client).
- `vite build` passes; new modules confirmed present in the bundle.
- No UI-in-browser testing - needs a review pass on a live install.

## Release notes

A first-party editor for the ISA-95 hierarchy vocabulary is available under "ISA-95" in the admin UI, including a one-click import that builds the vocabulary from the hierarchy values already saved on existing devices.
