### PR TITLE
Visualiser: Keycloak login with JWT support and kiosk auth_token

### DIFF
--- a/acs-mqtt/pom.xml
+++ b/acs-mqtt/pom.xml
@@ -40,6 +40,11 @@
             <artifactId>json</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+            <version>9.48</version>
+        </dependency>
+        <dependency>
             <groupId>io.reactivex.rxjava3</groupId>
             <artifactId>rxjava</artifactId>
         </dependency>

--- a/acs-mqtt/src/main/java/uk/co/amrc/factoryplus/hivemq_auth_krb/FPJwtVerifier.java
+++ b/acs-mqtt/src/main/java/uk/co/amrc/factoryplus/hivemq_auth_krb/FPJwtVerifier.java
@@ -1,0 +1,108 @@
+/* Factory+ HiveMQ auth plugin.
+ * Keycloak JWT verification.
+ * Copyright 2026 University of Sheffield AMRC
+ */
+
+package uk.co.amrc.factoryplus.hivemq_auth_krb;
+
+import java.net.URL;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.jwk.source.JWKSourceBuilder;
+import com.nimbusds.jose.proc.JWSVerificationKeySelector;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
+import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
+import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+
+/* Verifies Keycloak-issued JWTs presented as MQTT passwords, mirroring
+ * lib/js-service-api's JwtVerifier for the HTTP services. Configured
+ * from OIDC_DISCOVERY_URL; when that is unset JWT auth is disabled and
+ * passwords go to Kerberos as before.
+ *
+ * The discovery document is fetched lazily on first use so the broker
+ * still starts when Keycloak is down; nimbus's remote JWK source
+ * handles JWKS caching and refresh (including on unknown kid, which
+ * covers Keycloak key rotation). */
+public class FPJwtVerifier
+{
+    private static final Logger log = LoggerFactory.getLogger(FPJwtVerifier.class);
+
+    /* Deliberately identical in spirit to looks_like_jwt in
+     * js-service-api: three dot-separated base64url sections. Opaque
+     * F+ tokens are plain base64 so never match. */
+    private static final Pattern JWT_RX = Pattern.compile(
+        "^[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+$");
+
+    private final String discovery_url;
+    private ConfigurableJWTProcessor<SecurityContext> processor;
+
+    public FPJwtVerifier (String discovery_url)
+    {
+        this.discovery_url =
+            discovery_url == null || discovery_url.isBlank()
+                ? null : discovery_url;
+    }
+
+    public boolean enabled ()
+    {
+        return discovery_url != null;
+    }
+
+    public static boolean looksLikeJwt (CharSequence creds)
+    {
+        return JWT_RX.matcher(creds).matches();
+    }
+
+    /* Verify signature, expiry and issuer, and return the kerberos UPN
+     * from preferred_username (stamped by the F+ Keycloak SPI). Makes
+     * network calls (discovery, JWKS); run on a worker thread. */
+    public String verify (String token) throws Exception
+    {
+        JWTClaimsSet claims = processor().process(token, null);
+        String upn = claims.getStringClaim("preferred_username");
+        if (upn == null || upn.isBlank())
+            throw new SecurityException("JWT has no preferred_username claim");
+        return upn;
+    }
+
+    private synchronized ConfigurableJWTProcessor<SecurityContext> processor ()
+        throws Exception
+    {
+        if (processor != null)
+            return processor;
+
+        log.info("Fetching OIDC discovery document from {}", discovery_url);
+        JSONObject disco;
+        try (var body = new URL(discovery_url).openStream()) {
+            disco = new JSONObject(new JSONTokener(body));
+        }
+        String issuer = disco.getString("issuer");
+        URL jwks_uri = new URL(disco.getString("jwks_uri"));
+
+        JWKSource<SecurityContext> keys = JWKSourceBuilder
+            .create(jwks_uri)
+            .retrying(true)
+            .build();
+
+        var proc = new DefaultJWTProcessor<SecurityContext>();
+        proc.setJWSKeySelector(
+            new JWSVerificationKeySelector<>(JWSAlgorithm.RS256, keys));
+        proc.setJWTClaimsSetVerifier(new DefaultJWTClaimsVerifier<>(
+            new JWTClaimsSet.Builder().issuer(issuer).build(),
+            Set.of("exp", "preferred_username")));
+
+        processor = proc;
+        return processor;
+    }
+}

