### PR TITLE
Stop requesting GSS credential delegation (TGT NOT FORWARDABLE storm)

### DIFF
--- a/lib/js-gssapi/.gitignore
+++ b/lib/js-gssapi/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+build
+package-lock.json

--- a/lib/js-gssapi/CMakeLists.txt
+++ b/lib/js-gssapi/CMakeLists.txt
@@ -1,0 +1,52 @@
+cmake_minimum_required(VERSION 3.9)
+cmake_policy(SET CMP0042 NEW)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+project (node-gssapi)
+
+set(KRB5_DIR
+    "$ENV{KRB5_DIR}"
+    CACHE
+    PATH
+    "Root of MIT Kerberos source tree (optional).")
+mark_as_advanced(KRB5_DIR)
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  set (bit_suffix 64)
+else()
+  set (bit_suffix 32)
+endif()
+
+find_path(KRB5_INCLUDE_DIR krb5.h PATHS ${KRB5_DIR}/include)
+mark_as_advanced(KRB5_INCLUDE_DIR)
+find_library(KRB5_KRB5_LIB NAMES krb5 "krb5_${bit_suffix}" PATHS ${KRB5_DIR}/lib ${KRB5_DIR}/lib/amd64 ${KRB5_DIR}/lib/i386})
+find_library(KRB5_COM_ERR_LIB NAMES com_err "comerr${bit_suffix}" PATHS ${KRB5_DIR}/lib ${KRB5_DIR}/lib/amd64 ${KRB5_DIR}/lib/i386})
+find_library(KRB5_GSSAPI_LIB NAMES gssapi_krb5 "gssapi${bit_suffix}" PATHS ${KRB5_DIR}/lib ${KRB5_DIR}/lib/amd64 ${KRB5_DIR}/lib/i386})
+
+set(KRB5_LIBRARIES
+    ${KRB5_KRB5_LIB}
+    ${KRB5_COM_ERR_LIB}
+    ${KRB5_GSSAPI_LIB}
+    )
+mark_as_advanced(KRB5_LIBRARIES)
+
+if (NOT KRB5_KRB5_LIB OR NOT KRB5_COM_ERR_LIB OR NOT KRB5_GSSAPI_LIB)
+message(FATAL_ERROR "Could not find all Kerberos libraries. Perhaps you need to set KRB5_DIR in your environment")
+endif()
+
+execute_process(COMMAND node -p "require('node-addon-api').include"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE NODE_ADDON_API_DIR
+    )
+string(REPLACE "\n" "" NODE_ADDON_API_DIR ${NODE_ADDON_API_DIR})
+string(REPLACE "\"" "" NODE_ADDON_API_DIR ${NODE_ADDON_API_DIR})
+
+
+add_library(node-gssapi SHARED src/bind.cc src/module.cc ${CMAKE_JS_SRC})
+target_include_directories(node-gssapi PRIVATE  ${CMAKE_JS_INC} ${NODE_ADDON_API_DIR} ${KRB5_INCLUDE_DIR})
+target_link_libraries(node-gssapi PRIVATE ${CMAKE_JS_LIB} ${KRB5_LIBRARIES})
+set_target_properties(node-gssapi PROPERTIES PREFIX "" SUFFIX ".node")
+target_compile_definitions(node-gssapi PUBLIC -DNAPI_VERSION=5)

--- a/lib/js-gssapi/LICENSE
+++ b/lib/js-gssapi/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 jalfd
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/js-gssapi/README.md
+++ b/lib/js-gssapi/README.md
@@ -1,0 +1,38 @@
+# @amrc-factoryplus/gssapi
+
+GSSAPI bindings for Node.js.
+
+This is a fork of [gssapi.js](https://www.npmjs.com/package/gssapi.js)
+2.0.1 (upstream: `bitbucket:karoshealth/node-gssapi`, MIT licence).
+
+The JS API is identical to upstream. There is one behavioural change:
+
+## No credential delegation
+
+Upstream passes `GSS_C_DELEG_FLAG` unconditionally to
+`gss_init_sec_context`. That makes libkrb5 request a forwarded TGT
+from the KDC on *every* client context creation, i.e. on every
+Factory+ HTTP token fetch and MQTT connection. When the client's TGT
+is not forwardable (the normal case for ACS service principals, whose
+TGTs come straight from a keytab) the KDC refuses the request:
+
+    TGS_REQ ... TGT NOT FORWARDABLE: authtime ...,
+        sv1xxx@REALM for krbtgt/REALM@REALM,
+        KDC can't fulfill requested option
+
+libkrb5 then silently drops the flag and carries on without
+delegation, so the only effects are a wasted KDC round trip per token
+and a KDC log line per request. Under load (service reconnect storms)
+this multiplies into significant KDC noise and traffic.
+
+Nothing in Factory+ consumes delegated credentials - the server side
+(`acceptSecContext`) discards them - so this fork simply does not
+request delegation. If a future service genuinely needs delegation it
+should be added as an explicit per-context option, not a global
+default.
+
+## Building
+
+Native module built with cmake-js at install time; requires cmake and
+MIT Kerberos headers/libraries (`libkrb5-dev` on Debian). Unchanged
+from upstream.

--- a/lib/js-gssapi/dist/index.d.ts
+++ b/lib/js-gssapi/dist/index.d.ts
@@ -1,0 +1,23 @@
+/// <reference types="node" />
+export interface ClientContextOptions {
+    krbCcache?: string;
+    server: string;
+    mech?: "krb5" | "spnego";
+}
+export interface GssSecContext {
+    isComplete(): boolean;
+}
+export interface ServerGssSecContext extends GssSecContext {
+    clientName(): string;
+}
+export declare function createClientContext(options: ClientContextOptions): GssSecContext;
+export declare function createServerContext(): ServerGssSecContext;
+export declare function initSecContext(ctx: GssSecContext, token?: Buffer): Promise<Buffer>;
+export declare function acceptSecContext(ctx: ServerGssSecContext, token: Buffer): Promise<Buffer>;
+export declare function setKeytabPath(path: string): undefined;
+export declare function verifyCredentials(username: string, password: string, options?: {
+    keytab?: string;
+    serverPrincipal?: string;
+}): Promise<void>;
+export declare function kinit(ccname: string, username: string, password: string): Promise<string>;
+export declare function kdestroy(ccname: string): Promise<undefined>;

--- a/lib/js-gssapi/dist/index.js
+++ b/lib/js-gssapi/dist/index.js
@@ -1,0 +1,55 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.kdestroy = exports.kinit = exports.verifyCredentials = exports.setKeytabPath = exports.acceptSecContext = exports.initSecContext = exports.createServerContext = exports.createClientContext = void 0;
+const gssapi = require('bindings')('node-gssapi');
+function createClientContext(options) {
+    if (('krbCcache' in options) && typeof options.server !== 'string') {
+        throw new Error('"krbCcache" is specified, it must be a string');
+    }
+    if (typeof options.server !== 'string') {
+        throw new Error('"server" property must be a string');
+    }
+    if (typeof options.mech === 'string' && !['spnego', 'krb5'].includes(options.mech)) {
+        throw new Error('If "mech" is specified, it must be set to either "spnego" or "krb5"');
+    }
+    return new gssapi.GssSecContext(options.krbCcache || '', options.server || '', options.mech || '');
+}
+exports.createClientContext = createClientContext;
+function createServerContext() {
+    return new gssapi.GssSecContext('', '', '');
+}
+exports.createServerContext = createServerContext;
+async function initSecContext(ctx, token) {
+    if (token === undefined) {
+        token = Buffer.alloc(0);
+    }
+    return gssapi.initSecContext(ctx, token);
+}
+exports.initSecContext = initSecContext;
+async function acceptSecContext(ctx, token) {
+    return gssapi.acceptSecContext(ctx, token);
+}
+exports.acceptSecContext = acceptSecContext;
+function setKeytabPath(path) {
+    if (typeof path !== 'string') {
+        throw new Error("Keytab Path must be a string");
+    }
+    return gssapi.setKeytabPath(path);
+}
+exports.setKeytabPath = setKeytabPath;
+async function verifyCredentials(username, password, options) {
+    if (!options) {
+        options = {};
+    }
+    return gssapi.verifyCredentials(username, password, options.keytab || "", options.serverPrincipal || "");
+}
+exports.verifyCredentials = verifyCredentials;
+async function kinit(ccname, username, password) {
+    return gssapi.kinit(ccname, username, password);
+}
+exports.kinit = kinit;
+async function kdestroy(ccname) {
+    return gssapi.kdestroy(ccname).then(() => { });
+}
+exports.kdestroy = kdestroy;
+//# sourceMappingURL=index.js.map

--- a/lib/js-gssapi/package.json
+++ b/lib/js-gssapi/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@amrc-factoryplus/gssapi",
+  "version": "2.1.0",
+  "description": "GSSAPI bindings for Node.js. AMRC fork of gssapi.js without credential delegation.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/index.js",
+    "dist/index.d.ts",
+    "CMakeLists.txt",
+    "src/*"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "github:AMRC-FactoryPlus/amrc-connectivity-stack",
+    "directory": "lib/js-gssapi"
+  },
+  "scripts": {
+    "install": "cmake-js compile"
+  },
+  "author": "Jesper Alf Dam <jdam@vitalimages.com>",
+  "contributors": [
+    "AMRC <factoryplus@amrc.co.uk>"
+  ],
+  "license": "MIT",
+  "dependencies": {
+    "bindings": "^1.5.0",
+    "cmake-js": "^6.1.0",
+    "node-addon-api": "^1.7.2"
+  }
+}

