### PR TITLE
service-setup: per-client accessTokenLifespan passthrough

### DIFF
--- a/acs-service-setup/lib/openid.js
+++ b/acs-service-setup/lib/openid.js
@@ -294,6 +294,16 @@ class OpenIDSetup {
                 ...(spec.deviceAuthorizationFlowEnabled
                     ? { "oauth2.device.authorization.grant.enabled": "true" }
                     : {}),
+                // Per-client access-token lifespan override, in seconds.
+                // Keycloak's realm default (300s) is right for API tokens
+                // but wrong for an unattended display credential: a kiosk
+                // JWT (e.g. Grafana url_login) is re-presented on every
+                // request and the wall dies at exp, so a kiosk client
+                // wants a long lifespan (days) and a refresh-before-expiry
+                // on the consumer side. Omit for the realm default.
+                ...(spec.accessTokenLifespan
+                    ? { "access.token.lifespan": String(spec.accessTokenLifespan) }
+                    : {}),
             },
         };
         if (secret !== undefined) desired.secret = secret;

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -232,6 +232,13 @@ serviceSetup:
     #     name: Polyptic kiosk
     #     serviceAccountsEnabled: true
     #     standardFlowEnabled: false
+    #
+    # `accessTokenLifespan` (seconds) overrides the realm's access-token
+    # lifespan (default 300s) for one client. A kiosk JWT is re-presented
+    # on every request by the consuming app (e.g. Grafana url_login), so
+    # an unattended display dies at token expiry: give such clients a
+    # long lifespan (e.g. 2592000 = 30 days) and let the consumer refresh
+    # before expiry. Leave unset everywhere a human signs in.
     openidClients:
       grafana:
         enabled: true


### PR DESCRIPTION
Follow-on to #668 (the `serviceAccountsEnabled` passthrough), same shape: one more per-client field for values-declared OIDC clients.

## What
`ensure_client` gains an `accessTokenLifespan` passthrough (seconds) → the Keycloak client attribute `access.token.lifespan`, overriding the realm's access-token lifespan (default 300s) for that one client. Unset = realm default, byte-identical behaviour to today.

## Why
An unattended kiosk consumer authenticates a display via a JWT that the consuming app re-presents on **every** request — e.g. Grafana `auth.jwt url_login`, which is stateless (no session cookie is ever minted; verified by HAR capture on a live wall: hundreds of 200s, then everything 401s the moment the token passes `exp` + leeway). The wall therefore lives exactly one token lifespan, and with the realm's 300s default it gets bounced to the login screen every few minutes. Such clients need a long-lived token (e.g. `2592000` = 30 days) with the consumer refreshing before expiry; the realm default is untouched for every client where a human signs in.

```yaml
serviceSetup:
  config:
    openidClients:
      polyptic-kiosk:
        enabled: true
        serviceAccountsEnabled: true
        standardFlowEnabled: false
        accessTokenLifespan: 2592000
```

Docs added to the values.yaml machine-to-machine client section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)