### PR TITLE
Install libkrb5-dev in the js-lib publish workflow

### DIFF
--- a/.github/workflows/js-lib.yaml
+++ b/.github/workflows/js-lib.yaml
@@ -28,6 +28,14 @@ jobs:
         with:
           node-version: '20.x'
 
+      # Native libraries (js-gssapi) compile against the MIT Kerberos
+      # headers at install time. These are not preinstalled on the
+      # GitHub runners; installing them is harmless for pure-JS libs.
+      - name: Install native build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libkrb5-dev
+
       - name: Publish package
         working-directory: ${{ inputs.libdir }}
         run: |


### PR DESCRIPTION
## What failed

The `js/gssapi/v2.1.0` release (run 29016308920, 2026-07-09) failed in the
`js-lib / publish` job, so `@amrc-factoryplus/gssapi` was never published to
npm (`npm view @amrc-factoryplus/gssapi` returns E404 for all versions). That
404 broke the v6.0.0-rc.2 release: acs-admin's vite build cannot resolve the
`@amrc-factoryplus/gssapi` import in
`@amrc-factoryplus/service-client/lib/deps.js` (service-client depends on
`@amrc-factoryplus/gssapi: ^2.1.0`).

## Root cause

`js-lib.yaml` runs `npm install` in the library directory before
`npm publish`. For `lib/js-gssapi` (a native addon), `npm install` runs the
package's `install` script, `cmake-js compile`. The CMake configure step
requires the MIT Kerberos development files:

- `CMakeLists.txt` does `find_path(KRB5_INCLUDE_DIR krb5.h ...)` and
  `find_library` for `krb5`, `com_err`, and `gssapi_krb5`, with a
  `FATAL_ERROR` if the libraries are not found.
- The sources include `<krb5.h>`, `<gssapi/gssapi.h>` and
  `<gssapi/gssapi_krb5.h>`.

On Ubuntu these are all provided by `libkrb5-dev`, which is **not**
preinstalled on GitHub's `ubuntu-latest` runner images (only the runtime
`libkrb5-3` is present, which has neither the headers nor the unversioned
`.so` symlinks that `find_library` needs). So the configure step fails and
the publish never happens.

Ruled out: a broken tarball. `dist/index.js` and `dist/index.d.ts` are
committed to git (`git ls-files lib/js-gssapi`), and `npm pack --dry-run`
packs all 12 expected files (dist, CMakeLists.txt, src/*).

## The fix

Add a step to `js-lib.yaml` that installs `libkrb5-dev` before `npm install`.
This is a no-op cost for pure-JS libraries, so the workflow stays generic for
all `js/<lib>/vSEMVER` releases.

## How this was verified

- `npm install` of a copy of `lib/js-gssapi` on a machine with Kerberos dev
  headers available compiles and links cleanly, confirming the code builds
  fine once the headers exist and the failure is environmental.
- YAML syntax of the edited workflow validated.
- The full publish path can only be truly exercised by a release tag (the
  workflow is `workflow_call` from `release.yaml` and needs `NPM_TOKEN`).

## Follow-up after merge (not part of this PR)

Reusable workflows resolve at the tag ref, so the existing `js/gssapi/v2.1.0`
tag would still use the old workflow. After merging:

1. Cut a new `js/gssapi/v2.1.1` release from main to publish
   `@amrc-factoryplus/gssapi` to npm.
2. Re-run the failed v6.0.0-rc.2 jobs once the package resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
