### PR TITLE
Include the v6 external hosts in the Let's Encrypt certificate

### DIFF
--- a/deploy/templates/lets-encrypt/tls.yaml
+++ b/deploy/templates/lets-encrypt/tls.yaml
@@ -36,6 +36,18 @@ spec:
     - git.{{ .Values.acs.baseUrl}}
     - grafana.{{ .Values.acs.baseUrl}}
     - mqtt.{{ .Values.acs.baseUrl}}
+    {{- /* Hosts new in v6, included only when their service is deployed:
+         a SAN whose DNS record does not exist fails the http01 challenge
+         and wedges renewal of this whole certificate. */}}
+    {{- if .Values.openid.enabled }}
+    - openid.{{ .Values.acs.baseUrl}}
+    {{- end }}
+    {{- if .Values.i3x.enabled }}
+    - i3x.{{ .Values.acs.baseUrl}}
+    {{- end }}
+    {{- if .Values.dataAccess.enabled }}
+    - data-access.{{ .Values.acs.baseUrl}}
+    {{- end }}
     {{- range .Values.acs.letsEncrypt.additionalDnsNames }}
     - {{ . }}
     {{- end }}

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -25,11 +25,13 @@ The detail is in the sections below; this is the order to work in.
 
 1. **Before you start**, add DNS records for the three new external
    hosts (`openid`, `i3x`, `data-access`) and make sure your TLS
-   certificate covers them. If you issue certificates with the chart's
-   Let's Encrypt integration you must add them to
-   `acs.letsEncrypt.additionalDnsNames`, because the chart's own
-   certificate does not include them; a wildcard or externally-managed
-   certificate needs nothing.
+   certificate covers them. The chart's Let's Encrypt certificate
+   includes each of these hosts automatically while its service is
+   enabled, so create the DNS records **before** upgrading: a name on
+   the certificate that does not resolve fails the HTTP-01 challenge and
+   blocks issuance and renewal of the whole certificate. If you disable
+   a service, its host is left off the certificate and needs no record.
+   A wildcard or externally-managed certificate needs nothing.
 2. **Snapshot two persistent volumes.** The Grafana volume, because the
    dashboard and playlist migrations are one-way and cannot be rolled
    back. And the shared Postgres volume, because the Directory database
@@ -108,9 +110,10 @@ other central services continue to authenticate exactly as they did.
 On upgrade you must:
 
 - Create a DNS record for the new `openid.<acs.baseUrl>` host and ensure
-  the certificate Grafana's browser is served covers it. As noted in the
-  upgrade procedure, Let's Encrypt users must add the host to
-  `acs.letsEncrypt.additionalDnsNames`. The Keycloak discovery endpoint
+  the certificate Grafana's browser is served covers it. The chart's
+  Let's Encrypt certificate includes the host automatically while
+  `openid` is enabled, so the record must exist before the upgrade (see
+  the upgrade procedure). The Keycloak discovery endpoint
   must also resolve and present a valid certificate *from inside the
   cluster*, because the `service-setup` Job calls it there; a split-horizon
   DNS setup that only answers externally will wedge the Job.
@@ -261,12 +264,14 @@ unaffected.
 
 `i3x` and `data-access` are both enabled by default, and each publishes
 an external host: `i3x.<acs.baseUrl>` and `data-access.<acs.baseUrl>`.
-Add DNS records and extend your TLS certificate to cover them (for
-Let's Encrypt, add them to `acs.letsEncrypt.additionalDnsNames` as
-above), or set `i3x.enabled` or `dataAccess.enabled` to `false`. These
-services use only cluster-internal URLs at runtime, so a missing DNS
-record or an uncovered host does not stop them running; it stops the
-Manager's Explorer page and the browser-facing API from reaching them.
+Add DNS records and ensure your TLS certificate covers them, or set
+`i3x.enabled` or `dataAccess.enabled` to `false`. The chart's Let's
+Encrypt certificate includes each host automatically while its service
+is enabled, which is why the DNS records must exist before you upgrade;
+a disabled service's host is left off the certificate. These services
+use only cluster-internal URLs at runtime, so a missing DNS record or
+an uncovered host does not stop them running; it stops the Manager's
+Explorer page and the browser-facing API from reaching them.
 
 ### i3X authenticates every request but does not authorize per object
 


### PR DESCRIPTION
## The gap

The chart serves three new external hosts in v6 - `openid.<baseUrl>`, `i3x.<baseUrl>`, `data-access.<baseUrl>` - but `deploy/templates/lets-encrypt/tls.yaml` never listed them, so a Let's Encrypt site served a mismatched certificate on all three. For `openid` that is not cosmetic: the browser's SSO redirect to Keycloak fails on TLS, and the `service-setup` Job's discovery call can fail the same way. The release notes worked around it by telling operators to use `acs.letsEncrypt.additionalDnsNames`.

## The fix

Each host is added to the Certificate's `dnsNames`, gated on its service's enabled flag. The gating matters: a SAN whose DNS record does not exist fails the HTTP-01 challenge and wedges issuance **and renewal of the whole shared certificate**, so a disabled service must not force a DNS requirement onto the site. The release notes are updated to match - the workaround instruction is gone, replaced by "create the DNS records before you upgrade".

Render-verified with `helm template`: hosts present with defaults, individually dropped when `openid.enabled` / `i3x.enabled` / `dataAccess.enabled` are false, `additionalDnsNames` still appended.

## Deliberately not changed

`files.<baseUrl>` and `influxdb.<baseUrl>` are also served but have never been on the certificate - a pre-existing gap from v5. Adding them now would force a DNS requirement onto existing Let's Encrypt sites mid-upgrade (both services are enabled by default) and risk wedging renewal on sites that never created those records. Left for a considered fix, noted here so it is not forgotten.

## How to test

1. `helm template` with `acs.letsEncrypt.enabled=true`: the Certificate lists the three hosts.
2. With `i3x.enabled=false`: `i3x.<baseUrl>` is absent, the other two remain.
3. On a Let's Encrypt cluster with DNS in place, upgrade and confirm cert-manager re-issues with the new SANs and the Keycloak login page serves the new certificate.

## Release notes

The chart's Let's Encrypt certificate now covers the openid, i3x and data-access hosts automatically while those services are enabled. Create their DNS records before upgrading; a name that does not resolve blocks issuance and renewal of the whole certificate.