--- a/lib/js-gssapi/src/.clang-format
+++ b/lib/js-gssapi/src/.clang-format
@@ -1,0 +1,115 @@
+---
+Language: Cpp
+# BasedOnStyle:
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands: true
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: InlineOnly
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass: true
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: true
+  AfterNamespace: false
+#  AfterObjCDeclaration: true
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+# BreakAfterJavaFieldAnnotations:
+BreakBeforeBinaryOperators: None
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: AfterColon
+BreakStringLiterals: true
+ColumnLimit: 100
+CommentPragmas: '^// emacs: '
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat: false
+# ExperimentalAutoDetectBinPacking:
+FixNamespaceComments: true
+# ForEachMacros:
+IncludeBlocks: Merge
+IncludeCategories:
+  - Regex: '^<(asm|camutility|charls|cluster-backbone|docview|evbase|evclientbase|evdbus|evlogin|evncserver2|ftgl|fus3d|general2d|general3d|libwfm|mcop|micppunit|mistral|mitest|openglutils|pasviewer|qtutility|report|ris|session-manager|sickle|sparrow|sturgeon|third-party|catch|trompeloeil|tinymath|trident|vdbclient|vdbserver|virtualxray3d|wfm|wlmscp|yargnits)/'
+    Priority: 4
+  - Regex: '^<boost/'
+    Priority: 2
+  - Regex: '^<Q.+>'
+    Priority: 3
+  - Regex: '<[[:alnum:]]+>'
+    Priority: 1
+  - Regex: '^".+'
+    Priority: 5
+IncludeIsMainRegex: '(_unix|_linux|_windows)?$'
+IndentCaseLabels: false
+IndentPPDirectives: None
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+# MacroBlockBegin:
+# MacroBlockEnd:
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: All
+# ObjCBinPackProtocolList: Auto
+# ObjCBlockIndentWidth: 4
+# ObjCSpaceAfterProperty: false
+# ObjCSpaceBeforeProtocolList: false
+# PenaltyBreakAssignment
+# PenaltyBreakBeforeFirstCallParameter
+# PenaltyBreakComment
+# PenaltyBreakFirstLessLess
+# PenaltyBreakString
+# PenaltyBreakTemplateDeclaration
+# PenaltyExcessCharacter
+# PenaltyReturnTypeOnItsOwnLine
+PointerAlignment: Right
+# RawStringFormats:
+ReflowComments: true
+SortIncludes: true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: true
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Cpp11
+TabWidth: 4
+UseTab: Never

