### PR TITLE
Skip the Grafana 13 playlist migration that breaks upgraded databases

### DIFF
--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -533,6 +533,25 @@ grafana:
       # revoking Grafana.Perm.* in F+ downgrades on next login rather
       # than letting the 60s SPI cache staleness become permanent.
       role_attribute_strict: true
+    # Grafana 13 runs a unified-storage data migration for playlists on
+    # boot, enabled by default (MigratedUnifiedResources in
+    # pkg/setting/setting_unified_storage.go). Its SQL selects
+    # playlist.created_at, but the sqlstore migration which adds that
+    # column existed only in 11.x/12.x: v13 deleted playlist_mig.go
+    # entirely, so a database created by Grafana 10.x and upgraded
+    # straight to 13.x never gains the column. Grafana then dies on boot
+    # with "no such column: p.created_at" - the SELECT fails at prepare,
+    # so having no playlists does not help.
+    #
+    # ACS v5.1.0 shipped Grafana 10.0.1, so every site upgrading with a
+    # kept Grafana PVC hits this. Fresh installs do not: v13 seeds the
+    # column from its schema snapshot, which is why CI stayed green.
+    #
+    # Skipping the migration leaves the legacy playlist table untouched
+    # and unified storage with no playlists. ACS does not use playlists.
+    # Drop this key and add the columns by hand if you ever need them.
+    unified_storage.playlists.playlist.grafana.app:
+      enableMigration: false
   extraConfigmapMounts:
     - name: acs-grafana-config
       mountPath: /etc/acs-config


### PR DESCRIPTION
## The bug

Upgrading any ACS v5.1.0 installation to v6 leaves Grafana in CrashLoopBackOff:

```
Error: ✗ unable to start dualwrite service due to migration error:
  unified storage data migration failed: migration failed (id = playlists migration):
  migration failed for org 1 (default): SQL logic error: no such column: p.created_at (1)
```

Reproduced on amrc-fpd-jahx upgrading v5.1.0 -> v6.0.0-rc.4.

## Root cause

`playlist.created_at`/`updated_at` are added by a sqlstore migration that existed **only in the 11.x/12.x line**. Grafana 13 **deleted it** — `pkg/services/sqlstore/migrations/playlist_mig.go` is gone as of v13.0.0 and `migrations.go` no longer calls `addPlaylistMigrations` — so the 13.1.0 binary has no code path that can add those columns to an existing database.

It nevertheless still ships a unified-storage playlist data migration that is enabled by default (`MigratedUnifiedResources[PlaylistResource] = true`, `pkg/setting/setting_unified_storage.go`) whose SQL unconditionally selects `p.created_at` (`pkg/registry/apps/playlist/migrator/query_playlists.sql:7`). It fails at SQLite statement-prepare, so having zero playlists does not avoid it, and `RunMigrations` aborts on first failure so Grafana never finishes booting.

The upgrade paths:

| path | outcome |
|---|---|
| 10.x -> 13.x direct | **broken** — columns never added |
| 10.x -> 11/12 -> 13 | fine — 11/12 add the columns |
| fresh 13 install | fine — v13 seeds them from its schema snapshot |

ACS v5.1.0 ships Grafana 10.0.1 and v6 jumps straight to 13.1.0 (#670), so **every upgraded site hits this and no fresh install does** — which is exactly why CI stayed green through rc.4.

## The fix

Set `enableMigration: false` for the playlists resource. The flag is read at registration time (`pkg/storage/unified/migrations/resources.go:23-33`), so the broken SQL is never assembled — the same mechanism that already disables the datasource/stars/preferences/querycacheconfigs migrations by default.

It touches no data: the legacy `playlist` table is left as-is and unified storage simply has no playlists. ACS does not use playlists. Dashboards, folders, users, datasources and alerts are unaffected.

## Verified on a real cluster

With the migration skipped, on amrc-fpd-jahx:

```
logger=unifiedstorage-migrator msg="migrations completed" performed=0 skipped=2
logger=storage.unified.migrations msg="Unified storage migrations completed successfully"
```

The folder and dashboard migrations — which were masked behind the playlist failure and carry the real ACS data — then completed, and dashboards survived.

`helm template` renders `[unified_storage.playlists.playlist.grafana.app]` / `enableMigration = false`, with the `[auth]` block from #677 intact.

## How to test

1. Install v5.1.0, create a dashboard, upgrade to this build with the Grafana PVC kept.
2. Grafana starts; `kubectl logs deploy/acs-grafana -c grafana | grep -i migration` shows the playlist migration skipped and unified storage migrations completing.
3. The dashboard is still there.

## Notes

- This is an upstream Grafana bug: v13 removed a schema migration that databases in the wild still need. Worth reporting.
- One log line is a red herring — `"Unified storage config has no effect for fully migrated resources"` is emitted *before* the code that reads and honours the key.
- Untested: a fresh v13 install has no `playlist` table at all, so forcing the migration off might leave the Playlists UI empty in Legacy mode. Does not affect upgrades; worth a check against an empty namespace before v6.0.0 final.

## Release notes

Fixes Grafana failing to start after upgrading from v5, with `no such column: p.created_at`. Grafana 13 removed the schema migration that adds the playlist timestamp columns while still running a migration that requires them, so databases created by the Grafana 10.0.1 shipped in v5.1.0 could not start under v6.