### PR TITLE
Install the GSS fork in-tree so the acs-admin build works and #674 takes effect

### DIFF
--- a/.github/workflows/js-lib.yaml
+++ b/.github/workflows/js-lib.yaml
@@ -28,14 +28,6 @@ jobs:
         with:
           node-version: '20.x'
 
-      # Native libraries (js-gssapi) compile against the MIT Kerberos
-      # headers at install time. These are not preinstalled on the
-      # GitHub runners; installing them is harmless for pure-JS libs.
-      - name: Install native build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libkrb5-dev
-
       - name: Publish package
         working-directory: ${{ inputs.libdir }}
         run: |

--- a/acs-admin/vite.config.js
+++ b/acs-admin/vite.config.js
@@ -78,6 +78,7 @@ export default defineConfig({
       'got': EMPTY,
       'got-fetch': EMPTY,
       'gssapi.js': EMPTY,
+      '@amrc-factoryplus/gssapi': EMPTY,
       'path': 'path-browserify',
       'buffer': 'buffer/',
     },

--- a/acs-auth/package.json
+++ b/acs-auth/package.json
@@ -28,6 +28,9 @@
     "@amrc-factoryplus/service-client": "file:../lib/js-service-client",
     "uuid": "^11.0.5"
   },
+  "optionalDependencies": {
+    "@amrc-factoryplus/gssapi": "file:../lib/js-gssapi"
+  },
   "devDependencies": {
     "@eslint/js": "^9.18.0",
     "ajv": "^8.17.1",

--- a/acs-cluster-manager/package.json
+++ b/acs-cluster-manager/package.json
@@ -24,5 +24,8 @@
     "json-templates": "^5.0.0",
     "tmp-promise": "^3.0.3",
     "yaml": "^2.3.1"
+  },
+  "optionalDependencies": {
+    "@amrc-factoryplus/gssapi": "file:../lib/js-gssapi"
   }
 }

--- a/acs-cmdesc/package.json
+++ b/acs-cmdesc/package.json
@@ -32,5 +32,8 @@
     "http-errors": "^2.0.0",
     "timers-promises": "^1.0.1",
     "type-is": "^1.6.18"
+  },
+  "optionalDependencies": {
+    "@amrc-factoryplus/gssapi": "file:../lib/js-gssapi"
   }
 }

--- a/acs-configdb/package.json
+++ b/acs-configdb/package.json
@@ -31,6 +31,9 @@
     "json-merge-patch": "^1.0.2",
     "rxjs": "^7.8.1"
   },
+  "optionalDependencies": {
+    "@amrc-factoryplus/gssapi": "file:../lib/js-gssapi"
+  },
   "devDependencies": {
     "@eslint/js": "^9.13.0",
     "eslint": "^9.13.0",

--- a/acs-data-access/package.json
+++ b/acs-data-access/package.json
@@ -25,6 +25,9 @@
     "stream-size": "^0.0.6",
     "uuid": "^11.0.5"
   },
+  "optionalDependencies": {
+    "@amrc-factoryplus/gssapi": "file:../lib/js-gssapi"
+  },
   "devDependencies": {
     "eslint": "^9.23.0",
     "vitest": "^4.1.8"

--- a/acs-directory/package.json
+++ b/acs-directory/package.json
@@ -27,5 +27,8 @@
     "async": "^3.2.4",
     "express": "^4.17.1",
     "express-openapi-validator": "^4.13.2"
+  },
+  "optionalDependencies": {
+    "@amrc-factoryplus/gssapi": "file:../lib/js-gssapi"
   }
 }

--- a/acs-edge-sync/package.json
+++ b/acs-edge-sync/package.json
@@ -21,5 +21,8 @@
     "immutable": "^5.1.4",
     "json-merge-patch": "^1.0.2",
     "json-templates": "^5.2.0"
+  },
+  "optionalDependencies": {
+    "@amrc-factoryplus/gssapi": "file:../lib/js-gssapi"
   }
 }

--- a/acs-files/package.json
+++ b/acs-files/package.json
@@ -19,6 +19,9 @@
     "stream-size": "^0.0.6",
     "uuid": "^11.0.5"
   },
+  "optionalDependencies": {
+    "@amrc-factoryplus/gssapi": "file:../lib/js-gssapi"
+  },
   "devDependencies": {
     "eslint": "^9.23.0"
   }

--- a/acs-git/package.json
+++ b/acs-git/package.json
@@ -25,6 +25,9 @@
     "rxjs": "^7.8.1",
     "yaml": "^2.8.2"
   },
+  "optionalDependencies": {
+    "@amrc-factoryplus/gssapi": "file:../lib/js-gssapi"
+  },
   "devDependencies": {
     "@eslint/js": "^9.20.0",
     "eslint": "^9.20.1",

--- a/acs-i3x/package.json
+++ b/acs-i3x/package.json
@@ -43,6 +43,9 @@
     "validator": "^13.15.35",
     "zod": "^4.3.6"
   },
