### PR TITLE
service-setup: survive duplicate Keycloak protocol mappers

### DIFF
--- a/acs-service-setup/lib/openid.js
+++ b/acs-service-setup/lib/openid.js
@@ -319,9 +319,18 @@ class OpenIDSetup {
         }
         else {
             this.log("Updating client %s", name);
+            // Don't echo protocolMappers back: they are managed
+            // separately (ensure_factoryplus_claim_mappers), and
+            // Keycloak's updateClientProtocolMappers throws
+            // IllegalStateException on duplicate mapper names, which
+            // bricks every full-client PUT once a duplicate exists
+            // (two service-setup jobs racing can double-create; POST
+            // does not enforce name uniqueness). Omitting the field
+            // leaves the client's mappers untouched.
+            const { protocolMappers, ...current } = client;
             await this.api("PUT",
                 `/admin/realms/${encodeURIComponent(this.realm)}/clients/${client.id}`,
-                { ...client, ...desired });
+                { ...current, ...desired });
         }
         return client;
     }
@@ -351,8 +360,24 @@ class OpenIDSetup {
               // like contains(fp_permissions[*], '<uuid>').
               multivalued: true },
         ];
-        const byName = new Map(
-            (list.body ?? []).map(m => [m.name, m]));
+
+        // Self-heal duplicate mappers of our names: Keycloak accepts
+        // same-name POSTs (ids are the only uniqueness), but a client
+        // holding duplicates fails every subsequent full-client PUT
+        // with "Duplicate key openid-connect%<name>". Keep the first
+        // of each, delete the rest.
+        const managed = new Set(mappers.map(m => m.name));
+        const byName = new Map();
+        for (const m of list.body ?? []) {
+            if (!byName.has(m.name)) {
+                byName.set(m.name, m);
+                continue;
+            }
+            if (!managed.has(m.name)) continue;
+            this.log("Deleting duplicate %s mapper %s on client %s",
+                m.name, m.id, clientUuid);
+            await this.api("DELETE", `${path}/${m.id}`);
+        }
         for (const m of mappers) {
             const config = {
                 "id.token.claim":       "true",


### PR DESCRIPTION
## Summary

On amrc-fp the 6.1.1 upgrade's service-setup job fails permanently: `PUT /admin/realms/factory_plus/clients/<acs-cli>` returns 500. Keycloak's log shows `IllegalStateException: Duplicate key openid-connect%fp_principal_uuid` - the stored client has BOTH F+ mappers duplicated (confirmed via the admin API: two `fp_principal_uuid`, two `fp_permissions`). Keycloak accepts same-name mapper POSTs, so two service-setup jobs racing at some point double-created them; `updateClientProtocolMappers` then throws on every full-client update, so every retry fails identically.

Fix:
- `ensure_client` no longer echoes `protocolMappers` in the PUT body. Mappers are managed separately; omitting the field means "leave unchanged", so the client update succeeds even against damaged state.
- `ensure_factoryplus_claim_mappers` deletes duplicate F+ mappers (keeps the first), so existing damage self-heals on the next run with no manual Keycloak surgery.

## How to test

1. On a realm where a client has duplicated `fp_principal_uuid`/`fp_permissions` mappers (amrc-fp's acs-cli currently does), run service-setup from this build.
2. It should log "Updating client acs-cli", then "Deleting duplicate ... mapper" twice, and complete.
3. Verify the client now has exactly one mapper of each name and that a subsequent full-client PUT (any later service-setup run) succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)