--- a/acs-mqtt/src/main/java/uk/co/amrc/factoryplus/hivemq_auth_krb/FPKrbAuth.java
+++ b/acs-mqtt/src/main/java/uk/co/amrc/factoryplus/hivemq_auth_krb/FPKrbAuth.java
@@ -121,6 +121,15 @@ public class FPKrbAuth implements EnhancedAuthenticator {
         /* XXX should passwords be UTF-8? */
         var passwd_c = StandardCharsets.UTF_8.decode(passwd);
 
+        /* A Keycloak JWT may be presented as the password (browser
+         * clients logged in via OIDC). The username is ignored:
+         * identity comes from the verified token. */
+        String passwd_s = passwd_c.toString();
+        if (FPJwtVerifier.looksLikeJwt(passwd_s) && provider.jwtEnabled()) {
+            handleVerification(output, provider.verifyJwt(passwd_s));
+            return;
+        }
+
         var verify = provider.verifyPassword(user, passwd_c);
         handleVerification(output, verify);
     }

--- a/acs-mqtt/src/main/java/uk/co/amrc/factoryplus/hivemq_auth_krb/FPKrbAuthProvider.java
+++ b/acs-mqtt/src/main/java/uk/co/amrc/factoryplus/hivemq_auth_krb/FPKrbAuthProvider.java
@@ -30,6 +30,7 @@ import org.ietf.jgss.*;
 import org.json.*;
 
 import io.reactivex.rxjava3.core.*;
+import io.vavr.control.Option;
 
 import uk.co.amrc.factoryplus.client.*;
 import uk.co.amrc.factoryplus.gss.FPGssResult;
@@ -55,10 +56,12 @@ public class FPKrbAuthProvider implements EnhancedAuthenticatorProvider
         "8e32801b-f35a-4cbf-a5c3-2af64d3debd7");
 
     private FPServiceClient fplus;
+    private FPJwtVerifier jwt;
 
     public FPKrbAuthProvider ()
     {
         fplus = new FPServiceClient();
+        jwt = new FPJwtVerifier(System.getenv("OIDC_DISCOVERY_URL"));
     }
 
     public FPKrbAuthProvider start ()
@@ -86,6 +89,21 @@ public class FPKrbAuthProvider implements EnhancedAuthenticatorProvider
          * pool. */
         return fplus.gss()
             .verifyPassword(user, passwd)
+            .subscribeOn(fplus.getScheduler());
+    }
+
+    public boolean jwtEnabled ()
+    {
+        return jwt.enabled();
+    }
+
+    public Single<FPGssResult> verifyJwt (String token)
+    {
+        /* Verification may fetch the OIDC discovery document and JWKS
+         * over the network; keep it off the HiveMQ threads. */
+        return Single
+            .fromCallable(() -> new FPGssResult(
+                jwt.verify(token), Option.none()))
             .subscribeOn(fplus.getScheduler());
     }
 

--- a/acs-visualiser/bin/server.js
+++ b/acs-visualiser/bin/server.js
@@ -9,6 +9,16 @@
 import express from "express";
 
 const app = express();
+
+/* Runtime configuration for the browser app. When OIDC_DISCOVERY_URL
+ * is set the frontend delegates login to Keycloak; otherwise it falls
+ * back to the built-in username/password form. */
+app.get("/config.json", (req, res) => res.json({
+    oidc_discovery_url:     process.env.OIDC_DISCOVERY_URL || null,
+    oidc_client_id:         process.env.OIDC_CLIENT_ID || "visualiser",
+    directory_url:          process.env.DIRECTORY_EXTERNAL_URL || null,
+}));
+
 app.use(express.static("public", {
     maxAge: "1d",
 }));