--- a/lib/js-gssapi/src/bind.cc
+++ b/lib/js-gssapi/src/bind.cc
@@ -1,0 +1,248 @@
+#include "bind.h"
+#include "gss_impl.h"
+#include "krb_impl.h"
+
+static gss_OID_desc _gss_mech_spnego = {6, (void *)"\x2b\x06\x01\x05\x05\x02"}; // 1.3.6.1.5.5.2
+static const gss_OID gss_mech_spnego = &_gss_mech_spnego;
+
+Napi::Function GssSecContext::init(Napi::Env env)
+{
+    return DefineClass(env,
+                       "GssSecContext",
+                       {
+                           InstanceMethod("clientName", &GssSecContext::clientName),
+                           InstanceMethod("isComplete", &GssSecContext::isComplete),
+                       });
+}
+
+gss_OID parseMechanism(const std::string &mech)
+{
+    if (mech == "krb5") {
+        return const_cast<gss_OID>(gss_mech_krb5);
+    } else if (mech == "spnego") {
+        return gss_mech_spnego;
+    } else {
+        return GSS_C_NO_OID;
+    }
+}
+
+GssSecContext::GssSecContext(const Napi::CallbackInfo &info)
+    : Napi::ObjectWrap<GssSecContext>(info),
+      m_ccname(info[0].As<Napi::String>().Utf8Value()),
+      m_server_principal(info[1].As<Napi::String>().Utf8Value()),
+      m_mech(parseMechanism(info[2].As<Napi::String>().Utf8Value()))
+{}
+
+GssSecContext::~GssSecContext()
+{
+    if (m_ctx != GSS_C_NO_CONTEXT) {
+        OM_uint32 minor;
+        gss_delete_sec_context(&minor, &m_ctx, GSS_C_NO_BUFFER);
+        m_ctx = GSS_C_NO_CONTEXT;
+    }
+}
+
+Napi::Value GssSecContext::clientName(const Napi::CallbackInfo &info)
+{
+    return Napi::String::New(info.Env(), m_client_name);
+}
+
+Napi::Value GssSecContext::isComplete(const Napi::CallbackInfo &info)
+{
+    return Napi::Boolean::New(info.Env(), m_is_complete);
+}
+
+class GssAsyncWorker : public Napi::AsyncWorker
+{
+public:
+    GssAsyncWorker(GssSecContext *context, std::vector<char> input_token, Napi::Env env)
+        : Napi::AsyncWorker(env),
+          m_deferred(Napi::Promise::Deferred::New(env)),
+          m_context(context),
+          m_input_token(input_token)
+    {}
+
+    void OnOK() override
+    {
+        if (m_error.isError()) {
+            m_deferred.Reject(Napi::Error::New(Env(), m_error.toString()).Value());
+        } else {
+            auto vec = new std::vector<char>(m_output_token);
+            m_deferred.Resolve(Napi::Buffer<char>::New(
+                Env(),
+                vec->data(),
+                vec->size(),
+                [](Napi::Env, void *arg, std::vector<char> *hint) { delete hint; },
+                vec));
+        }
+    }
+
+    Napi::Promise::Deferred m_deferred;
+
+    GssSecContext *m_context;
+    const std::vector<char> m_input_token;
+    std::vector<char> m_output_token;
+    GssError m_error;
+};
+
+class InitSecContextWorker : public GssAsyncWorker
+{
+public:
+    using GssAsyncWorker::GssAsyncWorker;
+
+    void Execute() override
+    {
+        try {
+            const auto ccname = m_context->m_ccname;
+            const auto server_principal = m_context->m_server_principal;
+            const auto mech = m_context->m_mech;
+            GssError err;
+            if (!ccname.empty()) {
+                err.major = gss_krb5_ccache_name(&err.minor, ccname.data(), nullptr);
+                if (GSS_ERROR(err.major)) {
+                    m_error = err;
+                    return;
+                }
+            }
+            m_output_token = initSecContextImpl(
+                &m_context->m_ctx, server_principal, mech, m_input_token, m_context->m_is_complete);
+        } catch (const GssError &err) {
+            m_error = err;
+        }
+    }
+};
+
+class AcceptSecContextWorker : public GssAsyncWorker
+{
+public:
+    using GssAsyncWorker::GssAsyncWorker;
+
+    void Execute() override
+    {
+        try {
+            std::tie(m_output_token, m_client_name) =
+                acceptSecContextImpl(&m_context->m_ctx, m_input_token, m_context->m_is_complete);
+        } catch (const GssError &err) {
+            m_error = err;
+        }
+    }
+
+    void OnOK() override
+    {
+        m_context->m_client_name = m_client_name;
+        GssAsyncWorker::OnOK();
+    }
+
+private:
+    std::string m_client_name;
+};
+
+// Simple wrapper class which executes a std::function on a worker thread, and either resolves its
+// promise with no arguments, or rejects with an error
+class SimplePromiseWorker : public Napi::AsyncWorker
+{
+public:
+    SimplePromiseWorker(Napi::Env env, std::function<std::variant<std::string, KrbError>()> func)
+        : Napi::AsyncWorker(env), m_deferred(Napi::Promise::Deferred::New(env)), m_func(func)
+    {}
+
+    void Execute() override { m_result = m_func(); }
+    void OnOK() override
+    {
+        if (auto err = std::get_if<KrbError>(&m_result)) {
+            m_deferred.Reject(Napi::Error::New(Env(), err->message).Value());
+        } else {
+            m_deferred.Resolve(Napi::String::New(Env(), std::get<std::string>(m_result)));
+        }
+    }
+
+    Napi::Promise::Deferred m_deferred;
+    
+    std::function<std::variant<std::string, KrbError>()> m_func;
+    std::variant<std::string, KrbError> m_result;
+};
+
+Napi::Value acceptSecContext(const Napi::CallbackInfo &info)
+{
+    if (info.Length() < 2) {
+        throw Napi::TypeError::New(info.Env(), "2 arguments expected");
+    }
+
+    auto *ctx = Napi::ObjectWrap<GssSecContext>::Unwrap(info[0].As<Napi::Object>());
+    auto ab = info[1].As<Napi::Buffer<char>>();
+    auto token = std::vector<char>(static_cast<char *>(ab.Data()),
+                                   static_cast<char *>(ab.Data()) + ab.ByteLength());
+
+    AcceptSecContextWorker *worker = new AcceptSecContextWorker(ctx, token, info.Env());
+    worker->Queue();
+    return worker->m_deferred.Promise();
+}
+
+Napi::Value initSecContext(const Napi::CallbackInfo &info)
+{
+    if (info.Length() < 2) {
+        throw Napi::TypeError::New(info.Env(), "2 arguments expected");
+    }
+
+    auto *ctx = Napi::ObjectWrap<GssSecContext>::Unwrap(info[0].As<Napi::Object>());
+    auto ab = info[1].As<Napi::Buffer<char>>();
+    auto token = std::vector<char>(static_cast<char *>(ab.Data()),
+                                   static_cast<char *>(ab.Data()) + ab.ByteLength());
+
+    InitSecContextWorker *worker = new InitSecContextWorker(ctx, token, info.Env());
+    worker->Queue();
+    return worker->m_deferred.Promise();
+}
+
+Napi::Value setKeytabPath(const Napi::CallbackInfo &info)
+{
+    if (info.Length() < 1) {
+        throw Napi::TypeError::New(info.Env(), "1 argument expected");
+    }
+    std::string keytab_path(info[0].As<Napi::String>().Utf8Value());
+    if (!keytab_path.empty()) {
+        gsskrb5_register_acceptor_identity(keytab_path.c_str());
+    }
+    return info.Env().Undefined();
+}
+
+Napi::Value kinit(const Napi::CallbackInfo &info)
+{
+    if (info.Length() < 3) {
+        throw Napi::TypeError::New(info.Env(), "3 arguments expected");
+    }
+    std::string ccname(info[0].As<Napi::String>().Utf8Value());
+    std::string principal(info[1].As<Napi::String>().Utf8Value());
+    std::string password(info[2].As<Napi::String>().Utf8Value());
+    auto *worker =
+        new SimplePromiseWorker(info.Env(), [=]() { return kinit(ccname, principal, password); });
+    worker->Queue();
+    return worker->m_deferred.Promise();
+}
+
+Napi::Value kdestroy(const Napi::CallbackInfo &info)
+{
+    if (info.Length() < 1) {
+        throw Napi::TypeError::New(info.Env(), "1 arguments expected");
+    }
+    std::string ccname(info[0].As<Napi::String>().Utf8Value());
+    auto *worker = new SimplePromiseWorker(info.Env(), [=]() { return kdestroy(ccname); });
+    worker->Queue();
+    return worker->m_deferred.Promise();
+}
+
+Napi::Value verifyCredentials(const Napi::CallbackInfo &info)
+{
+    if (info.Length() < 4) {
+        throw Napi::TypeError::New(info.Env(), "4 arguments expected");
+    }
+    std::string principal(info[0].As<Napi::String>().Utf8Value());
+    std::string password(info[1].As<Napi::String>().Utf8Value());
+    std::string keytab(info[2].As<Napi::String>().Utf8Value());
+    std::string serverPrincipal(info[3].As<Napi::String>().Utf8Value());
+
+    auto *worker = new SimplePromiseWorker(
+        info.Env(), [=]() { return verifyCredentials(principal, password, keytab, serverPrincipal); });
+    worker->Queue();
+    return worker->m_deferred.Promise();
+}

--- a/lib/js-gssapi/src/bind.h
+++ b/lib/js-gssapi/src/bind.h
@@ -1,0 +1,38 @@
+#include <string>
+#include <gssapi/gssapi.h>
+#include <gssapi/gssapi_krb5.h>
+#include <krb5.h>
+#include <napi.h>
+
+Napi::Value acceptSecContext(const Napi::CallbackInfo &info);
+Napi::Value initSecContext(const Napi::CallbackInfo &info);
+Napi::Value setKeytabPath(const Napi::CallbackInfo &info);
+
+Napi::Value kinit(const Napi::CallbackInfo &info);
+Napi::Value kdestroy(const Napi::CallbackInfo &info);
+Napi::Value verifyCredentials(const Napi::CallbackInfo &info);
+
+class GssSecContext : public Napi::ObjectWrap<GssSecContext>
+{
+public:
+    static Napi::Function init(Napi::Env env);
+
+    GssSecContext(const Napi::CallbackInfo &info);
+
+    ~GssSecContext();
+
+    Napi::Value clientName(const Napi::CallbackInfo &info);
+    Napi::Value isComplete(const Napi::CallbackInfo &info);
+
+private:
+    friend class InitSecContextWorker;
+    friend class AcceptSecContextWorker;
+
+    const std::string m_ccname;
+    const std::string m_server_principal;
+    const gss_OID m_mech;
+
+    gss_ctx_id_t m_ctx = GSS_C_NO_CONTEXT;
+    std::string m_client_name;
+    bool m_is_complete = false;
+};

