### PR TITLE
Grant krb-keys-operator RBAC for localsecrets

### DIFF
--- a/deploy/templates/identity/rbac.yaml
+++ b/deploy/templates/identity/rbac.yaml
@@ -12,11 +12,18 @@ kind: ClusterRole
 metadata:
   name: krb-keys-operator
 rules:
+  # localsecrets is included because the operator registers a
+  # LocalSecret handler unconditionally, and the CRD arrives on the
+  # central cluster as soon as the first edge cluster is provisioned
+  # (it ships in the edge-cluster chart's crds/). Without this rule
+  # kopf's watch crash-loops with a 403 from that point on. The edge
+  # chart (edge-cluster/templates/krb-keys.yaml) already grants the
+  # same set.
   -   apiGroups: [factoryplus.app.amrc.co.uk]
-      resources: [kerberos-keys]
+      resources: [kerberos-keys, localsecrets]
       verbs: [list, get, watch, patch]
   -   apiGroups: [factoryplus.app.amrc.co.uk]
-      resources: [kerberos-keys/status]
+      resources: [kerberos-keys/status, localsecrets/status]
       verbs: [list, get, create, update, delete, watch, patch]
   -   apiGroups: [""]
       resources: [secrets]


### PR DESCRIPTION
## Summary

The central krb-keys-operator crash-loops its kopf watch with `APIForbiddenError: cannot list resource "localsecrets"` on any cluster that has (or has ever had) an edge cluster provisioned.

The operator registers a `LocalSecret` handler unconditionally, but the `localsecrets` CRD is only shipped by the edge-cluster chart. When the first edge cluster is provisioned the CRD gets installed on the central cluster too, kopf notices the now-served resource and tries to watch it, and the central `krb-keys-operator` ClusterRole - which only covers `kerberos-keys` - denies it. kopf then retries with backoff and escalates roughly every minute, forever.

The edge chart's own role (`edge-cluster/templates/krb-keys.yaml`) already grants `localsecrets` and `localsecrets/status`; the central chart just never got the matching rules. This mirrors them exactly.

## How to test

1. `helm template deploy -s templates/identity/rbac.yaml` - the ClusterRole now lists `[kerberos-keys, localsecrets]` and `[kerberos-keys/status, localsecrets/status]`.
2. Upgrade a cluster that has at least one edge cluster (so the CRD exists), restart the krb-keys-operator pod.
3. The operator log should no longer show the once-a-minute `APIForbiddenError ... localsecrets` traceback.