--- a/acs-visualiser/public/index.js
+++ b/acs-visualiser/public/index.js
@@ -7,6 +7,7 @@
 import MQTTClient from "./mqttclient.js";
 import Vis from "./vis.js";
 import Icons from "./icons.js";
+import { OidcClient } from "./oidc.js";
 import { FactoryPlus } from "./webpack.js";
 
 class FPlusVis {
@@ -45,11 +46,11 @@ class FPlusVis {
 
     async build_clients (opts, graph) {
         const directories = opts.directory.split(/\s+/);
-        const { username, password } = opts;
+        const { username, password, bearer_jwt } = opts;
 
-        return Promise.all(directories.map(async directory_url => { 
+        return Promise.all(directories.map(async directory_url => {
             const fplus = await new FactoryPlus.ServiceClient({
-                directory_url, username, password,
+                directory_url, username, password, bearer_jwt,
                 verbose:        "ALL",
                 browser:        true,
             }).init();
@@ -102,11 +103,8 @@ class FPlusVis {
             ["directory", "username", "password", "save", "login"]
                 .map(n => document.getElementById(n));
 
-        if (directory.value == "") {
-            const here = new URL(document.baseURI);
-            here.host = here.host.replace(/^[^.]*/, "directory");
-            directory.value = here.toString();
-        }
+        if (directory.value == "")
+            directory.value = this.default_directory();
 
         return new Promise((resolve, reject) => {
             login.addEventListener("click", () => {
@@ -127,12 +125,60 @@ class FPlusVis {
     async keydown (ev) {
         if (ev.key != "Escape") return;
 
+        if (this.oidc) {
+            await this.stop_vis();
+            this.oidc.logout();
+            return;
+        }
+
         this.clear_creds();
         await this.stop_vis();
         this.run();
     }
 
+    default_directory () {
+        const here = new URL(document.baseURI);
+        here.host = here.host.replace(/^[^.]*/, "directory");
+        return here.toString();
+    }
+
+    async fetch_config () {
+        try {
+            const res = await fetch("config.json");
+            if (!res.ok) return null;
+            return await res.json();
+        }
+        catch { return null; }
+    }
+
+    /* Log in via Keycloak. This may navigate away (to the Keycloak
+     * login page, or straight back if the SSO session is alive), and
+     * a `?auth_token=` JWT in our URL bypasses login entirely. */
+    async oidc_login (config) {
+        const oidc = await new OidcClient({
+            discovery_url:  config.oidc_discovery_url,
+            client_id:      config.oidc_client_id,
+        }).init();
+        await oidc.ensure_login();
+        this.oidc = oidc;
+        console.log("Logged in via OIDC as %s", oidc.username);
+
+        return {
+            directory:  config.directory_url ?? this.default_directory(),
+            bearer_jwt: bad => oidc.token(bad),
+        };
+    }
+
     async run () {
+        const config = await this.fetch_config();
+
+        if (config?.oidc_discovery_url) {
+            const creds = await this.oidc_login(config);
+            this.start_vis(creds);
+            return;
+        }
+
+        /* No OIDC configured (local dev): username/password form. */
         let creds = this.load_creds();
         if (!creds) {
             this.form.style.display = "";

--- a/acs-visualiser/public/oidc.js
+++ b/acs-visualiser/public/oidc.js
@@ -1,0 +1,272 @@
+/*
+ * Factory+ visualisation.
+ * Keycloak OIDC login (Authorization Code + PKCE) and token refresh.
+ * Copyright 2026 University of Sheffield AMRC
+ */
+
+const STORAGE = "fpvis-oidc";
+const SESSION = "fpvis-oidc-flow";
+
+/* Refresh this many seconds before the access token expires. */
+const REFRESH_MARGIN = 60;
+
+function b64url (buf) {
+    return btoa(String.fromCharCode(...new Uint8Array(buf)))
+        .replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function jwt_claims (token) {
+    try {
+        const b64 = token.split(".")[1]
+            .replace(/-/g, "+").replace(/_/g, "/");
+        return JSON.parse(atob(b64));
+    }
+    catch { return undefined; }
+}
+
+/* Delegates login to the Keycloak realm advertised by the discovery
+ * URL. Usage: construct, then `await ensure_login()`; this may
+ * navigate away (to Keycloak) and never resolve. Afterwards `token()`
+ * returns a valid access token, refreshing when needed.
+ *
+ * A token supplied via the `auth_token` query parameter (kiosk mode,
+ * matching Grafana's url_login) is used as-is: no refresh is possible
+ * as we hold no refresh token, so such tokens should be issued with a
+ * long lifespan (see values.yaml `accessTokenLifespan`). */
+export class OidcClient {
+    constructor (opts) {
+        this.discovery_url = opts.discovery_url;
+        this.client_id = opts.client_id;
+        this.redirect_uri = new URL(location.pathname, location.origin)
+            .toString();
+        this.tokens = null;
+        this.static_token = null;
+    }
+
+    async init () {
+        const res = await fetch(this.discovery_url);
+        if (!res.ok)
+            throw new Error(`OIDC discovery failed: ${res.status}`);
+        this.provider = await res.json();
+        return this;
+    }
+
+    /* The kerberos UPN of the logged-in user, for display. */
+    get username () {
+        const tok = this.static_token ?? this.tokens?.access_token;
+        return tok ? jwt_claims(tok)?.preferred_username : undefined;
+    }
+
+    async ensure_login () {
+        const here = new URL(location.href);
+
+        /* Kiosk mode: a JWT in the URL bypasses login entirely. Strip
+         * it from the address bar so it doesn't leak via bookmarks or
+         * copied links. */
+        const auth_token = here.searchParams.get("auth_token");
+        if (auth_token) {
+            here.searchParams.delete("auth_token");
+            history.replaceState(null, "", here);
+            this.static_token = auth_token;
+            return;
+        }
+
+        /* Returning from Keycloak with an authorization code. */
+        if (here.searchParams.get("code")) {
+            await this.finish_code_flow(here);
+            return;
+        }
+
+        /* An earlier session we can resume with the refresh token. */
+        const stored = this.load_tokens();
+        if (stored) {
+            this.tokens = stored;
+            try {
+                if (this.expiring_soon())
+                    await this.refresh();
+                this.schedule_refresh();
+                return;
+            }
+            catch (e) {
+                console.log(`Stored session unusable: ${e}`);
+                this.clear_tokens();
+            }
+        }
+
+        /* No credentials at all: go to Keycloak. If the Keycloak SSO
+         * session is still alive this bounces straight back without
+         * showing a login form. This navigates away; park forever. */
+        await this.start_code_flow();
+        await new Promise(() => {});
+    }
+
+    async start_code_flow () {
+        const verifier = b64url(crypto.getRandomValues(new Uint8Array(32)));
+        const challenge = b64url(await crypto.subtle.digest("SHA-256",
+            new TextEncoder().encode(verifier)));
+        const state = b64url(crypto.getRandomValues(new Uint8Array(16)));
+
+        sessionStorage.setItem(SESSION,
+            JSON.stringify({ verifier, state }));
+
+        const url = new URL(this.provider.authorization_endpoint);
+        url.search = new URLSearchParams({
+            response_type:          "code",
+            client_id:              this.client_id,
+            redirect_uri:           this.redirect_uri,
+            scope:                  "openid profile",
+            state,
+            code_challenge:         challenge,
+            code_challenge_method:  "S256",
+        });
+        location.assign(url);
+    }
+
+    async finish_code_flow (here) {
+        const flow = JSON.parse(sessionStorage.getItem(SESSION) ?? "null");
+        sessionStorage.removeItem(SESSION);
+
+        const code = here.searchParams.get("code");
+        const state = here.searchParams.get("state");
+
+        /* Clean the code out of the address bar whatever happens. */
+        for (const p of ["code", "state", "session_state", "iss"])
+            here.searchParams.delete(p);
+        history.replaceState(null, "", here);
+
+        if (!flow || flow.state !== state)
+            throw new Error("OIDC state mismatch");
+
+        await this.grant({
+            grant_type:     "authorization_code",
+            code,
+            redirect_uri:   this.redirect_uri,
+            code_verifier:  flow.verifier,
+        });
+        this.schedule_refresh();
+    }
+
+    async grant (params) {
+        const res = await fetch(this.provider.token_endpoint, {
+            method:     "POST",
+            headers:    { "Content-Type": "application/x-www-form-urlencoded" },
+            body:       new URLSearchParams({
+                client_id: this.client_id,
+                ...params,
+            }),
+        });
+        if (!res.ok)
+            throw new Error(`Token request failed: ${res.status}`);
+
+        const json = await res.json();
+        this.tokens = {
+            access_token:   json.access_token,
+            refresh_token:  json.refresh_token,
+            expires_at:     Date.now() + json.expires_in * 1000,
+        };
+        this.save_tokens();
+    }
+
+    async refresh () {
+        if (!this.tokens?.refresh_token)
+            throw new Error("No refresh token");
+        await this.grant({
+            grant_type:     "refresh_token",
+            refresh_token:  this.tokens.refresh_token,
+        });
+    }
+
+    expiring_soon () {
+        return this.tokens.expires_at - Date.now() < REFRESH_MARGIN * 1000;
+    }
+
+    /* Refresh proactively rather than waiting for a 401: this keeps
+     * the Keycloak session alive on an unattended display and means
+     * an MQTT reconnect always finds a live token. */
+    schedule_refresh () {
+        clearTimeout(this._timer);
+        const delay = Math.max(5000,
+            this.tokens.expires_at - Date.now() - REFRESH_MARGIN * 1000);
+        this._timer = setTimeout(async () => {
+            try {
+                await this.refresh();
+                this.schedule_refresh();
+            }
+            catch (e) {
+                /* Refresh token expired or revoked. Head back to
+                 * Keycloak; a live SSO session makes this invisible. */
+                console.log(`Token refresh failed, re-authenticating: ${e}`);
+                this.clear_tokens();
+                this.start_code_flow();
+            }
+        }, delay);
+    }
+
+    /* Token provider for the ServiceClient `bearer_jwt` option. `bad`
+     * is a token which has just been rejected; if it is our current
+     * token, refresh before returning. */
+    async token (bad) {
+        if (this.static_token) {
+            if (jwt_claims(this.static_token)?.exp * 1000 < Date.now())
+                console.log("Kiosk auth_token has expired");
+            return this.static_token;
+        }
+
+        if (!this.tokens) {
+            /* Tokens were cleared (failed refresh) while another
+             * caller was in flight; re-auth is already underway. */
+            await new Promise(() => {});
+        }
+
+        if (this.expiring_soon()
+                || (bad && bad === this.tokens.access_token)) {
+            try {
+                await this.refresh();
+                this.schedule_refresh();
+            }
+            catch (e) {
+                console.log(`Token refresh failed, re-authenticating: ${e}`);
+                this.clear_tokens();
+                await this.start_code_flow();
+                await new Promise(() => {});
+            }
+        }
+        return this.tokens.access_token;
+    }
+
+    logout () {
+        clearTimeout(this._timer);
+        this.clear_tokens();
+        if (this.static_token || !this.provider.end_session_endpoint) {
+            location.reload();
+            return;
+        }
+        const url = new URL(this.provider.end_session_endpoint);
+        url.search = new URLSearchParams({
+            client_id:                  this.client_id,
+            post_logout_redirect_uri:   this.redirect_uri,
+        });
+        location.assign(url);
+    }
+
+    save_tokens () {
+        try {
+            localStorage.setItem(STORAGE, JSON.stringify(this.tokens));
+        }
+        catch (e) {
+            console.log(`LocalStorage failed: ${e}`);
+        }
+    }
+
+    load_tokens () {
+        try {
+            return JSON.parse(localStorage.getItem(STORAGE) ?? "null");
+        }
+        catch { return null; }
+    }
+
+    clear_tokens () {
+        this.tokens = null;
+        localStorage.removeItem(STORAGE);
+    }
+}

--- a/deploy/templates/mqtt/mqtt.yaml
+++ b/deploy/templates/mqtt/mqtt.yaml
@@ -56,6 +56,7 @@ spec:
               value: "{{ .Values.acs.secure | ternary "mqtts://" "mqtt://" }}mqtt.{{.Values.acs.baseUrl | required "values.acs.baseUrl is required"}}"
             - name: VERBOSE
               value: {{.Values.mqtt.verbosity | quote | required "values.mqtt.verbosity is required!"}}
+{{ include "amrc-connectivity-stack.oidc-env" . | indent 12 }}
           volumeMounts:
             - mountPath: /etc/krb5.conf
               name: krb5-conf

--- a/deploy/templates/visualiser/visualiser.yaml
+++ b/deploy/templates/visualiser/visualiser.yaml
@@ -26,6 +26,11 @@ spec:
           env:
             - name: PORT
               value: "8080"
+            - name: OIDC_CLIENT_ID
+              value: visualiser
+            - name: DIRECTORY_EXTERNAL_URL
+              value: {{ include "amrc-connectivity-stack.external-url" (list . "directory") | quote }}
+{{ include "amrc-connectivity-stack.oidc-env" . | indent 12 }}
 {{ include "amrc-connectivity-stack.image" (list . .Values.visualiser) | indent 10 }}
 ---
 apiVersion: v1

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -244,6 +244,15 @@ serviceSetup:
         enabled: true
         name: Grafana
         redirectPath: /login/generic_oauth
+      # Browser SPA doing Authorization Code + PKCE; public because a
+      # client secret cannot be kept in a browser. The visualiser also
+      # honours a `?auth_token=<JWT>` query parameter (like Grafana's
+      # url_login) for unattended kiosk displays; mint such tokens from
+      # a service-account client with a long accessTokenLifespan.
+      visualiser:
+        enabled: true
+        name: ACS Visualiser
+        publicClient: true
       # Postman / curl / scripted-API client. Public (no client secret)
       # so it can be configured directly in Postman without keeping a
       # secret out of source control; PKCE S256 is enforced by

--- a/docs/auth/cli-and-jwt.md
+++ b/docs/auth/cli-and-jwt.md
@@ -164,6 +164,27 @@ The chart wires `OIDC_DISCOVERY_URL` into all eight services via the
 shared `amrc-connectivity-stack.oidc-env` helper, so opting a new
 service in is a single-line include in its deployment template.
 
+The MQTT broker also accepts JWTs: present the JWT as the MQTT
+password (the username is ignored; identity comes from the verified
+token's `preferred_username`). The HiveMQ plugin validates against
+the same realm via `OIDC_DISCOVERY_URL` and runs the normal MQTT ACL
+lookup for that principal.
+
+## The visualiser
+
+The visualiser is a browser SPA and logs in via the Keycloak login
+page (Authorization Code + PKCE, client `visualiser`), holding the
+JWT in the browser. It refreshes the token before expiry and uses it
+for the Directory, ConfigDB and the MQTT websocket connection.
+Pressing Escape logs out via Keycloak's end-session endpoint.
+
+For unattended kiosk displays it also supports Grafana-style URL
+login: `https://visualiser.<acs-base>/?auth_token=<JWT>` bypasses
+login entirely. The token is stripped from the address bar
+immediately. No refresh is possible in this mode, so mint the token
+from a service-account client with a long `accessTokenLifespan` (see
+`values.yaml` `serviceSetup.config.openidClients`).
+
 ## How services validate the JWT
 
 The auth middleware in `lib/js-service-api`:

--- a/lib/js-service-client/lib/service-client.js
+++ b/lib/js-service-client/lib/service-client.js
@@ -57,6 +57,10 @@ All interfaces use these options:
 - `directory_url`: The URL of the Directory, to start discovery.
 - `username`: The username to use (optional).
 - `password`: The password to use (optional).
+- `bearer_jwt`: A Keycloak JWT, or a (possibly async) function
+  returning one, used as the credential for every service including
+  MQTT (optional). The function is called with a known-bad token when
+  a refresh is needed.
 - `verbose`: Used to configure a Debug object.
 - `browser`: Must be set to true if we are running in a browser.
 

--- a/lib/js-service-client/lib/service/fetch.js
+++ b/lib/js-service-client/lib/service/fetch.js
@@ -243,6 +243,22 @@ prevent non-root service registrations from working correctly.
                 _with_auth(opts, "Bearer", jwt_ctx.jwt));
         }
 
+        /* If the client was constructed with its own Keycloak JWT
+         * (browser apps logged in via OIDC) send that directly. Unlike
+         * the forwarding case above we retry once on 401: the provider
+         * function is given the known-bad token and can refresh. */
+        if (this.fplus.opts.bearer_jwt) {
+            let jwt = await this.client_jwt();
+            let res = await this._real_fetch(url,
+                _with_auth(opts, "Bearer", jwt));
+            if (res?.status === 401) {
+                jwt = await this.client_jwt(jwt);
+                res = await this._real_fetch(url,
+                    _with_auth(opts, "Bearer", jwt));
+            }
+            return res;
+        }
+
         let token;
         const try_fetch = async () => {
             token = await this.service_token(opts.service_url, token);
@@ -257,15 +273,34 @@ prevent non-root service registrations from working correctly.
         return res;
     }
 
+    /** Resolve the client-wide `bearer_jwt` option to a token.
+     * The option may be a string or a function; a function is called
+     * with a known-bad token (if we have one) so it can refresh.
+     * Returns undefined if the option is not set.
+     * @arg bad (optional) A known-expired token.
+     */
+    async client_jwt (bad) {
+        const src = this.fplus.opts.bearer_jwt;
+        if (!src) return undefined;
+        return typeof src == "function" ? await src(bad) : src;
+    }
+
     /** Get a token for a service.
      * This fetches a bearer token from the /token endpoint. If a
      * known-bad token is passed in, because it has been used in a
      * request which got a 401 response, a new token will be requested
      * if the current token matches.
+     *
+     * If the client has a `bearer_jwt` this returns the JWT instead;
+     * the services accept a Keycloak JWT anywhere they accept an
+     * opaque token (notably WebSocket auth).
      * @arg base_url The service URL to get a token for.
      * @arg bad (optional) A known-expired token.
      */
     async service_token (base_url, bad) {
+        if (this.fplus.opts.bearer_jwt)
+            return this.client_jwt(bad);
+
         /* This might be a token or a promise for one */
         let token = this.tokens.get(base_url);
 

--- a/lib/js-service-client/lib/service/mqtt.js
+++ b/lib/js-service-client/lib/service/mqtt.js
@@ -121,6 +121,58 @@ export async function gss_mqtt (url, opts) {
     return mqtt;
 }
 
+/* Best-effort decode of a JWT's claims. No verification: the broker
+ * verifies, we only want the username for MQTT's CONNECT packet and
+ * for logging. */
+function jwt_claims (token) {
+    try {
+        const b64 = token.split(".")[1]
+            .replace(/-/g, "+").replace(/_/g, "/");
+        return JSON.parse(atob(b64));
+    }
+    catch { return undefined; }
+}
+
+/* Authenticate to the broker with a Keycloak JWT as the password. The
+ * broker ignores the username for JWT auth (identity comes from the
+ * verified token) but MQTT requires one, so send preferred_username.
+ * Tokens expire, so on every reconnect ask the provider for a current
+ * token, passing the one we just used as known-bad. */
+async function jwt_mqtt (url, opts, get_jwt) {
+    const verb = get_verb_from(opts);
+
+    const fresh_creds = async bad => {
+        const jwt = await get_jwt(bad);
+        const claims = jwt_claims(jwt);
+        return {
+            username: claims?.preferred_username ?? "jwt",
+            password: jwt,
+        };
+    };
+
+    const creds = await fresh_creds();
+    const mqtt = MQTT.connect(url, {
+        reconnectPeriod: 3000,
+        protocolVersion: 5,
+        ...opts,
+        ...creds,
+    });
+    mqtt.on("connect", ack => {
+        verb("MQTT connected (JWT)");
+        mqtt.emit("authenticated", ack);
+    });
+    mqtt.on("close", () => {
+        verb("MQTT fetching fresh JWT for reconnect");
+        fresh_creds(mqtt.options.password)
+            .then(creds => {
+                mqtt.options.username = creds.username;
+                mqtt.options.password = creds.password;
+            })
+            .catch(e => verb(`MQTT JWT refresh failed: ${e}`));
+    });
+    return mqtt;
+}
+
 async function basic_mqtt(url, opts) {
     const verb = get_verb_from(opts);
 
@@ -182,7 +234,12 @@ export class MQTTInterface extends ServiceInterface {
 
         this.debug.log("mqtt", `Connecting to broker ${url}`);
 
-        const { username, password } = this.fplus.opts;
+        const { username, password, bearer_jwt } = this.fplus.opts;
+
+        if (bearer_jwt)
+            return await jwt_mqtt(url, opts,
+                bad => this.fplus.Fetch.client_jwt(bad));
+
         const mqopts = {
             ...opts,
             username, password,


### PR DESCRIPTION
## Summary

The visualiser now logs in through the Keycloak login page instead of its custom credentials form, supports Grafana-style `?auth_token=<JWT>` URL login for kiosk displays, and handles token refresh so unattended sessions survive access-token expiry.

Two pieces of enabling infrastructure:

- **`lib/js-service-client`**: new `bearer_jwt` option (a token, or a refresh-aware provider function) used as the credential for HTTP, WebSocket auth and MQTT. The MQTT path re-resolves the token on every reconnect so a reconnect never presents a stale JWT.
- **`acs-mqtt` (HiveMQ plugin)**: accepts a Keycloak JWT as the MQTT password, mirroring the js-service-api JWT support. Verifies against the realm JWKS via `OIDC_DISCOVERY_URL` (nimbus-jose-jwt, lazy discovery so the broker starts while Keycloak is down), takes the principal from `preferred_username` (the kerberos UPN stamped by the F+ SPI), and runs the existing ACL pipeline unchanged. Non-JWT passwords go to Kerberos as before.

Visualiser specifics:

- Authorization Code + PKCE against a new public `visualiser` Keycloak client (PKCE S256 enforced by service-setup's existing public-client handling).
- Runtime config via a new `/config.json` endpoint fed by chart env vars. Without `OIDC_DISCOVERY_URL` the old username/password form remains as a local-dev fallback.
- Proactive refresh 60s before expiry, reactive refresh on 401, silent re-auth through the SSO session when the refresh token dies. Escape logs out via the end-session endpoint.
- `?auth_token=` is stripped from the address bar immediately; no refresh in kiosk mode, so mint kiosk tokens from a service-account client with a long `accessTokenLifespan`.

Chart: provisions the `visualiser` OIDC client and wires `OIDC_DISCOVERY_URL` into the visualiser and mqtt deployments, plus `DIRECTORY_EXTERNAL_URL` so the frontend need not derive the Directory URL from the page host.

## How to test

1. Deploy this branch (`helm upgrade`), confirm service-setup created the `visualiser` client in Keycloak (public, PKCE S256).
2. Open `https://visualiser.<acs-base>/` — you should land on the Keycloak login page, and after login the visualisation should start (Directory + MQTT websocket both authenticated with the JWT). Check the mqtt pod logs for `MQTT ACL [<your UPN>]`.
3. Leave the tab open past the access-token lifespan (default 300s) — the visualisation should keep running (proactive refresh) and the mqtt connection should survive.
4. Press Escape — you should be logged out via Keycloak and land back on the login page.
5. Kiosk: mint a JWT (e.g. client-credentials against a service-account client) and open `https://visualiser.<acs-base>/?auth_token=<JWT>` — no login page, token stripped from the URL.
6. Regression: MQTT password auth with a Kerberos password and GSSAPI both still work (edge agents, cell gateways unaffected).

## Release notes

- The visualiser now signs in via the central Keycloak login page; the built-in credentials form is no longer shown on cluster deployments.
- The visualiser supports unattended kiosk displays via a `?auth_token=<JWT>` URL parameter, matching Grafana's url_login.
- The MQTT broker accepts Keycloak JWTs as passwords anywhere it previously required a Kerberos password.