--- a/lib/js-gssapi/src/gss_impl.h
+++ b/lib/js-gssapi/src/gss_impl.h
@@ -1,0 +1,202 @@
+#ifndef NODE_KRB5_GSS_IMPL_H
+#define NODE_KRB5_GSS_IMPL_H
+
+#include <string>
+#include <utility>
+#include <vector>
+#include <gssapi/gssapi.h>
+#include <gssapi/gssapi_krb5.h>
+
+struct GssError
+{
+    OM_uint32 major = 0;
+    OM_uint32 minor = 0;
+
+    static std::string errorCodeToString(OM_uint32 err, bool is_minor)
+    {
+        if (!GSS_ERROR(err)) {
+            return "<none>";
+        }
+
+        std::string message;
+
+        OM_uint32 unused;
+        OM_uint32 msg_id = 0;
+        do {
+            gss_buffer_desc buf;
+            gss_display_status(&unused,
+                               err,
+                               is_minor ? GSS_C_MECH_CODE : GSS_C_GSS_CODE,
+                               GSS_C_NO_OID,
+                               &msg_id,
+                               &buf);
+
+            if (!message.empty()) {
+                message += "; ";
+            }
+            message.append(std::string(static_cast<const char *>(buf.value), buf.length));
+
+            gss_release_buffer(&unused, &buf);
+        } while (msg_id != 0);
+        return message;
+    }
+
+    std::string toString() const
+    {
+        return std::to_string(major) + ": " + errorCodeToString(major, false) +
+               " (minor: " + std::to_string(minor) + ": " + errorCodeToString(minor, true) + ")";
+    }
+
+    bool isError() const { return GSS_ERROR(major) || GSS_ERROR(minor); }
+};
+
+struct ScopedBuffer
+{
+    ScopedBuffer() : m_allocated(true) {}
+
+    ScopedBuffer(const std::vector<char> &contents) : m_allocated(false)
+    {
+        m_buffer.length = contents.size();
+        m_buffer.value = const_cast<char *>(contents.data());
+    }
+
+    ~ScopedBuffer()
+    {
+        if (m_allocated && m_buffer.value != nullptr) {
+            OM_uint32 unused;
+            gss_release_buffer(&unused, &m_buffer);
+        }
+    }
+
+    ScopedBuffer(ScopedBuffer &&) = delete;
+
+    std::vector<char> toVector() const
+    {
+        return std::vector<char>(static_cast<char *>(m_buffer.value),
+                                 static_cast<char *>(m_buffer.value) + m_buffer.length);
+    }
+
+    gss_buffer_desc m_buffer = GSS_C_EMPTY_BUFFER;
+    bool m_allocated;
+};
+
+struct ScopedName
+{
+    ScopedName() {}
+
+    ScopedName(std::string principal, bool is_service)
+    {
+        gss_buffer_desc service;
+        service.length = principal.size();
+        service.value = const_cast<char *>(principal.data());
+        auto name_type = is_service ? GSS_C_NT_HOSTBASED_SERVICE : GSS_C_NT_USER_NAME;
+        GssError error;
+        error.major = gss_import_name(&error.minor, &service, name_type, &m_name);
+        if (GSS_ERROR(error.major)) {
+            throw error;
+        }
+    }
+
+    ~ScopedName()
+    {
+        if (m_name != gss_name_t()) {
+            OM_uint32 unused;
+            gss_release_name(&unused, &m_name);
+        }
+    }
+
+    ScopedName(ScopedName &&) = delete;
+
+    std::string toString() const
+    {
+        OM_uint32 unused;
+        ScopedBuffer buf;
+        gss_display_name(&unused, m_name, &buf.m_buffer, nullptr);
+        const auto vec = buf.toVector();
+        return std::string(vec.begin(), vec.end());
+    };
+
+    gss_name_t m_name = {};
+};
+
+std::vector<char> initSecContextImpl(gss_ctx_id_t *ctx,
+                                     std::string server_name,
+                                     gss_OID mech_type,
+                                     std::vector<char> token,
+                                     bool &complete)
+{
+    complete = false;
+    ScopedName imported_server(server_name, true);
+
+    ScopedBuffer input(token);
+    ScopedBuffer output;
+
+    GssError err;
+    /* AMRC fork: upstream also passes GSS_C_DELEG_FLAG here. That
+     * makes libkrb5 request a forwarded TGT from the KDC on every
+     * context creation; when the client's TGT is not forwardable the
+     * KDC refuses ("TGT NOT FORWARDABLE") and the flag is silently
+     * dropped, costing one wasted KDC round trip per token. Nothing
+     * in Factory+ consumes delegated credentials, so don't ask. */
+    err.major = gss_init_sec_context(&err.minor,
+                                     GSS_C_NO_CREDENTIAL,
+                                     ctx,
+                                     imported_server.m_name,
+                                     mech_type,
+                                     GSS_C_MUTUAL_FLAG | GSS_C_REPLAY_FLAG,
+                                     GSS_C_INDEFINITE,
+                                     GSS_C_NO_CHANNEL_BINDINGS,
+                                     &input.m_buffer,
+                                     nullptr,
+                                     &output.m_buffer,
+                                     nullptr,
+                                     nullptr);
+
+    if (GSS_ERROR(err.major)) {
+        throw err;
+    }
+
+    if (err.major == GSS_S_COMPLETE) {
+        complete = true;
+    }
+
+    return output.toVector();
+}
+
+std::pair<std::vector<char>, std::string>
+acceptSecContextImpl(gss_ctx_id_t *ctx, std::vector<char> token, bool &complete)
+{
+    complete = false;
+    ScopedBuffer input(token);
+    ScopedBuffer output;
+
+    OM_uint32 ret_flags = 0;
+    gss_cred_id_t delegated_cred = GSS_C_NO_CREDENTIAL;
+
+    ScopedName client_name;
+
+    GssError err;
+    err.major = gss_accept_sec_context(&err.minor,
+                                       ctx,
+                                       GSS_C_NO_CREDENTIAL,
+                                       &input.m_buffer,
+                                       GSS_C_NO_CHANNEL_BINDINGS,
+                                       &client_name.m_name,
+                                       nullptr,
+                                       &output.m_buffer,
+                                       &ret_flags,
+                                       nullptr,
+                                       &delegated_cred);
+
+    if (GSS_ERROR(err.major)) {
+        throw err;
+    }
+
+    if (err.major == GSS_S_COMPLETE) {
+        complete = true;
+    }
+
+    return std::pair{output.toVector(), client_name.toString()};
+}
+
+#endif

