### PR TITLE
Upgrade Keycloak from 26.1.1 to 26.6.3

### DIFF
--- a/acs-keycloak-spi/pom.xml
+++ b/acs-keycloak-spi/pom.xml
@@ -24,7 +24,7 @@
              the base assumes (lib/X), so acs.top must point at the repo root. -->
         <acs.top>..</acs.top>
 
-        <keycloak.version>26.1.1</keycloak.version>
+        <keycloak.version>26.6.3</keycloak.version>
         <!-- 5.18.0 supports inline-mocking on JDK 24/25; 5.11 throws
              "Could not modify all classes [interface
              org.keycloak.models.KeycloakSession]" on JDK 25. -->

--- a/acs-keycloak/Dockerfile
+++ b/acs-keycloak/Dockerfile
@@ -8,7 +8,12 @@
 #   * lib  -> ../lib (provides java-base-pom and the in-tree mvn repo)
 #   * spi  -> ../acs-keycloak-spi (the SPI source tree)
 
-ARG keycloak_version=26.1.1
+# 26.6.3: first line we ship with pgjdbc >= 42.7.5, fixing the
+# GSSInputStream partial-read bug (pgjdbc #3373) that corrupts GSS
+# encrypted Postgres streams under unlucky TCP segmentation, seen as
+# "Could not use AES128 Cipher - Checksum failed" crash loops on
+# amrc-fp. Also covers pgjdbc CVE-2025-49146.
+ARG keycloak_version=26.6.3
 ARG maven_image=docker.io/library/maven:3.9-eclipse-temurin-21
 ARG revision=unknown
 

--- a/deploy/templates/openid/openid.yaml
+++ b/deploy/templates/openid/openid.yaml
@@ -112,10 +112,14 @@ spec:
             - name: KC_HEALTH_ENABLED
               value: "true"
 
-            # Initial admin user (for bootstrapping the realm via service-setup)
-            - name: KEYCLOAK_ADMIN
+            # Initial admin user (for bootstrapping the realm via
+            # service-setup). KC_BOOTSTRAP_ADMIN_* replaced the
+            # deprecated KEYCLOAK_ADMIN vars in Keycloak 26; only
+            # consulted when the master realm has no admin yet, so this
+            # is inert on established installations.
+            - name: KC_BOOTSTRAP_ADMIN_USERNAME
               value: _bootstrap
-            - name: KEYCLOAK_ADMIN_PASSWORD
+            - name: KC_BOOTSTRAP_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: keycloak-clients

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -8,6 +8,27 @@ chronological order.
 These changes have not been released yet, but are likely to appear in
 the next release.
 
+### Keycloak upgraded from 26.1 to 26.6
+
+The bundled Keycloak moves to 26.6.3, primarily for its PostgreSQL
+JDBC driver (42.7.11): the 42.7.4 driver shipped with Keycloak 26.1
+has a bug (pgjdbc #3373) where the GSS-encrypted database stream is
+corrupted by partial TCP reads, crashing Keycloak with "Could not use
+AES128 Cipher - Checksum failed" under network conditions that split
+GSS tokens across reads. Seen in production; the trigger is
+environmental (TCP segmentation behaviour), so any site can hit it.
+
+Keycloak migrates its database schema one-way on first start of the
+new version; downgrading afterwards requires a database restore. The
+F+ SPI is rebuilt against 26.6 (no source changes needed) and the
+chart now uses the KC_BOOTSTRAP_ADMIN environment variables in place
+of the KEYCLOAK_ADMIN ones deprecated in Keycloak 26 (only consulted
+when the master realm has no admin, so inert on established sites).
+Keycloak 26.2-26.6 also tightens some token-endpoint behaviour
+(introspection audience checks, userinfo with lightweight tokens);
+none of it affects the flows ACS provisions, but sites with custom
+OIDC clients should skim the upstream migration notes.
+
 ## v6.1.3
 
 ### ACL editor shows identity-less principals


### PR DESCRIPTION
## Summary

Keycloak 26.1 bundles pgjdbc 42.7.4, whose `GSSInputStream` assumes every socket read returns a complete GSS token. When TCP segmentation splits a token across reads, decryption fails with "Could not use AES128 Cipher - Checksum failed" and Keycloak crash-loops - which is exactly what took out amrc-fp after routine node maintenance changed the path's segmentation behaviour. Fixed upstream in pgjdbc 42.7.5 ([pgjdbc#3373](https://github.com/pgjdbc/pgjdbc/pull/3373), hardened in [#3500](https://github.com/pgjdbc/pgjdbc/pull/3500)); Keycloak 26.6.3 ships 42.7.11 (also covering CVE-2025-49146).

- `acs-keycloak`: base image 26.1.1 → 26.6.3.
- `acs-keycloak-spi`: rebuilt against 26.6.3 - no source changes needed, all 80 tests pass.
- Chart: `KEYCLOAK_ADMIN`/`KEYCLOAK_ADMIN_PASSWORD` → `KC_BOOTSTRAP_ADMIN_USERNAME`/`KC_BOOTSTRAP_ADMIN_PASSWORD` (deprecated replacements; only consulted when the master realm has no admin, so inert on established sites).
- Release notes: one-way schema migration warning and a pointer at the 26.2-26.6 token-endpoint tightening for sites with custom OIDC clients.

Migration notes 26.2-26.6 reviewed against our surface: probes (`/health/*` on 9000) unchanged, `start --optimized=false` fine under the stricter validation, jgroups/JDBC_PING unchanged, custom login theme only uses its own `resourcesPath` (the 26.3 common-resource reshuffle doesn't touch it - verify visually on first deploy), service-setup admin API usage unaffected.

Verified: image builds with the SPI via the CI build contexts, `kc.sh build` accepts the providers (same benign internal-SPI warnings as 26.1), bundled driver confirmed as pgjdbc 42.7.11.

## How to test

1. Cut a dev release and deploy to ago first (schema migration is one-way - snapshot/backup the keycloak database before upgrading a production site).
2. Log in to Grafana, the visualiser, and the admin UI via Keycloak; check the login page still renders the ACS theme.
3. Confirm service-setup completes (realm update, clients, mappers, service-account principals).
4. Kiosk: mint a client-credentials token and check `fp_principal_uuid` is present; `?auth_token=` login still works.
5. On amrc-fp specifically: confirm Keycloak stays up past startup (the pgjdbc bug fired within ~40s of every boot there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)