### PR TITLE
Keep Keycloak SPI timeout below Keycloak's 3s hard limit

### DIFF
--- a/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/FactoryPlusUserStorageProviderFactory.java
+++ b/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/FactoryPlusUserStorageProviderFactory.java
@@ -56,7 +56,12 @@ public class FactoryPlusUserStorageProviderFactory
     static final String CONFIG_KRB_PRINCIPAL      = "auth.principal";
     static final String CONFIG_KRB_KEYTAB_PATH    = "auth.keytab.path";
     static final String CONFIG_DEFAULT_REALM      = "default.realm";
-    static final String DEFAULT_TIMEOUT_SECONDS   = "5";
+    /* Must stay below Keycloak's 3-second ServicesUtils.timeBoundOne
+     * hard limit on user-storage lookups. With a longer value our own
+     * timeout can never fire: Keycloak interrupts the thread first and
+     * the admin sees an opaque InterruptedException instead of a clean
+     * timeout naming the F+ auth service. */
+    static final String DEFAULT_TIMEOUT_SECONDS   = "2";
     static final String DEFAULT_CACHE_TTL_SECONDS = "60";
 
     private static final List<ProviderConfigProperty> CONFIG_PROPERTIES =
@@ -73,7 +78,10 @@ public class FactoryPlusUserStorageProviderFactory
             .property()
                 .name(CONFIG_TIMEOUT_SECONDS)
                 .label("Request timeout (seconds)")
-                .helpText("Per-request timeout for F+ auth calls.")
+                .helpText("Per-request timeout for F+ auth calls. Keep "
+                    + "this below 3 seconds: Keycloak hard-kills user "
+                    + "storage lookups at 3s, so a longer value here "
+                    + "never takes effect.")
                 .type(ProviderConfigProperty.STRING_TYPE)
                 .defaultValue(DEFAULT_TIMEOUT_SECONDS)
                 .add()

--- a/acs-service-setup/lib/openid.js
+++ b/acs-service-setup/lib/openid.js
@@ -183,7 +183,11 @@ class OpenIDSetup {
             parentId: realmUuid,
             config: {
                 "auth.url":             [this.auth_internal_url],
-                "auth.timeout.seconds": ["5"],
+                // Must stay below Keycloak's 3s hard limit on user
+                // storage lookups; a longer value never takes effect
+                // and slow F+ auth calls surface as an opaque
+                // InterruptedException instead of a clean timeout.
+                "auth.timeout.seconds": ["2"],
                 "cache.ttl.seconds":    ["60"],
                 // Disable Keycloak's per-user attribute cache for this
                 // federation. With the default (DEFAULT, cache forever)


### PR DESCRIPTION
## Summary

Keycloak hard-kills user-storage lookups after 3 seconds (`ServicesUtils.timeBoundOne`). The Factory+ federation SPI defaulted its own per-request timeout to 5 seconds, and service-setup provisioned the same value into the federation component, so the SPI's timeout could never fire: Keycloak always interrupted the thread first.

The functional consequence is diagnostic, not behavioural. When the F+ auth service is slow (as during the ACL storm fixed by #671), login fails either way, but the log shows an opaque `InterruptedException` inside `HttpClientImpl.send` instead of a clean `HttpTimeoutException` naming the F+ auth call. That cost real time when diagnosing the rc.1 login failure.

## Changes

- `FactoryPlusUserStorageProviderFactory.DEFAULT_TIMEOUT_SECONDS`: 5 → 2, with a comment explaining the 3s ceiling.
- The `auth.timeout.seconds` help text now warns that values of 3s or more never take effect.
- `acs-service-setup/lib/openid.js`: provisioned federation config 5 → 2 to match.

## How to test

1. `mvn test` in `acs-keycloak-spi`: 80 tests, all passing.
2. On a deployed cluster, block the auth service (e.g. scale it to 0) and attempt a Grafana login. The openid pod log should show a timeout exception naming `http://auth.factory-plus...` after ~2s rather than an `InterruptedException` at 3s.
3. Re-run service-setup; the federation component in Keycloak (Admin console → User federation → factoryplus) should show Request timeout = 2.