--- a/lib/js-gssapi/src/krb_impl.h
+++ b/lib/js-gssapi/src/krb_impl.h
@@ -1,0 +1,268 @@
+#ifndef NODE_KRB5_IMPL_H
+#define NODE_KRB5_IMPL_H
+
+#include <string>
+#include <utility>
+#include <optional>
+#include <variant>
+#include <vector>
+#include <krb5.h>
+
+struct KrbError
+{
+    std::string message;
+};
+
+using ResultType = std::variant<std::string, KrbError>;
+
+std::string errorString(krb5_context ctx, krb5_error_code error)
+{
+    const auto *raw = krb5_get_error_message(ctx, error);
+    const auto str = std::string(raw) + " (" + std::to_string(error) + ")";
+    krb5_free_error_message(ctx, raw);
+    return str;
+}
+
+struct Krb5Context
+{
+    Krb5Context() : ctx(nullptr) { error = krb5_init_context(&ctx); }
+
+    Krb5Context(const Krb5Context &) = delete;
+    Krb5Context &operator=(const Krb5Context &) = delete;
+
+    ~Krb5Context()
+    {
+        if (ctx != nullptr) {
+            krb5_free_context(ctx);
+        }
+    }
+
+    krb5_context operator*() { return ctx; }
+
+    krb5_context ctx;
+    krb5_error_code error;
+};
+
+template<typename Resource, typename FreeFunc, FreeFunc *free_func>
+struct Krb5Resource
+{
+    Krb5Resource(krb5_context context, const std::optional<Resource> &resource)
+        : m_ctx(context), m_resource(resource) {}
+
+    ~Krb5Resource()
+    {
+        if (m_resource) {
+            // Little inconsistency here. Some krb5 free functions take the argument by value,
+            // others as a pointer. Let's try to handle both
+            if constexpr (std::is_convertible_v<FreeFunc,
+                                                krb5_error_code (*)(krb5_context, Resource)>) {
+                free_func(m_ctx, *m_resource);
+            } else if constexpr (std::is_convertible_v<FreeFunc,
+                                                       krb5_error_code (*)(krb5_context,
+                                                                           Resource *)>) {
+                free_func(m_ctx, &*m_resource);
+            }
+        }
+    }
+
+    Krb5Resource(const Krb5Resource &) = delete;
+    Krb5Resource &operator=(const Krb5Resource &) = delete;
+
+    Krb5Resource(Krb5Resource &&rhs)
+        : m_ctx(rhs.m_ctx), m_resource(rhs.m_resource)
+    {
+        rhs.m_ctx = nullptr;
+        rhs.m_resource.reset();
+    }
+
+    // Not used right now, so not implemented. Compiler will tell us if ever needed.
+    Krb5Resource &operator=(Krb5Resource &&rhs) = delete;
+
+    Resource &operator*() { return *m_resource; }
+
+    Resource release()
+    {
+        Resource r = *m_resource;
+        m_resource.reset();
+        return r;
+    }
+
+private:
+    krb5_context m_ctx;
+    std::optional<Resource> m_resource;
+};
+
+using Principal = Krb5Resource<krb5_principal, decltype(krb5_free_principal), krb5_free_principal>;
+using UnparsedName = Krb5Resource<char*, decltype(krb5_free_unparsed_name), krb5_free_unparsed_name>;
+using Credentials = Krb5Resource<krb5_creds, decltype(krb5_free_creds), krb5_free_creds>;
+using Ccache = Krb5Resource<krb5_ccache, decltype(krb5_cc_close), krb5_cc_close>;
+using Keytab = Krb5Resource<krb5_keytab, decltype(krb5_kt_close), krb5_kt_close>;
+
+/// The functions in this krb5 namespace have the same signature as
+/// the MIT kerberos library, except they don't use out parameters
+/// and return an error code. Instead they return a Krb5Resource
+/// and throw errors.
+namespace krb5 {
+
+    Principal parse_name(krb5_context context, const char *name)
+    {
+        krb5_principal resource;
+        const auto err = krb5_parse_name(context, name, &resource);
+        if (err) {
+            throw err;
+        }
+        return Principal(context, resource);
+    }
+
+    Principal cc_get_principal(krb5_context context, krb5_ccache cc)
+    {
+        krb5_principal resource;
+        const auto err = krb5_cc_get_principal(context, cc, &resource);
+        if (err) {
+            throw err;
+        }
+        return Principal(context, resource);
+    }
+
+    UnparsedName unparse_name(krb5_context context, krb5_const_principal princ)
+    {
+        char *resource = nullptr;
+        const auto err = krb5_unparse_name(context, princ, &resource);
+        if (err) {
+            throw err;
+        }
+        return UnparsedName(context, resource);
+    }
+
+    Credentials get_init_creds_password(krb5_context context,
+                                        krb5_principal client,
+                                        const char *password,
+                                        krb5_get_init_creds_opt *k5_gic_options)
+    {
+        krb5_creds resource;
+        const auto err = krb5_get_init_creds_password(context, &resource, client,
+                                                      const_cast<char*>(password), nullptr, nullptr, 0,
+                                                      nullptr, k5_gic_options);
+        if (err) {
+            throw err;
+        }
+        return Credentials(context, resource);
+    }
+
+    Ccache cc_resolve(krb5_context context, const char *name)
+    {
+        krb5_ccache resource;
+        const auto err = krb5_cc_resolve(context, name, &resource);
+        if (err) {
+            throw err;
+        }
+        return Ccache(context, resource);
+    }
+
+    Keytab kt_resolve(krb5_context context, const char *name)
+    {
+        krb5_keytab resource;
+        const auto err = krb5_kt_resolve(context, name, &resource);
+        if (err) {
+            throw err;
+        }
+        return Keytab(context, resource);
+    }
+
+}
+
+std::string getDefaultPrincipal(krb5_context ctx, krb5_ccache cache)
+{
+    Principal principal = krb5::cc_get_principal(ctx, cache);
+
+    UnparsedName name = krb5::unparse_name(ctx, *principal);
+    return *name;
+}
+
+ResultType kinit(std::string cc_name, std::string princ_name, std::string password)
+{
+    Krb5Context context;
+    if (context.error != 0) {
+        return KrbError{"Could not initialize Kerberos library. Error code (" +
+               std::to_string(context.error) + ")"};
+    }
+    try {
+        Principal principal = krb5::parse_name(*context, princ_name.data());
+        Credentials creds = krb5::get_init_creds_password(*context, *principal, password.data(), nullptr);
+        Ccache ccache = krb5::cc_resolve(*context, cc_name.data());
+        auto err = krb5_cc_initialize(*context, *ccache, *principal);
+        if (err != 0) {
+            return KrbError{errorString(*context, err)};
+        }
+        std::string princ_name = getDefaultPrincipal(*context, *ccache);
+
+        err = krb5_cc_store_cred(*context, *ccache, &*creds);
+        if (err != 0) {
+            return KrbError{errorString(*context, err)};
+        }
+
+        return princ_name;
+    } catch (krb5_error_code error) {
+        return KrbError{errorString(*context, error)};
+    }
+}
+
+ResultType kdestroy(std::string cc_name)
+{
+    Krb5Context context;
+    if (context.error != 0) {
+        return KrbError{"Could not initialize Kerberos library. Error code (" +
+               std::to_string(context.error) + ")"};
+    }
+    try {
+        Ccache ccache = krb5::cc_resolve(*context, cc_name.data());
+        const auto krb5_cc = ccache.release();
+        const auto err = krb5_cc_destroy(*context, krb5_cc);
+        if (err != 0) {
+            return KrbError{errorString(*context, err)};
+        }
+        return std::string();
+    } catch (krb5_error_code error) {
+        return KrbError{errorString(*context, error)};
+    }
+}
+
+ResultType verifyCredentials(std::string princ_name, std::string password, std::string keytab_path, std::string server_principal)
+{
+    Krb5Context context;
+    if (context.error != 0) {
+        return KrbError{"Could not initialize Kerberos library. Error code (" +
+               std::to_string(context.error) + ")"};
+    }
+    try {
+        Principal principal = krb5::parse_name(*context, princ_name.data());
+        Credentials creds = krb5::get_init_creds_password(*context, *principal, password.data(), nullptr);
+
+        krb5_verify_init_creds_opt opts;
+        krb5_verify_init_creds_opt_init(&opts);
+
+        krb5_verify_init_creds_opt_set_ap_req_nofail(&opts, 1);
+
+        std::optional<Keytab> kt;
+        if (!keytab_path.empty()) {
+            kt.emplace(krb5::kt_resolve(*context, keytab_path.data()));
+        }
+
+        std::optional<Principal> server_princ;
+        if (!server_principal.empty()) {
+            server_princ.emplace(krb5::parse_name(*context, server_principal.data()));
+        }
+
+        const auto err = krb5_verify_init_creds(*context, &*creds,
+                                                server_princ ? **server_princ : nullptr,
+                                                kt ? **kt : nullptr, nullptr, &opts);
+        if (err == 0) {
+            return std::string();
+        }
+        return KrbError{errorString(*context, err)};
+    } catch (krb5_error_code err) {
+        return KrbError{errorString(*context, err)};
+    }
+}
+
+#endif