+  "optionalDependencies": {
+    "@amrc-factoryplus/gssapi": "file:../lib/js-gssapi"
+  },
   "devDependencies": {
     "@types/compression": "^1.7.5",
     "@types/express": "^4.17.21",

--- a/acs-monitor/package.json
+++ b/acs-monitor/package.json
@@ -22,6 +22,9 @@
     "rxjs": "^7.8.2",
     "uuid": "^9.0.1"
   },
+  "optionalDependencies": {
+    "@amrc-factoryplus/gssapi": "file:../lib/js-gssapi"
+  },
   "devDependencies": {
     "@eslint/js": "^9.20.0",
     "eslint": "^9.39.2",

--- a/acs-opcua-server-edge/package.json
+++ b/acs-opcua-server-edge/package.json
@@ -13,5 +13,8 @@
     "dependencies": {
         "@amrc-factoryplus/service-client": "file:../lib/js-service-client",
         "node-opcua": "^2.145.0"
+    },
+    "optionalDependencies": {
+        "@amrc-factoryplus/gssapi": "file:../lib/js-gssapi"
     }
 }

--- a/acs-service-setup/package.json
+++ b/acs-service-setup/package.json
@@ -18,6 +18,9 @@
     "uuid": "^11.1.0",
     "yaml": "^2.8.2"
   },
+  "optionalDependencies": {
+    "@amrc-factoryplus/gssapi": "file:../lib/js-gssapi"
+  },
   "devDependencies": {
     "@eslint/js": "^9.16.0",
     "eslint": "^9.39.2",

--- a/edge-helm-charts/package.json
+++ b/edge-helm-charts/package.json
@@ -13,5 +13,8 @@
   "dependencies": {
     "@amrc-factoryplus/service-client": "../lib/js-service-client",
     "isomorphic-git": "^1.32.2"
+  },
+  "optionalDependencies": {
+    "@amrc-factoryplus/gssapi": "file:../lib/js-gssapi"
   }
 }

--- a/historian-sparkplug/package.json
+++ b/historian-sparkplug/package.json
@@ -32,6 +32,9 @@
     "pino": "^8.11.0",
     "pino-pretty": "^10.0.0"
   },
+  "optionalDependencies": {
+    "@amrc-factoryplus/gssapi": "file:../lib/js-gssapi"
+  },
   "devDependencies": {
     "cross-env": "^7.0.3",
     "dotenv": "^16.0.3",

--- a/lib/js-service-api/package-lock.json
+++ b/lib/js-service-api/package-lock.json
@@ -66,7 +66,6 @@
         "globals": "^15.11.0"
       },
       "optionalDependencies": {
-        "@amrc-factoryplus/gssapi": "file:../js-gssapi",
         "got-fetch": "^5.1.8",
         "gssapi.js": "^2.0.1"
       }

--- a/lib/js-service-api/package-lock.json
+++ b/lib/js-service-api/package-lock.json
@@ -66,7 +66,7 @@
         "globals": "^15.11.0"
       },
       "optionalDependencies": {
-        "@amrc-factoryplus/gssapi": "^2.1.0",
+        "@amrc-factoryplus/gssapi": "file:../js-gssapi",
         "got-fetch": "^5.1.8",
         "gssapi.js": "^2.0.1"
       }

--- a/lib/js-service-client/package.json
+++ b/lib/js-service-client/package.json
@@ -19,7 +19,6 @@
     "sparkplug-payload": "^1.0.3"
   },
   "optionalDependencies": {
-    "@amrc-factoryplus/gssapi": "file:../js-gssapi",
     "got-fetch": "^5.1.8",
     "gssapi.js": "^2.0.1"
   },

--- a/lib/js-service-client/package.json
+++ b/lib/js-service-client/package.json
@@ -19,7 +19,7 @@
     "sparkplug-payload": "^1.0.3"
   },
   "optionalDependencies": {
-    "@amrc-factoryplus/gssapi": "^2.1.0",
+    "@amrc-factoryplus/gssapi": "file:../js-gssapi",
     "got-fetch": "^5.1.8",
     "gssapi.js": "^2.0.1"
   },

--- a/uns-ingester-sparkplug/package.json
+++ b/uns-ingester-sparkplug/package.json
@@ -32,6 +32,9 @@
     "pino": "^8.11.0",
     "pino-pretty": "^10.0.0"
   },
