### PR TITLE
Put oauth_allow_insecure_email_lookup in the section Grafana actually reads

### DIFF
--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -468,18 +468,40 @@ grafana:
       root_url: "$__file{/etc/acs-config/root_url}"
     auth:
       # Hide the local username/password form: F+ via Keycloak is the
-      # only intended login path. The default Grafana admin (seed in
-      # Secret grafana-admin-user) is reachable via the URL
-      # /login?disableLoginForm=false for emergency access if Keycloak
-      # is unreachable.
+      # only intended login path.
       #
-      # Operators that want the form back can override with:
+      # There is NO query-parameter escape hatch. With this set,
+      # registration.go does not register the form client at all, so no
+      # interactive or API password login exists -- the local admin in
+      # Secret grafana-admin-user cannot log in while this is true.
+      # To break glass (Keycloak down, no F+ login possible), override
+      # the value and restart the pod:
       #   grafana:
       #     grafana.ini:
       #       auth:
       #         disable_login_form: false
       disable_login_form: true
       oauth_auto_login: false
+      # Required for OAuth to be able to claim an existing Grafana
+      # user at all - without this flag, pkg/services/authn/clients/
+      # oauth.go leaves lookupParams.Email AND lookupParams.Login
+      # both nil, so lookupByOneOf finds nothing, Grafana drops into
+      # createUser, and the create collides with the existing row's
+      # email/login uniqueness check ("user already exists"). The
+      # "insecure" wording refers to providers that don't verify
+      # emails - ours is our own Keycloak federating F+ Auth, and
+      # the FactoryPlusUserAdapter already stamps email_verified=true
+      # because the email is derived from a kerberos-authoritative
+      # F+ Principal record.
+      #
+      # This MUST live under `auth`, not `auth.generic_oauth`: Grafana
+      # reads it with a hardcoded section literal --
+      #   KeyValue("auth", "oauth_allow_insecure_email_lookup")
+      # -- and the grafana subchart renders every top-level grafana.ini
+      # key as its own ini section, so nesting it under
+      # auth.generic_oauth emits [auth.generic_oauth] where the flag is
+      # silently ignored and defaults back to false.
+      oauth_allow_insecure_email_lookup: true
     auth.basic:
       enabled: false
     auth.generic_oauth:
@@ -511,18 +533,6 @@ grafana:
       # revoking Grafana.Perm.* in F+ downgrades on next login rather
       # than letting the 60s SPI cache staleness become permanent.
       role_attribute_strict: true
-      # Required for OAuth to be able to claim an existing Grafana
-      # user at all - without this flag, pkg/services/authn/clients/
-      # oauth.go leaves lookupParams.Email AND lookupParams.Login
-      # both nil, so lookupByOneOf finds nothing, Grafana drops into
-      # createUser, and the create collides with the existing row's
-      # email/login uniqueness check ("user already exists"). The
-      # "insecure" wording refers to providers that don't verify
-      # emails - ours is our own Keycloak federating F+ Auth, and
-      # the FactoryPlusUserAdapter already stamps email_verified=true
-      # because the email is derived from a kerberos-authoritative
-      # F+ Principal record.
-      oauth_allow_insecure_email_lookup: true
   extraConfigmapMounts:
     - name: acs-grafana-config
       mountPath: /etc/acs-config

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -80,8 +80,19 @@ database are all created automatically; there is no manual realm or
 client configuration to do.
 
 Setting `openid.enabled` to `false` will skip Keycloak, but Grafana then
-has no interactive login other than the local emergency admin account,
-which remains reachable at `/login?disableLoginForm=false`.
+has no interactive login at all. Hiding the login form does not leave a
+back door: Grafana does not register the password login client when
+`auth.disable_login_form` is set, so the local admin account cannot sign
+in interactively or over the API, and there is no query parameter that
+re-enables the form. To recover access, put the form back with a values
+override and restart the Grafana pod:
+
+```yaml
+grafana:
+  grafana.ini:
+    auth:
+      disable_login_form: false
+```
 
 ### Grafana upgraded from v10 to v13
 


### PR DESCRIPTION
## The bug

`deploy/values.yaml` nested `oauth_allow_insecure_email_lookup` under the `auth.generic_oauth` map. The grafana subchart renders every top-level `grafana.ini` key as its own ini section, so it landed in `[auth.generic_oauth]` — and Grafana reads it with a hardcoded section literal:

```go
// pkg/services/authn/clients/oauth.go:207 (v13.1.0)
allowInsecureEmailLookup := c.settingsProviderSvc.KeyValue("auth", "oauth_allow_insecure_email_lookup").MustBool(false)
```

go-ini child sections inherit *from* the parent, never the reverse, so the value was silently discarded and the read fell back to `conf/defaults.ini:708` (`false`, declared inside `[auth]`).

## Why that locks everyone out

`oauth.go:206-210` starts with an empty `lookupParams` and only populates `Email` when the flag is true; `Login` is never set on it. With the flag ineffective, `lookupByOneOf` matches nothing, sync falls through to `createUser`, and the insert collides with the existing row's login/email uniqueness — **every user who existed under v5's auth.proxy is refused OAuth login with "user already exists"**, admin included. Only brand-new principals can sign in.

## The fix

Move the key into the `auth` map so it renders into `[auth]`. Verified by render, not by reading — `helm template` now emits:

```ini
[auth]
disable_login_form = true
oauth_allow_insecure_email_lookup = true
oauth_auto_login = false
```

with the `[auth.generic_oauth]` block otherwise unchanged.

Also corrects a false claim in `docs/reference/release-notes.md` and in the values.yaml comment: the v6.0.0 notes said the seeded admin stays reachable at `/login?disableLoginForm=false`. **No such query parameter exists.** With `disable_login_form: true`, `registration.go` does not register the form client at all, so no interactive or API password login exists. Replaced with the real break-glass procedure: override `disable_login_form` to false and restart the pod.

## On grafana/grafana#103974

An earlier review flagged this issue as evidence that the `[auth]` file setting might be ignored anyway. It is not: the reporter closed it himself explaining he had enabled the flag via `PUT /api/admin/settings`, and the resulting row in the `setting` table was shadowing his file config. That override path is Enterprise-only — OSS registers only `GET /admin/settings` (`pkg/api/api.go:116`) and `OSSImpl.Update` hard-returns an error, so the failure mode cannot occur here. `OSSImpl.KeyValue` reads `Cfg.Raw` — the parsed ini file — and nothing else.

Three independent investigations (v13.1.0 source, issue history, chart render) agreed unanimously.

## How to test

1. Upgrade a cluster that has pre-existing v5 Grafana accounts.
2. A user whose account was created by the v5 auth.proxy signs in via the Factory+ button and **reclaims their existing account**, keeping their dashboards — rather than being refused with "user already exists".
3. `kubectl get cm acs-grafana -o yaml` shows the key under `[auth]`.

## Release notes

Fixes Grafana SSO refusing every pre-existing user with "user already exists" after upgrading to v6. Corrects the documented Grafana emergency-access procedure, which described a query parameter that does not exist.