--- a/lib/js-gssapi/src/module.cc
+++ b/lib/js-gssapi/src/module.cc
@@ -1,0 +1,18 @@
+#include "bind.h"
+
+Napi::Object init(Napi::Env env, Napi::Object exports)
+{
+    exports.Set(Napi::String::New(env, "acceptSecContext"),
+                Napi::Function::New(env, acceptSecContext));
+    exports.Set(Napi::String::New(env, "initSecContext"), Napi::Function::New(env, initSecContext));
+    exports.Set(Napi::String::New(env, "setKeytabPath"), Napi::Function::New(env, setKeytabPath));
+    exports.Set(Napi::String::New(env, "GssSecContext"), GssSecContext::init(env));
+
+    exports.Set(Napi::String::New(env, "verifyCredentials"),
+                Napi::Function::New(env, verifyCredentials));
+    exports.Set(Napi::String::New(env, "kinit"), Napi::Function::New(env, kinit));
+    exports.Set(Napi::String::New(env, "kdestroy"), Napi::Function::New(env, kdestroy));
+    return exports;
+};
+
+NODE_API_MODULE(NODE_GYP_MODULE_NAME, init);

--- a/lib/js-service-api/lib/auth.js
+++ b/lib/js-service-api/lib/auth.js
@@ -6,10 +6,14 @@
 
 import crypto from "crypto";
 
-import GSS from "gssapi.js";
 import { pathToRegexp } from "path-to-regexp";
 
-import { jwt_context } from "@amrc-factoryplus/service-client";
+/* GSS comes via the service-client re-export so we pick up the same
+ * implementation the client side uses (the @amrc-factoryplus/gssapi
+ * fork when installed, upstream gssapi.js otherwise). It is undefined
+ * on platforms with no GSS support; auth attempts then fail rather
+ * than the module failing to load. */
+import { GSS, jwt_context } from "@amrc-factoryplus/service-client";
 
 import { JwtVerifier, looks_like_jwt } from "./jwt.js";
 

--- a/lib/js-service-api/package-lock.json
+++ b/lib/js-service-api/package-lock.json
@@ -18,7 +18,6 @@
         "cors": "^2.8.5",
         "deep-equal": "^2.2.3",
         "express": "^5.0.1",
-        "gssapi.js": "^2.0.1",
         "immutable": "^5.1.3",
         "jose": "^5.9.6",
         "optional-js": "^2.3.0",
@@ -67,6 +66,7 @@
         "globals": "^15.11.0"
       },
       "optionalDependencies": {
+        "@amrc-factoryplus/gssapi": "^2.1.0",
         "got-fetch": "^5.1.8",
         "gssapi.js": "^2.0.1"
       }
@@ -369,21 +369,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ansi": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
-      "integrity": "sha512-iFY7JCgHbepc0b82yLaw4IMortylNb6wG4kL+4R0C3iv6i+RHGHux/yUX5BTiRvSX/shMnngjR1YyNMnXEFh5A==",
-      "license": "MIT"
-    },
-    "node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -398,53 +383,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/are-we-there-yet": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
-      "integrity": "sha512-Zfw6bteqM9gQXZ1BIWOgM8xEwMrUGoyL8nW13+O+OOgNX3YhuDN1GDgg1NzdTlmm3j+9sHy7uBZ12r+z9lXnZQ==",
-      "deprecated": "This package is no longer supported.",
-      "license": "ISC",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.0 || ^1.1.13"
-      }
-    },
-    "node_modules/are-we-there-yet/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
-    },
-    "node_modules/are-we-there-yet/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/are-we-there-yet/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
-    "node_modules/are-we-there-yet/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/argparse": {
@@ -485,56 +423,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/big-integer": {
-      "version": "1.6.52",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-      "license": "Unlicense",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/binary": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
-      "license": "MIT",
-      "dependencies": {
-        "buffers": "~0.1.1",
-        "chainsaw": "~0.1.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/body-parser": {
@@ -565,33 +458,11 @@
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
       "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/buffer-indexof-polyfill": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/buffer-shims": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "integrity": "sha512-Zy8ZXMyxIT6RMTeY7OP/bDndfj6bwCan7SS98CEndS6deHwWPpseeHlwarNcBim+etXnF9HBc1non5JgDaJU1g==",
-      "license": "MIT"
-    },
-    "node_modules/buffers": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
-      "engines": {
-        "node": ">=0.2.0"
       }
     },
     "node_modules/bytes": {
@@ -660,27 +531,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/camelcase": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha512-DLIsRzJVBQu72meAKPkWQOLcujdXT32hwdfnkI1frSiSRMK1MofjKHf+MEx0SB6fjEFXL8fBDv1dKymBlOp4Qw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/chainsaw": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
-      "license": "MIT/X11",
-      "dependencies": {
-        "traverse": ">=0.3.0 <0.4"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -696,74 +546,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
-    },
-    "node_modules/cliui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha512-0yayqDxWQbqk3ojkYqUKqaAQ6AfNKeKWRNA8kR0WXzAsdHpP4BIaOmMAG87JGuO6qcobyW4GjxHd9PmhEd+T9w==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
-      }
-    },
-    "node_modules/cmake-js": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-6.3.2.tgz",
-      "integrity": "sha512-7MfiQ/ijzeE2kO+WFB9bv4QP5Dn2yVaAP2acFJr4NIFy2hT4w6O4EpOTLNcohR5IPX7M4wNf/5taIqMj7UA9ug==",
-      "license": "MIT",
-      "dependencies": {
-        "axios": "^0.21.1",
-        "bluebird": "^3",
-        "debug": "^4",
-        "fs-extra": "^5.0.0",
-        "is-iojs": "^1.0.1",
-        "lodash": "^4",
-        "memory-stream": "0",
-        "npmlog": "^1.2.0",
-        "rc": "^1.2.7",
-        "semver": "^5.0.3",
-        "splitargs": "0",
-        "tar": "^4",
-        "unzipper": "^0.8.13",
-        "url-join": "0",
-        "which": "^1.0.9",
-        "yargs": "^3.6.0"
-      },
-      "bin": {
-        "cmake-js": "bin/cmake-js"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/cmake-js/node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
-    },
-    "node_modules/code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/color-convert": {
@@ -790,6 +572,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/content-disposition": {
@@ -831,12 +614,6 @@
       "engines": {
         "node": ">=6.6.0"
       }
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.6",
@@ -887,15 +664,6 @@
         }
       }
     },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/deep-equal": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
