### PR TITLE
Upgrade bundled Grafana from 10.0.1 to 13.1.0

### DIFF
--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -451,7 +451,10 @@ grafana:
   deploymentStrategy:
     type: Recreate
   image:
-    tag: 10.0.1
+    # v13 migrates dashboards to a new schema ON FIRST USE and the migration
+    # is one-way — see "Grafana upgraded from v10 to v13" in the release
+    # notes before downgrading this on an existing installation.
+    tag: 13.1.0
   enabled: true
   persistence:
     enabled: true

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -83,6 +83,36 @@ Setting `openid.enabled` to `false` will skip Keycloak, but Grafana then
 has no interactive login other than the local emergency admin account,
 which remains reachable at `/login?disableLoginForm=false`.
 
+### Grafana upgraded from v10 to v13
+
+The bundled Grafana image moves from 10.0.1 to 13.1.0. Grafana 10.x
+left support in 2024, so this catches up two majors of security fixes,
+and the newer `auth.jwt` support is what lets machine-to-machine
+consumers sign in with tokens (see below).
+
+Three upstream Grafana changes are worth knowing about when upgrading
+an existing installation:
+
+- Dashboards are migrated to Grafana's new dashboard schema as they are
+  used, and the migration is one-way: once v13 has written to the
+  Grafana database you cannot return to the previous image without
+  losing dashboards. Snapshot the Grafana PersistentVolume before
+  upgrading if the dashboards matter.
+- Support for AngularJS plugins has been removed (disabled by default
+  in Grafana 11, gone entirely in 12). Grafana's built-in panels are
+  unaffected and legacy Graph/Table panels are migrated automatically,
+  but any third-party Angular panel or data source plugin will no
+  longer render. Audit your dashboards for these before upgrading.
+- Links that deep-link a single panel changed format in Grafana 11
+  (`?viewPanel=5` became `?viewPanel=panel-5-…`), so bookmarks and
+  kiosk URLs pointing at individual panels need re-copying from the new
+  UI. Links to whole dashboards, including kiosk-mode links, are
+  unchanged.
+
+Also removed upstream, though ACS does not deploy either: the image
+renderer plugin and legacy alerting. If you added one of those to your
+own installation, migrate off it before upgrading.
+
 ### Machine-to-machine OIDC clients
 
 Clients declared under `serviceSetup.config.openidClients` may now set


### PR DESCRIPTION
## What

Bumps the default Grafana image from **10.0.1** (June 2023, out of support since 2024) to **13.1.0** (current stable), and documents the operator-facing consequences in the v6.0.0 release notes.

## Why

- Two majors of security fixes on a network-facing, credential-holding component.
- The newer `[auth.jwt]` support is what machine-to-machine consumers (#668) use to sign in with tokens — including the dev-mode JWKS exemption needed on non-TLS test deployments (the https-scheme check is unconditional in 10.0.1; verified conditional in 12.x/13.1.0 source).
- Removes per-deployment drift: existing dev clusters already override the tag upwards.

## Breaking changes documented (from the Grafana 10 baseline)

- **One-way dashboard schema migration** in v13 — snapshot the Grafana PV before upgrading; no downgrade after.
- **AngularJS plugin removal** (disabled in 11, gone in 12) — core panels fine, legacy Graph/Table auto-migrate, third-party Angular plugins stop rendering.
- **`viewPanel` deep-link format change** (11) — single-panel bookmarks/kiosk URLs need re-copying; whole-dashboard links unchanged.
- Image renderer plugin + legacy alerting removed upstream — ACS deploys neither.

Not touched: the Grafana Helm chart dependency stays at 6.52.4; this is an image bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)