### PR TITLE
Support client-credentials OIDC clients via serviceAccountsEnabled

### DIFF
--- a/acs-service-setup/lib/openid.js
+++ b/acs-service-setup/lib/openid.js
@@ -256,7 +256,14 @@ class OpenIDSetup {
             publicClient,
             standardFlowEnabled: spec.standardFlowEnabled ?? true,
             directAccessGrantsEnabled: spec.directAccessGrantsEnabled ?? false,
-            serviceAccountsEnabled: false,
+            // Enables the OAuth client-credentials grant (Keycloak
+            // "service account") for machine-to-machine consumers, e.g.
+            // an unattended kiosk fetching a Grafana JWT. Keycloak only
+            // supports service accounts on confidential clients, so
+            // this cannot be combined with publicClient. A pure
+            // service client should also set standardFlowEnabled:
+            // false - it has no browser login to redirect.
+            serviceAccountsEnabled: !publicClient && !!spec.serviceAccountsEnabled,
             rootUrl: spec.rootUrl ?? root,
             baseUrl: spec.baseUrl ?? root,
             redirectUris: spec.redirectUris

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -218,6 +218,20 @@ serviceSetup:
     #   redirectUris            (list of full URLs)
     #   webOrigins              (list of origins)
     #   postLogoutRedirectUris  (list of full URLs)
+    #
+    # Machine-to-machine clients: set `serviceAccountsEnabled: true` to
+    # enable the OAuth client-credentials grant (Keycloak "service
+    # account") so an unattended consumer - a kiosk, a scheduled job -
+    # can exchange the generated client_secret for tokens with no
+    # human login. Such clients are necessarily confidential (ignored
+    # if publicClient is set) and should also set
+    # `standardFlowEnabled: false`: they have no browser flow, so no
+    # redirect URIs are ever exercised. Example:
+    #   polyptic-kiosk:
+    #     enabled: true
+    #     name: Polyptic kiosk
+    #     serviceAccountsEnabled: true
+    #     standardFlowEnabled: false
     openidClients:
       grafana:
         enabled: true


### PR DESCRIPTION
## What

`ensure_client` in acs-service-setup hardcoded `serviceAccountsEnabled: false`, so no client declared in `serviceSetup.config.openidClients` could use the OAuth client-credentials grant. This passes the flag through from the per-client values spec, exactly like the other flow flags (`standardFlowEnabled`, `directAccessGrantsEnabled`, `deviceAuthorizationFlowEnabled`), and documents it in `values.yaml` with an example.

Guarded to confidential clients: Keycloak does not support service accounts on public clients, so `publicClient: true` wins and the flag is ignored.

## Why

Machine-to-machine consumers need a way to obtain tokens from the realm with no human login. First consumer: Polyptic display walls fetching Grafana JWTs unattended (Grafana `[auth.jwt]` + `url_login`) — an operator declares:

```yaml
serviceSetup:
  config:
    openidClients:
      polyptic-kiosk:
        enabled: true
        name: Polyptic kiosk
        serviceAccountsEnabled: true
        standardFlowEnabled: false   # no browser flow
```

and the existing machinery does the rest — the chart already generates a stable client secret for any enabled non-builtin entry (`keycloak-clients` Secret), and service-setup already applies per-client overrides idempotently.

## Notes

- No chart template changes; the spec flows to service-setup verbatim, so this is service-setup code + values docs only.
- Pure service clients get the F+ claim mappers like every other client; the mappers are harmless for a service account with no F+ principal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)