### PR TITLE
Add files and influxdb to the Let's Encrypt certificate

### DIFF
--- a/deploy/templates/lets-encrypt/tls.yaml
+++ b/deploy/templates/lets-encrypt/tls.yaml
@@ -36,9 +36,15 @@ spec:
     - git.{{ .Values.acs.baseUrl}}
     - grafana.{{ .Values.acs.baseUrl}}
     - mqtt.{{ .Values.acs.baseUrl}}
-    {{- /* Hosts new in v6, included only when their service is deployed:
-         a SAN whose DNS record does not exist fails the http01 challenge
-         and wedges renewal of this whole certificate. */}}
+    {{- /* Per-service hosts, included only when their service is
+         deployed: a SAN whose DNS record does not exist fails the http01
+         challenge and wedges renewal of this whole certificate. */}}
+    {{- if .Values.files.enabled }}
+    - files.{{ .Values.acs.baseUrl}}
+    {{- end }}
+    {{- if .Values.influxdb2.enabled }}
+    - influxdb.{{ .Values.acs.baseUrl}}
+    {{- end }}
     {{- if .Values.openid.enabled }}
     - openid.{{ .Values.acs.baseUrl}}
     {{- end }}

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -31,7 +31,11 @@ The detail is in the sections below; this is the order to work in.
    the certificate that does not resolve fails the HTTP-01 challenge and
    blocks issuance and renewal of the whole certificate. If you disable
    a service, its host is left off the certificate and needs no record.
-   A wildcard or externally-managed certificate needs nothing.
+   The certificate now also covers `files.<baseUrl>` and
+   `influxdb.<baseUrl>`, which were served in v5 but missing from the
+   certificate; a Let's Encrypt site without DNS records for those two
+   must add them before upgrading, for the same reason. A wildcard or
+   externally-managed certificate needs nothing.
 2. **Snapshot two persistent volumes.** The Grafana volume, because the
    dashboard and playlist migrations are one-way and cannot be rolled
    back. And the shared Postgres volume, because the Directory database


### PR DESCRIPTION
Completes #682. `files.<baseUrl>` and `influxdb.<baseUrl>` have been served since v5 but were never on the chart's certificate, so Let's Encrypt sites served a mismatched certificate on both. #682 left them out to avoid imposing a new DNS requirement mid-upgrade; decision taken to fix the oversight properly instead.

Both are added gated on `files.enabled` / `influxdb2.enabled`, matching their ingress gating. Render-verified: present by default, absent when disabled, `additionalDnsNames` unaffected.

The release notes now warn that a Let's Encrypt site without DNS records for these two must create them before upgrading, since an unresolvable SAN fails the HTTP-01 challenge and blocks issuance and renewal of the whole certificate.

## Release notes

The Let's Encrypt certificate now also covers the files and influxdb hosts while those services are enabled. Let's Encrypt sites must ensure DNS records exist for every enabled service's host before upgrading.