+  "optionalDependencies": {
+    "@amrc-factoryplus/gssapi": "file:../lib/js-gssapi"
+  },
   "devDependencies": {
     "cross-env": "^7.0.3",
     "dotenv": "^16.0.3",


### PR DESCRIPTION
## What was broken

`v6.0.0-rc.2`'s release failed: the `acs-admin` image build errored with

```
[vite]: Rollup failed to resolve import "@amrc-factoryplus/gssapi" from
  /app/acs-admin/node_modules/@amrc-factoryplus/service-client/lib/deps.js
```

which fail-fast-cancelled the other 18 JS image builds and skipped the chart release.

## Root cause

Two separate defects, both introduced by 42a88e0a ("Prefer @amrc-factoryplus/gssapi over gssapi.js for GSS"):

1. **The browser build.** `acs-admin` is the only bundled build in the tree, and `vite.config.js` aliases native GSS out of it (`'gssapi.js': EMPTY`). 42a88e0a introduced a *second* bare specifier, `@amrc-factoryplus/gssapi`, into `deps.js` — a module that gets bundled — without adding it to that alias list. `v5.1.0` and `v6.0.0-rc.1` are byte-identical here and built fine; rc.1 predates the vendoring by 3h40m and its `acs-admin` job passed.

2. **The fork was never installed.** It was declared as a *registry* dependency (`^2.1.0`) of a package that is not on npm. `bun install`/`npm install` logged the 404 as a warning and skipped it (it is optional), so `deps.js` fell through its `.catch()` to upstream `gssapi.js` — **with** credential delegation. #674's delegation fix has therefore been inert since it merged.

The npm 404 was never the cause of the build failure. In the same rc.2 run, `acs-edge` (npm, same `deps.js` via `file:`) built successfully.

## The fix

- `acs-admin/vite.config.js`: alias `@amrc-factoryplus/gssapi` to the empty stub, next to the existing `gssapi.js` entry. This alone unblocks the build — aliases intercept the specifier before node resolution, so the package need not be installed. It is also correct on its own merits: without it, an installed fork would drag the native addon loader (`bindings`, `file-uri-to-path`) into the browser bundle.
- The 16 in-tree services that use GSS via `service-client` declare `"@amrc-factoryplus/gssapi": "file:../lib/js-gssapi"` in `optionalDependencies`, which is what actually installs the fork and makes #674 live. A `file:` ref declared *by* a `file:`-linked package does not install — npm resolves the nested path relative to the copied location, hits ENOENT, and silently skips it. `optionalDependencies` (not `dependencies`) matches how `gssapi.js` is declared and keeps `npm install` working without krb5 headers.
- Excluded: `acs-admin` (browser; the alias handles it), `acs-edge` (never imports `service-client`), `acs-example-service` (not built).
- Reverts #675. Its premise was wrong: `js/gssapi/v2.1.0` did not fail on missing Kerberos headers, it failed in 2s at workflow evaluation with `Secret NPM_TOKEN is required, but not provided`. No step ever ran. `js/gssapi/v2.1.1`, cut *with* the libkrb5-dev step, failed identically. The repo has no Actions secrets, and the js-lib workflow has never published anything — it was created 2025-06-16, four days *after* service-client 1.6.0 went to npm. The npm route is abandoned; the fork stays in-tree.

## Verification

- rc.2's failure reproduced locally byte-identically, then `built in 22.14s` with the alias. The bundled GSS import compiles to `import('./emptyModule-...js')`, giving the browser the same `GSS === {}` it has had since before the fork — no behaviour change.
- No native code in the bundle: `node-gssapi` and `file-uri-to-path` both 0 matches.
- The real fork installs and compiles via `npm install --install-links` (`build/Release/node-gssapi.node` present, true GSS surface). The js-build base image already installs `krb5-dev` explicitly "to build gssapi.js", so the fork builds wherever `gssapi.js` already does.
- With the per-service declaration, `deps.js` resolves the fork rather than upstream, even with `gssapi.js` also installed.
- `acs-i3x` jest: 13 suites, 342 tests passing.

## How to test

1. Merge and cut `v6.0.0-rc.3`.
2. Confirm the `acs-admin` build passes and the chart release runs.
3. In a built service image, confirm `node_modules/@amrc-factoryplus/gssapi/build/Release/node-gssapi.node` exists.
4. On a cluster, confirm the KDC no longer logs a refused `TGT NOT FORWARDABLE` request per token/MQTT connect.

## Known gaps

- `acs-edge` imports `@amrc-factoryplus/utilities`, not `service-client`, so edge agents keep the upstream delegating `gssapi.js`. If edge principals contribute to the KDC storm, this does not resolve it for them.
- Registry consumers of `service-client` (`acs-mcp`, `acs-visualiser`, `historian-uns`, `lib/js-sparkplug-app`) resolve the published copy and keep delegating.

## Release notes

Fixes the `acs-admin` image build, which broke in v6.0.0-rc.2. The GSS fork that removes Kerberos credential delegation is now actually installed in the services that use it, so the fix released in #674 takes effect.
