### PR TITLE
Give the configdb pre-upgrade backup hook fsGroup so it works on block storage

### DIFF
--- a/deploy/templates/hooks/pre-upgrade-backup.yaml
+++ b/deploy/templates/hooks/pre-upgrade-backup.yaml
@@ -13,6 +13,17 @@ spec:
   template:
     spec:
       restartPolicy: Never
+      # pg_dump runs as the image's non-root "node" user (uid 1000). On a
+      # block storage class that formats volumes root-owned (Ceph RBD, most
+      # CSI drivers), writing the dump to /backups fails with "Permission
+      # denied" and this pre-upgrade hook aborts the whole helm upgrade.
+      # local-path provisions its dirs world-writable, so the fault is
+      # invisible there - it only shows on real block storage. fsGroup 1000
+      # (matching the files service) makes the kubelet chown the backup
+      # volume group-writable and adds the process to that group.
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
       volumes:
         - name: krb5-conf
           configMap:


### PR DESCRIPTION
## The bug

Upgrading the production amrc-fp cluster to v6.0.0 aborted at the `configdb-pre-upgrade-backup` helm pre-upgrade hook:

```
pg_dump: error: could not open output file "/backups/configdb-backup-....sql": Permission denied
```

The hook runs `pg_dump` as the image's non-root `node` user (uid 1000) but its pod has no `securityContext`. On a storage class that formats volumes root-owned - Ceph RBD and most CSI block drivers - the non-root process cannot write to `/backups`, and because it is a `pre-upgrade` hook the whole `helm upgrade` aborts before any v6 manifest is applied.

## Why it passed every test

The fault is storage-class-dependent. It was tested extensively on a `local-path` cluster, whose provisioner creates directories world-writable (`mkdir -m 0777`), so the missing `fsGroup` never mattered. It only appears on real block storage. The production cluster runs rook-ceph; the test cluster was on local-path.

## The fix

Add the same pod `securityContext` the files service already uses:

```yaml
securityContext:
  fsGroup: 1000
  fsGroupChangePolicy: OnRootMismatch
```

The kubelet then chowns the backup volume group-writable and adds the process to group 1000. No behaviour change on local-path (already writable).

## Note

The hook is gated by a `lookup` for an existing `configdb-backups` PVC, so it does not render under `helm template`; verified structurally instead (pod-level securityContext, correct values). This is the only thing in the chart that writes to that volume.

## Release notes

Fixes v6.0.0 aborting at the ConfigDB pre-upgrade backup on clusters using Ceph or other block storage that formats volumes root-owned; the backup job could not write its dump. No effect on local-path installations.