@@ -926,15 +694,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -978,12 +737,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "license": "MIT"
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -1005,51 +758,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/duplexer2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "readable-stream": "^2.0.2"
-      }
-    },
-    "node_modules/duplexer2/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
-    },
-    "node_modules/duplexer2/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/duplexer2/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
-    "node_modules/duplexer2/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/ee-first": {
@@ -1376,12 +1084,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
-    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -1441,26 +1143,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -1494,48 +1176,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/fs-extra": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      }
-    },
-    "node_modules/fs-minipass": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^2.6.0"
-      }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "license": "ISC"
-    },
-    "node_modules/fstream": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-      "deprecated": "This package is no longer supported.",
-      "license": "ISC",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      },
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -1552,20 +1192,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/gauge": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
-      "integrity": "sha512-fVbU2wRE91yDvKUnrIaQlHKAWKY5e08PmztCrwuH5YVQ+Z/p3d0ny2T48o6uvAAXHIUnfaQdHkmxYbQft1eHVA==",
-      "deprecated": "This package is no longer supported.",
-      "license": "ISC",
-      "dependencies": {
-        "ansi": "^0.3.0",
-        "has-unicode": "^2.0.0",
-        "lodash.pad": "^4.1.0",
-        "lodash.padend": "^4.1.0",
-        "lodash.padstart": "^4.1.0"
       }
     },
     "node_modules/get-intrinsic": {
@@ -1605,27 +1231,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -1662,24 +1267,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC"
-    },
-    "node_modules/gssapi.js": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/gssapi.js/-/gssapi.js-2.0.1.tgz",
-      "integrity": "sha512-5D+qylV8uIKMaxTTKhpzvfGRz5+okr/rpwC6YlaCoDVBpvkuNgL8pM7+r7aTzZ2oT5dA4w2WoZTV82opGj+RZQ==",
-      "hasInstallScript": true,
-      "license": "ISC",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "cmake-js": "^6.1.0",
-        "node-addon-api": "^1.7.2"
       }
     },
     "node_modules/has-bigints": {
@@ -1742,12 +1329,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-      "license": "ISC"
     },
     "node_modules/hasown": {
       "version": "2.0.3",
@@ -1840,27 +1421,10 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/internal-slot": {
@@ -1875,15 +1439,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/ipaddr.js": {
@@ -1997,18 +1552,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
-      "license": "MIT",
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -2021,12 +1564,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/is-iojs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-iojs/-/is-iojs-1.1.0.tgz",
-      "integrity": "sha512-tLn1j3wYSL6DkvEI+V/j0pKohpa5jk+ER74v6S4SgCXnjS0WA+DoZbwZBrrhgwksMvtuwndyGeG5F8YMsoBzSA==",
-      "license": "MIT"
     },
     "node_modules/is-map": {
       "version": "2.0.3",
@@ -2178,6 +1715,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/jose": {
@@ -2223,15 +1761,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -2240,18 +1769,6 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
-      }
-    },
-    "node_modules/lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==",
-      "license": "MIT",
-      "dependencies": {
-        "invert-kv": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/levn": {
@@ -2267,12 +1784,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/listenercount": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-      "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
-      "license": "ISC"
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -2290,35 +1801,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.pad": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
-      "integrity": "sha512-mvUHifnLqM+03YNzeTBS1/Gr6JRFjd3rRx88FHWUvamVaT9k2O/kXha3yBSOwB9/DTQrSTLJNHvLBBt2FdX7Mg==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.padend": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-      "integrity": "sha512-sOQs2aqGpbl27tmCS1QNZA09Uqp01ZzWfDUoD+xzTii0E7dSQfRKcRetFwa+uXaxaqL+TKm7CgD2JdKP7aZBSw==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.padstart": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
-      "integrity": "sha512-sW73O6S8+Tg66eY56DBk85aQzzUJDtpoXFBgELMd5P/SotAguo+1kYO6RuYgXxA4HJH3LFTFPASX6ET6bjfriw==",
       "license": "MIT"
     },
     "node_modules/math-intrinsics": {
@@ -2337,15 +1824,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/memory-stream": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/memory-stream/-/memory-stream-0.0.3.tgz",
-      "integrity": "sha512-q0D3m846qY6ZkIt+19ZemU5vH56lpOZZwoJc3AICARKh/menBuayQUjAGPrqtHQQMUYERSdOrej92J9kz7LgYA==",
-      "license": "MMIT",
-      "dependencies": {
-        "readable-stream": "~1.0.26-2"
       }
     },
     "node_modules/merge-descriptors": {
@@ -2389,52 +1867,13 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-      "license": "ISC",
-      "dependencies": {
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.0"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^2.9.0"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/ms": {
@@ -2457,33 +1896,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/node-addon-api": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
-      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
-      "license": "MIT"
-    },
-    "node_modules/npmlog": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
-      "integrity": "sha512-1J5KqSRvESP6XbjPaXt2H6qDzgizLTM7x0y1cXIjP2PpvdCqyNC7TO3cPRKsuYlElbi/DwkzRRdG2zpmE0IktQ==",
-      "deprecated": "This package is no longer supported.",
-      "license": "ISC",
-      "dependencies": {
-        "ansi": "~0.3.0",
-        "are-we-there-yet": "~1.0.0",
-        "gauge": "~1.2.0"
-      }
-    },
-    "node_modules/number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/object-assign": {
@@ -2597,18 +2009,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/os-locale": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha512-PRT7ZORmwu2MEFt4/fv3Q+mEfN4zetKxufQrkShY2oGvUms9r8otu5HfdyIFHkYXjO7laNsoVGmM2MANfuTA8g==",
-      "license": "MIT",
-      "dependencies": {
-        "lcid": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -2673,15 +2073,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -2716,12 +2107,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -2785,48 +2170,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/readable-stream/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "license": "MIT"
-    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -2855,19 +2198,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
       }
     },
     "node_modules/router": {
@@ -2905,26 +2235,6 @@
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
@@ -2947,15 +2257,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
-    },
-    "node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
     },
     "node_modules/send": {
       "version": "1.2.1",
@@ -3033,12 +2334,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -3141,12 +2436,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/splitargs": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/splitargs/-/splitargs-0.0.7.tgz",
-      "integrity": "sha512-UUFYD2oWbNwULH6WoVtLUOw8ch586B+HUqcsAjjjeoBQAM1bD4wZRXu01koaxyd8UeYpybWqW4h+lO1Okv40Tg==",
-      "license": "ISC"
-    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -3167,38 +2456,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "license": "MIT"
-    },
-    "node_modules/string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
-      "license": "MIT",
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-json-comments": {
@@ -3227,25 +2484,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/tar": {
-      "version": "4.4.19",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
-      "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
-      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^1.1.4",
-        "fs-minipass": "^1.2.7",
-        "minipass": "^2.9.0",
-        "minizlib": "^1.3.3",
-        "mkdirp": "^0.5.5",
-        "safe-buffer": "^5.2.1",
-        "yallist": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=4.5"
-      }
-    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -3253,15 +2491,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
-      }
-    },
-    "node_modules/traverse": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
-      "license": "MIT/X11",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/tslib": {
@@ -3314,15 +2543,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -3330,56 +2550,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/unzipper": {
-      "version": "0.8.14",
-      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.8.14.tgz",
-      "integrity": "sha512-8rFtE7EP5ssOwGpN2dt1Q4njl0N1hUXJ7sSPz0leU2hRdq6+pra57z4YPBlVqm40vcgv6ooKZEAx48fMTv9x4w==",
-      "license": "MIT",
-      "dependencies": {
-        "big-integer": "^1.6.17",
-        "binary": "~0.3.0",
-        "bluebird": "~3.4.1",
-        "buffer-indexof-polyfill": "~1.0.0",
-        "duplexer2": "~0.1.4",
-        "fstream": "~1.0.10",
-        "listenercount": "~1.0.1",
-        "readable-stream": "~2.1.5",
-        "setimmediate": "~1.0.4"
-      }
-    },
-    "node_modules/unzipper/node_modules/bluebird": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
-      "license": "MIT"
-    },
-    "node_modules/unzipper/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
-    },
-    "node_modules/unzipper/node_modules/process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha512-yN0WQmuCX63LP/TMvAg31nvT6m4vDqJEiiv2CAZqWOGNWutc9DfDk1NPYYmKUFmaVM2UwDowH4u5AHWYP/jxKw==",
-      "license": "MIT"
-    },
-    "node_modules/unzipper/node_modules/readable-stream": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-      "integrity": "sha512-NkXT2AER7VKXeXtJNSaWLpWIhmtSE3K2PguaLEeWr4JILghcIKqoLt1A3wHrnpDC5+ekf8gfk1GKWkFXe4odMw==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-shims": "^1.0.0",
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "string_decoder": "~0.10.x",
-        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/uri-js": {
@@ -3391,18 +2561,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/url-join": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
-      "integrity": "sha512-H6dnQ/yPAAVzMQRvEvyz01hhfQL5qRWSEt7BX8t9DqnPw9BjMb64fjIRq76Uvf1hkHp+mTZvEVJ5guXOT0Xqaw==",
-      "license": "MIT"
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "11.1.1",
@@ -3500,37 +2658,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/window-size": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-      "integrity": "sha512-2thx4pB0cV3h+Bw7QmMXcEbdmOzv9t0HFplJH/Lz6yu60hXYy5RT8rUu+wlIreVxWsGN20mo+MHeCSfUpQBwPw==",
-      "license": "MIT",
-      "bin": {
-        "window-size": "cli.js"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3560,33 +2693,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/y18n": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-      "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
-      "license": "ISC"
-    },
-    "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "license": "ISC"
-    },
-    "node_modules/yargs": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-      "integrity": "sha512-ONJZiimStfZzhKamYvR/xvmgW3uEkAUFSP91y2caTEPhzF6uP2JfPiVZcq66b/YR0C3uitxSV7+T1x8p5bkmMg==",
-      "license": "MIT",
-      "dependencies": {
-        "camelcase": "^2.0.1",
-        "cliui": "^3.0.3",
-        "decamelize": "^1.1.1",
-        "os-locale": "^1.4.0",
-        "string-width": "^1.0.1",
-        "window-size": "^0.1.4",
-        "y18n": "^3.2.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/lib/js-service-api/package.json
+++ b/lib/js-service-api/package.json
@@ -17,7 +17,6 @@
     "cors": "^2.8.5",
     "deep-equal": "^2.2.3",
     "express": "^5.0.1",
-    "gssapi.js": "^2.0.1",
     "immutable": "^5.1.3",
     "jose": "^5.9.6",
     "optional-js": "^2.3.0",

--- a/lib/js-service-client/lib/deps.js
+++ b/lib/js-service-client/lib/deps.js
@@ -11,7 +11,12 @@ import { sp_remove_longs } from "./sparkplug/util.js";
  * a bug in Rollup where it insists on adding a semicolon after
  * the `await` keyword.
  */
-export const GSS = await import("gssapi.js")
+/* Prefer our fork, which doesn't request credential delegation
+ * (upstream's GSS_C_DELEG_FLAG costs a refused KDC round trip per
+ * token when the TGT is not forwardable). Fall back to upstream
+ * gssapi.js for consumers which don't have the fork installed. */
+export const GSS = await import("@amrc-factoryplus/gssapi")
+        .catch(e => import("gssapi.js"))
         .then(mod => mod.default)
         .catch(e => undefined);
 

--- a/lib/js-service-client/package.json
+++ b/lib/js-service-client/package.json
@@ -19,6 +19,7 @@
     "sparkplug-payload": "^1.0.3"
   },
   "optionalDependencies": {
+    "@amrc-factoryplus/gssapi": "^2.1.0",
     "got-fetch": "^5.1.8",
     "gssapi.js": "^2.0.1"
   },


