### PR TITLE
Fix unbounded subscription leak in auth ACL tracking

### DIFF
--- a/acs-auth/lib/dataflow.js
+++ b/acs-auth/lib/dataflow.js
@@ -200,13 +200,20 @@ export class DataFlow {
         const principal$ = valid_uuid(input)
             ? rx.of(input)
             : this.track_kerberos(input);
+        /* switchMap, not mergeMap: mergeMap keeps every inner
+         * subscription alive, so each re-emission of the principal
+         * (one per identity write, via the identities refetch) added
+         * another permanent subscription to acl_for. Long-lived
+         * notify sessions accumulated these without bound and every
+         * subsequent emission fanned out through all of them. */
         return rxx.rx(
             principal$,
-            rx.mergeMap(p => p ? this.acl_for(p) : rx.of([])),
+            rx.switchMap(p => p ? this.acl_for(p) : rx.of([])),
             rx.map(acl => imm.Seq(acl)
                 .filter(e => e.permission == perm)
                 .map(e => e.target)
                 .toSet()),
+            rx.distinctUntilChanged(imm.is),
             rx.tap(ptd =>
                 this.log("Permitted %s for %s: %o", perm, input, ptd.toJS())));
     }
@@ -288,10 +295,15 @@ export class DataFlow {
     }
 
     track_kerberos (upn) {
+        /* The identities seq refetches the whole table on every
+         * identity write, so it re-emits equal content freely. Dedupe
+         * on the resolved UUID so downstream pipelines only see a
+         * change when the mapping actually changes. */
         return rxx.rx(
             this.identities,
             rx.map(ids => ids.filter(i => i.kind == "kerberos" && i.name == upn)),
-            rx.map(acc => acc[0]?.uuid));
+            rx.map(acc => acc[0]?.uuid),
+            rx.distinctUntilChanged());
     }
 
     find_kerberos (upn) {


### PR DESCRIPTION
## Summary

Fixes an unbounded rxjs subscription leak in the auth service's ACL tracking that can peg the event loop and take the whole cluster down with it.

`DataFlow.track_targets` used `mergeMap` over the principal stream. `track_kerberos` re-emits the resolved principal UUID on every identities refetch, and `_track_model` refetches the whole identity table on *every* identity write. `mergeMap` keeps each inner `acl_for` subscription alive forever, so every long-lived notify session (configdb, cmdesc, git, cluster-manager all hold one) accumulated one more permanent inner subscription per identity write. Each subsequent emission then fanned out through all of them.

Observed on a fresh v6.0.0-rc.1 install (where bootstrap writes many identities): auth pinned at a full CPU core writing ~5,600 log lines/second of ACL dumps, fast enough to roll the container log over in about 20 seconds. While it spun, HTTP requests queued: the HiveMQ Kerberos plugin timed out (5s) so every service got "Bad User Name or Password" from MQTT and hammered reconnects, and the Keycloak federation SPI hit its 3s hard limit, making Grafana/Keycloak admin login impossible.

## The fix

- `track_targets`: `mergeMap` → `switchMap`, so re-resolution of the principal replaces the inner subscription instead of adding one.
- `track_kerberos`: `distinctUntilChanged()` on the resolved UUID, so equal-content identity refetches don't propagate at all.
- `track_targets`: `distinctUntilChanged(imm.is)` on the computed target set, so downstream `combineLatest` pipelines (notify `_get_acl`, `permitted`) only re-fire when the ACL genuinely changes. This also moves the "Permitted" log line onto real changes only.

## Verification

Drove the real `DataFlow.track_targets`/`track_kerberos` methods with a stubbed identities stream and a counting `acl_for`:

| | emissions after 51 identity refetches | concurrent inner subscriptions |
|---|---|---|
| before | 51 | 51 (leak) |
| after | 1 | 1 |

## How to test

1. Deploy a fresh cluster from this branch (or restart the auth pod on an affected one).
2. Rotate a KerberosKey or otherwise cause identity writes while configdb et al hold notify sessions.
3. `kubectl top pod` on auth should stay in single-digit millicores and the log should not storm with `ACL update` / `Permitted` dumps.
4. Grafana login via Keycloak succeeds.

## Notes

The `XXX` full-refetch in `_track_model` is untouched: refetches are now harmless to downstream subscribers, but each write still costs one full-table read. Deduping the notify `Response` bodies for `grants` churn is a possible follow-up; grant writes still produce one notify update per subscriber.