### PR DESCRIPTION
## Summary

Every Factory+ JS service floods the KDC with refused `TGT NOT FORWARDABLE` requests - one per HTTP token fetch and MQTT connection. This PR removes the cause: the `gssapi.js` npm module hardcodes `GSS_C_DELEG_FLAG` in `gss_init_sec_context`, so libkrb5 asks the KDC for a forwarded TGT on every client context. ACS service principals hold non-forwardable TGTs (straight from keytabs), so the KDC refuses every time:

```
TGS_REQ (1 etypes {aes256-cts-hmac-sha1-96(18)}) 10.42.0.42: TGT NOT FORWARDABLE:
    authtime ..., sv1configdb@... for krbtgt/..., KDC can't fulfill requested option
```

libkrb5 silently drops the flag and carries on, so nothing breaks - but every token costs an extra KDC round trip, and under reconnect storms (see #671) this multiplies into thousands of KDC log lines per minute. Nothing in Factory+ consumes delegated credentials; the server side discards them.

## Changes

- **`lib/js-gssapi`**: vendored fork of gssapi.js 2.0.1 (MIT, provenance in README) published as `@amrc-factoryplus/gssapi` 2.1.0. One change: no `GSS_C_DELEG_FLAG`. Publishable via the existing js-lib release workflow with a release tagged `js/gssapi/v2.1.0`.
- **`js-service-client`**: `deps.js` prefers the fork and falls back to `gssapi.js`; the fork is added to `optionalDependencies` alongside the existing entries.
- **`js-service-api`**: takes `GSS` from the service-client re-export instead of its own `gssapi.js` import, so the native dependency has one owner. service-api now loads on GSS-less platforms and fails at auth time rather than import time.

## Rollout

Safe to merge before the npm publish: npm skips unpublished optional dependencies (verified with npm 10.8.2), so installs fall back to upstream `gssapi.js` and behave exactly as today. Once `js/gssapi/v2.1.0` is released to npm, rebuilt images pick the fork up automatically. Services consuming `@amrc-factoryplus/service-client` from the registry (historian-uns, acs-mcp) get the fix when service-client is next published and bumped.

## Verification

A/B tested both modules against a live ACS KDC (fpd-ago, via port-forward) from a Linux container (node:22-bookworm, MIT krb5, cmake - same toolchain as the Docker builds):

| module | SPNEGO token | KDC log |
|---|---|---|
| gssapi.js 2.0.1 | minted, 812 bytes | `TGS_REQ ... ISSUE` **plus** `TGS_REQ (1 etypes ...) TGT NOT FORWARDABLE` |
| fork | minted, 812 bytes | single `TGS_REQ ... ISSUE`, nothing refused |

The refused request's signature (single-etype TGS_REQ for krbtgt) exactly matches the storm seen from every sv1 principal in production KDC logs.

Also verified: the fork compiles on Linux and macOS; with the fork installed, `service-client`'s `GSS` export resolves to it; without it, the fallback to `gssapi.js` loads and `service-api`'s auth module imports cleanly.

## Decisions

- Left the direct `gssapi.js` deps in the handful of services that declare one (acs-i3x, uns-ingester-sparkplug, historian-uns): they are the fallback path and become vestigial once service-client ships the fork; removing them is trivial follow-up cleanup.
- Delegation is removed globally rather than made an option. If a future service genuinely needs delegated credentials it should be an explicit per-context option in the fork.
