### PR TITLE
Keycloak SPI: cross-realm Kerberos login, and fix realm casing on user lookup

### DIFF
--- a/acs-keycloak-spi/README.md
+++ b/acs-keycloak-spi/README.md
@@ -9,22 +9,138 @@ consumers (Grafana, acs-i3x, future shims).
 See:
 - Pitch: `docs/plans/2026-05-07-keycloak-fp-user-storage-spi.md`
 - Implementation plan: `docs/plans/2026-05-07-keycloak-fp-spi-plan.md`
+- Cross-realm design: `docs/plans/2026-07-27-keycloak-spi-cross-realm-design.md`
 
 ## Status
 
-**Phase 1 of 12 — build skeleton + hello-world SPI.**
+In production since ACS v6. The plugin:
 
-The plugin currently:
-- Loads in Keycloak as the `factoryplus` user storage provider
-- Implements `UserLookupProvider` against an injectable `FactoryPlusUserStore`
-- Ships with a `NullFactoryPlusUserStore` default that returns no users
+- Loads in Keycloak as the `factoryplus` user storage provider, and is
+  provisioned as the realm's federation by `acs-service-setup`
+- Resolves users from the Factory+ auth service over its v2 identity API,
+  authenticating with SPNEGO as `sv1openid`
+- Validates passwords against the KDC via `Krb5LoginModule`
+- Stamps `fp_principal_uuid` and `fp_permissions` into issued tokens via
+  its two protocol mappers
+- Caches hits and misses for a configurable TTL
+- Accepts logins from configured foreign Kerberos realms (off by default;
+  see Cross-realm login below)
 
-It does NOT yet:
-- Talk to a real Factory+ auth service (Phase 2)
-- Implement group lookups, credential validation, or claim mappers
-- Replace Kerberos federation in the Helm deployment
+It does not:
+- Support email lookup (Factory+ has no email field)
+- Support free-text user search, arbitrary user attributes, or group
+  membership queries
+- Write to Factory+, other than mirroring a cross-realm user's Kerberos
+  identity after their password has validated
 
-Refer to the plan doc for the full phase map.
+## Configuration
+
+Set on the federation component. `acs-service-setup/lib/openid.js`
+populates all of these from the Helm chart, so on a normal ACS
+deployment you configure them through `values.yaml` rather than by hand.
+
+| Key | Default | Meaning |
+|---|---|---|
+| `auth.url` | (blank) | Base URL of the Factory+ auth service. Blank disables F+ lookups entirely: the federation loads but returns no users. |
+| `auth.timeout.seconds` | `2` | Per-request timeout for F+ auth calls. **Must stay under 3s**, see below. |
+| `cache.ttl.seconds` | `60` | How long to cache lookups, including misses. `0` disables caching. |
+| `auth.principal` | (blank) | Principal the SPI authenticates as, e.g. `sv1openid@FACTORYPLUS.LOCAL`. Blank calls F+ unauthenticated, which is only useful against a stand-in server. |
+| `auth.keytab.path` | (blank) | Keytab holding credentials for that principal. Must be readable by Keycloak's process. |
+| `default.realm` | (blank) | Realm appended to usernames typed without an `@realm` suffix, so local users can log in with a short name. |
+| `trusted.realms` | (blank) | Comma-separated Kerberos realms accepted for cross-realm login. Blank means none. |
+| `trusted.realm.auth.urls` | (blank) | Comma-separated `REALM=url` entries naming each trusted realm's own F+ auth service. |
+| `trusted.realm.timeout.seconds` | `1.5` | Per-request timeout for calls to a trusted realm's auth service. |
+
+### The 3-second budget
+
+Keycloak hard-kills user storage lookups at 3 seconds, and overshooting
+surfaces as an opaque `InterruptedException` rather than a timeout
+naming the slow service. The cross-realm resolve runs **in series**
+after the local lookup misses, so `auth.timeout.seconds` and
+`trusted.realm.timeout.seconds` share that one budget. Do not raise
+either without lowering the other.
+
+### Username casing
+
+Keycloak lower-cases the username before it reaches the provider. The
+SPI tries the resulting UPN verbatim first, then retries with the realm
+portion (everything after the last `@`) upper-cased. That covers both
+the usual uppercase realms and deployments whose realm genuinely is
+lower case.
+
+Only the realm is touched. An F+ identity stored with capitals in the
+**user** portion (`Me1ago@REALM`) cannot be matched, because the
+original casing is gone by the time we see it. Store user portions in
+lower case.
+
+## Cross-realm login
+
+With `trusted.realms` set, a user from a listed realm can sign in with
+no pre-existing Factory+ principal on this cluster. Once their home KDC
+accepts the password, the SPI writes their Kerberos identity here and
+they appear in the ACL editor by their UPN, with no permissions until an
+admin grants some. Nothing is written before the KDC has confirmed the
+password.
+
+This is off by default and requires cross-realm Kerberos trust to
+already exist: the realm and its KDC must be in `krb5.conf` on this
+cluster. Listing a realm here does not create that trust.
+
+There are two supported modes, and the choice matters.
+
+### With an `authUrl`: shared principal UUID, blanket read on the home cluster
+
+Give the realm an entry in `trusted.realm.auth.urls` and the SPI
+resolves the user's principal UUID from their home cluster, so they keep
+one identity across both.
+
+This requires a manual grant **on the home cluster**: the consuming
+cluster's `sv1openid@<CONSUMING-REALM>` must hold `ReadKrb`
+(`e8c9c0f7-0d54-4db2-b8d6-cd80c45f6a5c`).
+
+Know what you are granting. `ReadKrb` cannot be scoped to individual
+principals - it can only be granted on Wildcard, and acs-auth treats it
+as a blanket "read any identity" capability (see the comment at
+`acs-auth/lib/dataflow.js:273`). The grant lets the consuming cluster's
+Keycloak **read and enumerate every identity record in the home
+cluster's auth service**, as a standing capability, regardless of who
+actually logs in or whether anyone ever does.
+
+That grant is also the revocation point for the whole trust
+relationship: remove it and the consuming cluster can no longer resolve
+home principals.
+
+Without the grant the home cluster returns 403 and the login **fails**.
+It does not quietly fall back to minting a local UUID - that would
+defeat revocation, and would leave you with some users on home-derived
+UUIDs and some on local ones depending on when they first logged in.
+The logged message names the missing permission, the principal that was
+denied and the cluster that denied it. A standing denial is cached for
+30 seconds so it costs one outbound call rather than one per login
+attempt; 5xx and timeouts stay uncached, since those are transient and
+recovery should be immediate.
+
+### Without an `authUrl`: no grant, no outbound call, per-cluster UUID
+
+Listing a realm in `trusted.realms` with no entry in
+`trusted.realm.auth.urls` is a fully supported configuration, not a
+degraded fallback. On this path the consuming cluster makes no outbound
+call to the home cluster at all and needs no permission there
+whatsoever; it mints a fresh local principal UUID on first successful
+login.
+
+The cost is that the UUID is not shared: the user is recognisably the
+same person by UPN, but each cluster's auth service knows them by a
+different UUID, so grants do not correlate across clusters.
+
+If you are unwilling to grant blanket identity read across a cluster
+boundary, use this mode.
+
+### On this cluster
+
+`sv1openid` needs `WriteKrb` (`327c4cc8-9c46-4e1e-bb6b-257ace37b0f6`) on
+Wildcard to mirror the identity. The Helm chart grants this
+automatically via `acs-service-setup/dumps/service-accounts.yaml`.
 
 ## Build
 
@@ -44,9 +160,8 @@ mvn -B test       # unit tests (no Docker required)
 mvn -B verify     # unit + integration tests (Testcontainers, requires Docker)
 ```
 
-The current Phase 1 test count is 17 unit tests (5 classes) + 2
-integration tests in `FactoryPlusFederationIT` (real Keycloak via
-Testcontainers).
+Currently 115 unit tests across 10 classes, plus 4 integration tests in
+`FactoryPlusFederationIT` (real Keycloak via Testcontainers).
 
 ### Running integration tests locally
 

--- a/acs-keycloak-spi/README.md
+++ b/acs-keycloak-spi/README.md
@@ -86,17 +86,62 @@ This is off by default and requires cross-realm Kerberos trust to
 already exist: the realm and its KDC must be in `krb5.conf` on this
 cluster. Listing a realm here does not create that trust.
 
-There are two supported modes, and the choice matters.
+There are two modes. Pick deliberately, and see the one-way-door warning
+at the end.
 
-### With an `authUrl`: shared principal UUID, blanket read on the home cluster
+### Recommended: no `authUrl`, derived UUIDs
+
+List the realm and nothing else. The principal UUID is derived from the
+user's UPN as a UUIDv5, which means:
+
+- No principal to create and no permission to obtain on the home
+  cluster. No coordination with whoever runs it.
+- No outbound call at login, so no dependency on the home cluster being
+  up, reachable, or still existing.
+- Every ACS cluster derives the *same* UUID for the same person, with no
+  coordination, so identity stays consistent across the estate anyway.
+- **Admins can pre-grant**: compute the UUID and attach permissions
+  before the user has ever logged in, so their first login works
+  properly instead of landing with nothing.
+
+What you give up is reusing the UUID the user has *on their home
+cluster*, so grants made there do not follow them here.
+
+#### Computing a UUID to pre-grant
+
+```sh
+python3 -c "import uuid; print(uuid.uuid5(uuid.UUID(
+  'cb3714c4-c85c-482a-987b-408293aa141e'), 'me1ago@AMRC-FP.SHEF.AC.UK'))"
+```
+
+```
+12bb7b35-16c8-572d-af5f-c1f312ec4ae8
+```
+
+The name you hash is the **canonicalised UPN**: realm portion in
+CAPITALS, user portion exactly as the person types it into the login
+form (which Keycloak lower-cases, so in practice lower case). Nothing
+local feeds into it - not the default realm, not the cluster name - and
+that is what makes every cluster agree.
+
+The namespace `cb3714c4-c85c-482a-987b-408293aa141e` is fixed forever.
+Changing it would orphan every principal ever derived from it, so it is
+pinned by a unit test, along with the example above as a known-answer
+vector.
+
+### The alternative: `authUrl`, home-derived UUIDs
 
 Give the realm an entry in `trusted.realm.auth.urls` and the SPI
 resolves the user's principal UUID from their home cluster, so they keep
-one identity across both.
+that cluster's identity here. Take this only when you specifically need
+that - typically because the two clusters are administered together and
+grants are expected to correlate.
 
-This requires a manual grant **on the home cluster**: the consuming
-cluster's `sv1openid@<CONSUMING-REALM>` must hold `ReadKrb`
-(`e8c9c0f7-0d54-4db2-b8d6-cd80c45f6a5c`).
+This requires manual setup **on the home cluster**: the consuming
+cluster's `sv1openid@<CONSUMING-REALM>` must exist as a principal there
+and hold `ReadKrb` (`e8c9c0f7-0d54-4db2-b8d6-cd80c45f6a5c`). Logins from
+that realm then also depend on the home cluster being reachable within
+the timeout budget.
 
 Know what you are granting. `ReadKrb` cannot be scoped to individual
 principals - it can only be granted on Wildcard, and acs-auth treats it
@@ -111,30 +156,25 @@ relationship: remove it and the consuming cluster can no longer resolve
 home principals.
 
 Without the grant the home cluster returns 403 and the login **fails**.
-It does not quietly fall back to minting a local UUID - that would
-defeat revocation, and would leave you with some users on home-derived
-UUIDs and some on local ones depending on when they first logged in.
-The logged message names the missing permission, the principal that was
+It does not quietly fall back to deriving a UUID - that would defeat
+revocation, and would leave you with some users on home-derived UUIDs
+and some on derived ones depending on when they first logged in. The
+logged message names the missing permission, the principal that was
 denied and the cluster that denied it. A standing denial is cached for
 30 seconds so it costs one outbound call rather than one per login
 attempt; 5xx and timeouts stay uncached, since those are transient and
 recovery should be immediate.
 
-### Without an `authUrl`: no grant, no outbound call, per-cluster UUID
+### Pick one and stay: switching later is close to a one-way door
 
-Listing a realm in `trusted.realms` with no entry in
-`trusted.realm.auth.urls` is a fully supported configuration, not a
-degraded fallback. On this path the consuming cluster makes no outbound
-call to the home cluster at all and needs no permission there
-whatsoever; it mints a fresh local principal UUID on first successful
-login.
+Changing modes does not migrate anyone. Add an `authUrl` to a realm that
+has been running without one and users who already logged in keep their
+derived UUID, while first-time users get home-derived ones. The estate
+splits by *when each person first signed in*, which stays invisible
+until someone's permissions do not behave as expected. Converging
+afterwards means re-pointing identity records by hand.
 
-The cost is that the UUID is not shared: the user is recognisably the
-same person by UPN, but each cluster's auth service knows them by a
-different UUID, so grants do not correlate across clusters.
-
-If you are unwilling to grant blanket identity read across a cluster
-boundary, use this mode.
+Decide before the first login from that realm, not after.
 
 ### On this cluster
 

--- a/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/CachingFactoryPlusUserStore.java
+++ b/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/CachingFactoryPlusUserStore.java
@@ -77,6 +77,33 @@ public class CachingFactoryPlusUserStore implements FactoryPlusUserStore {
         return fresh;
     }
 
+    /** Delegates the write, then drops every cache entry that could
+     *  still describe this user as absent or provisional.
+     *
+     *  <p>This is load-bearing, not hygiene. The lookup that produced
+     *  the provisional user cached it under whatever string Keycloak
+     *  passed in - typically a lower-cased short name, not the
+     *  canonical UPN we admit under. Leaving that entry in place means
+     *  the next lookup within the TTL keeps reporting the user as
+     *  provisional even though the principal now exists, and any
+     *  negatively cached miss keeps masking it for the full 60s. */
+    @Override
+    public String admit(String upn, String uuid) {
+        String admitted = delegate.admit(upn, uuid);
+        byUsername.remove(upn);
+        byUsername.entrySet().removeIf(e -> describes(e.getValue(), upn, admitted));
+        if (admitted != null) byUuid.remove(admitted);
+        if (uuid != null) byUuid.remove(uuid);
+        return admitted;
+    }
+
+    private static boolean describes(Entry entry, String upn, String uuid) {
+        if (entry == null || entry.result().isEmpty()) return false;
+        FactoryPlusUser user = entry.result().get();
+        if (upn != null && upn.equalsIgnoreCase(user.username())) return true;
+        return uuid != null && uuid.equals(user.uuid());
+    }
+
     private Optional<FactoryPlusUser> cached(ConcurrentMap<String, Entry> map,
                                              String key,
                                              Supplier<Optional<FactoryPlusUser>> fetch) {

--- a/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/FPAuthBackedUserStore.java
+++ b/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/FPAuthBackedUserStore.java
@@ -57,6 +57,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -283,9 +286,10 @@ public class FPAuthBackedUserStore implements FactoryPlusUserStore {
         FactoryPlusUserStore home = homeStores.get(realm);
         if (home == null) {
             /* Trusted realm with no auth URL: no outbound dependency at
-             * all, just mint an identity for them on first successful
-             * login. */
-            return Optional.of(provisional(freshUuid(), canonical));
+             * all. Derive their UUID from the UPN, so this cluster and
+             * every other cluster agree on it without coordinating,
+             * and so an admin can pre-grant before first login. */
+            return Optional.of(provisional(null, canonical));
         }
 
         /* A standing denial short-circuits before we make any call.
@@ -395,20 +399,96 @@ public class FPAuthBackedUserStore implements FactoryPlusUserStore {
      *  Keycloak derives the federated storage id from it and re-reads
      *  the user by that id later in the same login flow, so a null here
      *  would break the flow after {@link #admit} had already written.
-     *  Minting early is safe: the UUID is not persisted anywhere until
-     *  the KDC has confirmed the password. */
+     *  Deriving early is safe: the UUID is not persisted anywhere until
+     *  the KDC has confirmed the password.
+     *
+     *  <p>A UUID supplied by the caller (i.e. resolved from the home
+     *  cluster) is adopted unchanged. Only the mint path derives. */
     private static FactoryPlusUser provisional(String uuid, String upn) {
         return new FactoryPlusUser(
-            uuid == null ? freshUuid() : uuid, upn, null, true);
+            uuid == null ? mintedUuid(upn) : uuid, upn, null, true);
     }
 
-    private static String freshUuid() {
-        return UUID.randomUUID().toString();
+    /** Namespace for name-based principal UUIDs. Randomly generated
+     *  once, on 2026-07-27, and fixed forever after.
+     *
+     *  <p><b>This value must NEVER change.</b> Every principal ever
+     *  minted on the cross-realm path is derived from it, so changing
+     *  it silently orphans all of them: the same user would resolve to
+     *  a different UUID, their existing grants would attach to a
+     *  principal nothing looks up any more, and there is no migration
+     *  short of re-pointing every identity record by hand. */
+    static final UUID ACS_PRINCIPAL_NAMESPACE =
+        UUID.fromString("cb3714c4-c85c-482a-987b-408293aa141e");
+
+    /** Derive a principal UUID from a UPN, for the mint path only.
+     *
+     *  <p>UUIDv5 (RFC 4122 name-based, SHA-1) over
+     *  {@link #ACS_PRINCIPAL_NAMESPACE} and the canonicalised UPN. Two
+     *  properties fall out of this that random minting cannot give:
+     *
+     *  <ul>
+     *  <li>Every consuming cluster independently derives the SAME UUID
+     *  for a given foreign UPN, with no coordination and no outbound
+     *  calls. Clusters stood up years apart agree.
+     *  <li>An admin can <b>pre-grant</b>: compute the UUID and attach
+     *  permissions before the user has ever logged in, so their first
+     *  login lands with the access they need instead of with nothing.
+     *  </ul>
+     *
+     *  <p>The name input is exactly the canonicalised UPN - the same
+     *  string written into the F+ identity record: realm portion
+     *  upper-cased, user portion exactly as received from Keycloak
+     *  (which means lower-cased, since Keycloak folds it before we see
+     *  it). Nothing local feeds into it. That is deliberate and load
+     *  bearing: if the input varied with local configuration, two
+     *  clusters would derive different UUIDs and the whole property
+     *  would be lost. Do not "improve" this by mixing in the realm
+     *  list, the auth URL, or anything else.
+     *
+     *  <p>See the design doc for the one-liner that reproduces this by
+     *  hand, so operators can pre-grant. */
+    static String mintedUuid(String upn) {
+        return uuidV5(ACS_PRINCIPAL_NAMESPACE, upn).toString();
+    }
+
+    /** RFC 4122 section 4.3 name-based UUID, SHA-1 flavour (version 5).
+     *
+     *  <p>Hand-rolled because the JDK ships no v5 generator.
+     *  {@code UUID.nameUUIDFromBytes} is NOT a substitute: it is MD5
+     *  and stamps version 3. */
+    static UUID uuidV5(UUID namespace, String name) {
+        MessageDigest sha1;
+        try {
+            sha1 = MessageDigest.getInstance("SHA-1");
+        }
+        catch (NoSuchAlgorithmException e) {
+            /* SHA-1 is required of every conformant JRE. */
+            throw new FactoryPlusAuthException("SHA-1 unavailable", e);
+        }
+        /* Namespace goes in as its 16 raw bytes, big-endian, NOT as its
+         * printed form. */
+        ByteBuffer ns = ByteBuffer.allocate(16);
+        ns.putLong(namespace.getMostSignificantBits());
+        ns.putLong(namespace.getLeastSignificantBits());
+        sha1.update(ns.array());
+        sha1.update(name.getBytes(StandardCharsets.UTF_8));
+        byte[] hash = sha1.digest();
+
+        /* Truncate to 128 bits, then overwrite version and variant. */
+        hash[6] = (byte) ((hash[6] & 0x0f) | 0x50);          // version 5
+        hash[8] = (byte) ((hash[8] & 0x3f) | 0x80);          // RFC 4122 variant
+        ByteBuffer out = ByteBuffer.wrap(hash, 0, 16);
+        return new UUID(out.getLong(), out.getLong());
     }
 
     @Override
     public String admit(String upn, String uuid) {
-        String target = (uuid == null || uuid.isBlank()) ? freshUuid() : uuid;
+        /* A null uuid means the mint path: derive rather than
+         * randomise, so this cluster agrees with every other cluster
+         * about who this UPN is. */
+        String target = (uuid == null || uuid.isBlank())
+            ? mintedUuid(upn) : uuid;
         URI uri = baseUrl.resolve("/v2/principal/" + encode(target)
             + "/" + encode(IDENTITY_KIND_KERBEROS));
         /* acs-auth parses request bodies with express.json({strict:

--- a/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/FPAuthBackedUserStore.java
+++ b/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/FPAuthBackedUserStore.java
@@ -29,6 +29,10 @@
  *       200 with the UUID string (NOT JSON object) when the UPN matches
  *       410 when no identity has that UPN
  *
+ *   PUT /v2/principal/{uuid}/kerberos    (cross-realm admit only)
+ *       body is the UPN as a JSON string; guarded by WriteKrb on the
+ *       target UUID. Creates the local principal if absent.
+ *
  * findByUsername therefore costs two HTTP calls (identity lookup, then
  * principal lookup). Login is rare; Phase 5 adds caching to fold both
  * into a single warm path.
@@ -59,11 +63,17 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 public class FPAuthBackedUserStore implements FactoryPlusUserStore {
 
@@ -76,6 +86,18 @@ public class FPAuthBackedUserStore implements FactoryPlusUserStore {
     private final HttpClient http;
     private final KerberosAuthenticator authenticator;
     private final String defaultRealm;
+    /** Realms (upper-cased) we accept cross-realm logins from. Empty by
+     *  default, which makes the whole cross-realm path inert. */
+    private final Set<String> trustedRealms;
+    /** Home-cluster stores, keyed by upper-cased realm. Built once at
+     *  construction: each one does a JAAS login through the shared
+     *  authenticator, so building per request would blow Keycloak's
+     *  storage-lookup budget. A trusted realm with no entry here takes
+     *  the mint-fresh path. */
+    private final Map<String, FactoryPlusUserStore> homeStores;
+    /** Same keys as {@link #homeStores}, kept so error messages can
+     *  name the cluster that refused us. */
+    private final Map<String, URI> homeAuthUrls;
 
     /** No-auth constructor; useful for unauthenticated test setups
      *  (Wiremock fixtures, etc). */
@@ -102,11 +124,63 @@ public class FPAuthBackedUserStore implements FactoryPlusUserStore {
     public FPAuthBackedUserStore(URI baseUrl, Duration timeout,
                                  KerberosAuthenticator authenticator,
                                  String defaultRealm) {
+        this(baseUrl, timeout, authenticator, defaultRealm,
+            Set.of(), Map.of(), timeout);
+    }
+
+    /** Cross-realm constructor.
+     *
+     *  <p>{@code trustedRealms} names the Kerberos realms whose users
+     *  may log in without a pre-existing local F+ principal. Matching
+     *  is case-insensitive because Keycloak lower-cases the username
+     *  before it reaches us. An empty set (the default everywhere
+     *  else) disables the feature entirely.
+     *
+     *  <p>{@code homeAuthUrls} maps realm name to that realm's F+ auth
+     *  base URL. A trusted realm present here has its principal UUID
+     *  resolved from the home cluster; a trusted realm absent from it
+     *  gets a fresh locally-minted UUID instead.
+     *
+     *  <p>{@code homeTimeout} bounds the remote resolve. It must be
+     *  small: the remote call happens in series after the local miss,
+     *  and Keycloak hard-kills the whole user-storage lookup at 3
+     *  seconds. See {@code FactoryPlusUserStorageProviderFactory}. */
+    public FPAuthBackedUserStore(URI baseUrl, Duration timeout,
+                                 KerberosAuthenticator authenticator,
+                                 String defaultRealm,
+                                 Set<String> trustedRealms,
+                                 Map<String, URI> homeAuthUrls,
+                                 Duration homeTimeout) {
         this.baseUrl = baseUrl;
         this.timeout = timeout;
         this.authenticator = authenticator;
         this.defaultRealm = (defaultRealm == null || defaultRealm.isBlank())
             ? null : defaultRealm.trim();
+
+        Set<String> realms = new HashSet<>();
+        for (String r : trustedRealms) {
+            if (r == null || r.isBlank()) continue;
+            realms.add(canonical_realm(r));
+        }
+        this.trustedRealms = Set.copyOf(realms);
+
+        Map<String, FactoryPlusUserStore> homes = new HashMap<>();
+        Map<String, URI> urls = new HashMap<>();
+        for (Map.Entry<String, URI> e : homeAuthUrls.entrySet()) {
+            String realm = canonical_realm(e.getKey());
+            if (!this.trustedRealms.contains(realm)) continue;
+            urls.put(realm, e.getValue());
+            /* Reuse this class as the remote client: it already does
+             * the identity + principal GETs and the SPNEGO handshake,
+             * and JaasKerberosAuthenticator derives the service
+             * principal from the target host, so the ticket is for the
+             * remote realm's HTTP service. No default realm and no
+             * trusted realms of its own - the remote store is a leaf. */
+            homes.put(realm, new FPAuthBackedUserStore(
+                e.getValue(), homeTimeout, authenticator, null));
+        }
+        this.homeStores = Map.copyOf(homes);
+        this.homeAuthUrls = Map.copyOf(urls);
 
         // Pin HTTP/1.1: Java's default tries an h2c upgrade on plaintext
         // connections (sends Upgrade: h2c + Connection: Upgrade). Node's
@@ -131,7 +205,7 @@ public class FPAuthBackedUserStore implements FactoryPlusUserStore {
                     .flatMap(this::fetchPrincipal);
             if (found.isPresent()) return found;
         }
-        return Optional.empty();
+        return resolveCrossRealm(candidates);
     }
 
     /** Short names get {@code @<defaultRealm>} appended so local users
@@ -178,6 +252,180 @@ public class FPAuthBackedUserStore implements FactoryPlusUserStore {
 
     private static String canonical_realm(String realm) {
         return realm.trim().toUpperCase(Locale.ROOT);
+    }
+
+    /** Cross-realm fallback, reached only when every casing candidate
+     *  missed locally.
+     *
+     *  <p>Kerberos cross-realm trust is a KDC-level fact: it provisions
+     *  nothing in Factory+, so a foreign user has no principal here to
+     *  resolve. When their realm is explicitly trusted we return a
+     *  provisional user - a promise that, if the KDC confirms the
+     *  password, the provider will write the identity via
+     *  {@link #admit}. Nothing is written on this path: lookup happens
+     *  before the password is checked, so it runs for unauthenticated
+     *  callers.
+     *
+     *  <p>Untrusted realms return empty, exactly as before this
+     *  feature existed. */
+    private Optional<FactoryPlusUser> resolveCrossRealm(List<String> candidates) {
+        if (trustedRealms.isEmpty() || candidates.isEmpty())
+            return Optional.empty();
+
+        /* Last candidate carries the upper-cased realm, which is the
+         * form we canonicalise a mirrored principal to. */
+        String canonical = candidates.get(candidates.size() - 1);
+        int at = canonical.lastIndexOf('@');
+        if (at < 0) return Optional.empty();
+        String realm = canonical_realm(canonical.substring(at + 1));
+        if (!trustedRealms.contains(realm)) return Optional.empty();
+
+        FactoryPlusUserStore home = homeStores.get(realm);
+        if (home == null) {
+            /* Trusted realm with no auth URL: no outbound dependency at
+             * all, just mint an identity for them on first successful
+             * login. */
+            return Optional.of(provisional(freshUuid(), canonical));
+        }
+
+        /* A standing denial short-circuits before we make any call.
+         * See recordDenial for why this one failure mode is cached and
+         * the others deliberately are not. */
+        throwIfDenied(realm);
+
+        /* Resolve against the home cluster's F+ Auth. A timeout or 5xx
+         * propagates as FactoryPlusAuthException, so Keycloak fails the
+         * login instead of reporting user_not_found - "the home cluster
+         * is unreachable" and "no such user" are different answers. A
+         * 410/404 falls out as empty and gets negatively cached by the
+         * caching decorator. */
+        try {
+            for (String upn : candidates) {
+                Optional<FactoryPlusUser> found = home.findByUsername(upn);
+                if (found.isEmpty()) continue;
+                /* Prefer the home cluster's own spelling of the UPN over
+                 * the candidate that happened to match: it is the
+                 * authoritative casing, and it is what we mirror locally. */
+                FactoryPlusUser hit = found.get();
+                String name = hit.username() == null ? upn : hit.username();
+                return Optional.of(provisional(hit.uuid(), name));
+            }
+        }
+        catch (FactoryPlusAccessDeniedException e) {
+            throw recordDenial(realm, e);
+        }
+        return Optional.empty();
+    }
+
+    /** How long a 403 from a home cluster suppresses further calls to
+     *  it. Short enough that fixing the grant takes effect promptly,
+     *  long enough that a standing misconfiguration doesn't cost an
+     *  outbound call per login attempt. */
+    private static final Duration DENIAL_TTL = Duration.ofSeconds(30);
+
+    /** Home clusters that have refused us, and when the denial expires.
+     *  Keyed by realm: the denial is a property of the trust
+     *  relationship, not of the user who happened to trigger it. */
+    private final ConcurrentMap<String, Instant> homeDenials =
+        new ConcurrentHashMap<>();
+
+    /** Turn a bare 403 into something an operator can act on, and
+     *  remember it briefly.
+     *
+     *  <p>A 403 here means the home cluster has not granted this
+     *  cluster's SPI principal {@code ReadKrb}. That is the single most
+     *  likely setup mistake in this feature, and the fix lives on a
+     *  different cluster from the error, so the message names the
+     *  permission, the principal that was denied, and who denied it.
+     *
+     *  <p>We deliberately do NOT fall back to minting a fresh UUID.
+     *  The {@code ReadKrb} grant is the kill switch for the whole trust
+     *  relationship; minting on denial would defeat revocation and
+     *  split the estate into home-derived and locally-minted principals
+     *  depending on when each user first logged in.
+     *
+     *  <p>Caching: {@link CachingFactoryPlusUserStore} deliberately
+     *  never caches exceptions, so a transient F+ blip cannot lock out
+     *  lookups for a full TTL. That reasoning holds for 5xx and
+     *  timeouts and is unchanged. A 403 is different in kind: it is a
+     *  standing configuration state, and lookup runs BEFORE password
+     *  validation, so while misconfigured anyone who can reach the
+     *  login page could bounce one call off the remote cluster per
+     *  attempt just by typing foreign usernames. Hence this small
+     *  realm-keyed denial cache, which suppresses the call without
+     *  softening the failure. */
+    private FactoryPlusAccessDeniedException recordDenial(
+            String realm, FactoryPlusAccessDeniedException cause) {
+        homeDenials.put(realm, Instant.now().plus(DENIAL_TTL));
+        return deniedException(realm, cause);
+    }
+
+    private void throwIfDenied(String realm) {
+        Instant until = homeDenials.get(realm);
+        if (until == null) return;
+        if (until.isBefore(Instant.now())) {
+            homeDenials.remove(realm, until);
+            return;
+        }
+        throw deniedException(realm, null);
+    }
+
+    private FactoryPlusAccessDeniedException deniedException(
+            String realm, Throwable cause) {
+        URI homeUrl = homeAuthUrls.get(realm);
+        String principal = authenticator == null ? null
+            : authenticator.principalName();
+        String msg = "Cross-realm login from " + realm + " failed: the home"
+            + " Factory+ Auth service" + (homeUrl == null ? "" : " at " + homeUrl)
+            + " refused the identity lookup with 403. Grant "
+            + (principal == null ? "this cluster's SPI principal" : principal)
+            + " the ReadKrb permission"
+            + " (e8c9c0f7-0d54-4db2-b8d6-cd80c45f6a5c) on the Wildcard target"
+            + " in " + realm + "'s Factory+ Auth. Note ReadKrb is blanket"
+            + " read of every identity record and cannot be narrowed;"
+            + " if that is not acceptable, remove this realm's entry from"
+            + " trusted.realm.auth.urls to mint local principals instead.";
+        return cause == null
+            ? new FactoryPlusAccessDeniedException(msg)
+            : new FactoryPlusAccessDeniedException(msg, cause);
+    }
+
+    /** Provisional users carry a real UUID from the moment of lookup,
+     *  even on the mint-fresh path where nothing has resolved it.
+     *  Keycloak derives the federated storage id from it and re-reads
+     *  the user by that id later in the same login flow, so a null here
+     *  would break the flow after {@link #admit} had already written.
+     *  Minting early is safe: the UUID is not persisted anywhere until
+     *  the KDC has confirmed the password. */
+    private static FactoryPlusUser provisional(String uuid, String upn) {
+        return new FactoryPlusUser(
+            uuid == null ? freshUuid() : uuid, upn, null, true);
+    }
+
+    private static String freshUuid() {
+        return UUID.randomUUID().toString();
+    }
+
+    @Override
+    public String admit(String upn, String uuid) {
+        String target = (uuid == null || uuid.isBlank()) ? freshUuid() : uuid;
+        URI uri = baseUrl.resolve("/v2/principal/" + encode(target)
+            + "/" + encode(IDENTITY_KIND_KERBEROS));
+        /* acs-auth parses request bodies with express.json({strict:
+         * false}), so the UPN goes over the wire as a JSON string
+         * literal, not as bare text. */
+        HttpResponse<String> res = sendPut(uri, jsonString(upn));
+        requireSuccess(res, uri);
+        return target;
+    }
+
+    private static String jsonString(String value) {
+        try {
+            return MAPPER.writeValueAsString(value);
+        }
+        catch (JsonProcessingException e) {
+            throw new FactoryPlusAuthException("Cannot encode " + value, e);
+        }
     }
 
     @Override
@@ -285,6 +533,15 @@ public class FPAuthBackedUserStore implements FactoryPlusUserStore {
     }
 
     private HttpResponse<String> sendGet(URI uri) {
+        return send(uri, null);
+    }
+
+    private HttpResponse<String> sendPut(URI uri, String body) {
+        return send(uri, body);
+    }
+
+    /** GET when {@code body} is null, PUT otherwise. */
+    private HttpResponse<String> send(URI uri, String body) {
         // Fresh HttpClient (and therefore fresh TCP socket) per
         // request. The F+ auth Node HTTP server's idle keep-alive
         // timeout (~5s) is shorter than the JDK HttpClient's default
@@ -299,8 +556,14 @@ public class FPAuthBackedUserStore implements FactoryPlusUserStore {
             .build();
         HttpRequest.Builder builder = HttpRequest.newBuilder(uri)
             .timeout(timeout)
-            .header("Accept", "application/json")
-            .GET();
+            .header("Accept", "application/json");
+        if (body == null) {
+            builder.GET();
+        }
+        else {
+            builder.header("Content-Type", "application/json")
+                .PUT(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8));
+        }
         if (authenticator != null) {
             builder.header("Authorization", "Negotiate " + authenticator.spnegoTokenFor(uri));
         }
@@ -329,9 +592,13 @@ public class FPAuthBackedUserStore implements FactoryPlusUserStore {
             String body = res.body();
             if (body != null && body.length() > 500)
                 body = body.substring(0, 500) + "...[truncated]";
-            throw new FactoryPlusAuthException(
-                "F+ auth returned " + status + " for " + uri
-                    + " body=" + body);
+            String msg = "F+ auth returned " + status + " for " + uri
+                + " body=" + body;
+            // 403 gets its own type so the cross-realm resolve can
+            // distinguish a standing permission problem from a
+            // transient fault. Both stay fatal.
+            if (status == 403) throw new FactoryPlusAccessDeniedException(msg);
+            throw new FactoryPlusAuthException(msg);
         }
     }
 

--- a/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/FPAuthBackedUserStore.java
+++ b/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/FPAuthBackedUserStore.java
@@ -60,6 +60,8 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 
@@ -105,6 +107,7 @@ public class FPAuthBackedUserStore implements FactoryPlusUserStore {
         this.authenticator = authenticator;
         this.defaultRealm = (defaultRealm == null || defaultRealm.isBlank())
             ? null : defaultRealm.trim();
+
         // Pin HTTP/1.1: Java's default tries an h2c upgrade on plaintext
         // connections (sends Upgrade: h2c + Connection: Upgrade). Node's
         // HTTP parser rejects that with 400 "Invalid Upgrade header".
@@ -121,24 +124,60 @@ public class FPAuthBackedUserStore implements FactoryPlusUserStore {
 
     @Override
     public Optional<FactoryPlusUser> findByUsername(String username) {
-        String upn = applyDefaultRealm(username);
-        return fetchUuidByIdentity(IDENTITY_KIND_KERBEROS, upn)
-            .flatMap(this::fetchPrincipal);
+        List<String> candidates = candidateUpns(applyDefaultRealm(username));
+        for (String upn : candidates) {
+            Optional<FactoryPlusUser> found =
+                fetchUuidByIdentity(IDENTITY_KIND_KERBEROS, upn)
+                    .flatMap(this::fetchPrincipal);
+            if (found.isPresent()) return found;
+        }
+        return Optional.empty();
     }
 
     /** Short names get {@code @<defaultRealm>} appended so local users
      *  can log in with just their username. Inputs that already
      *  contain {@code @} (and the default realm itself) are used
-     *  verbatim - the SPI does not force any case normalisation,
-     *  since while uppercase Kerberos realms are convention, not
-     *  every deployment follows it and case-folding inputs would
-     *  break lookups against F+ entries that don't match the forced
-     *  casing. */
+     *  verbatim here; the realm-case retry happens in
+     *  {@link #candidateUpns}. */
     private String applyDefaultRealm(String username) {
         if (username == null) return null;
         if (username.contains("@")) return username;
         if (defaultRealm == null) return username;
         return username + "@" + defaultRealm;
+    }
+
+    /** The UPNs to try against F+, in order.
+     *
+     *  <p>Keycloak lower-cases the whole username before it reaches the
+     *  provider, so a user typing {@code me1ago@AMRC-FP.SHEF.AC.UK}
+     *  arrives as {@code me1ago@amrc-fp.shef.ac.uk}. F+ Auth compares
+     *  identity names with exact string equality, so the lookup misses
+     *  even though the principal exists. We therefore retry with the
+     *  realm portion (everything after the LAST {@code @}) upper-cased.
+     *
+     *  <p>Retry rather than unconditional upper-casing: uppercase
+     *  Kerberos realms are convention, not a rule, and a deployment
+     *  whose realm genuinely is lower case must keep working. The
+     *  verbatim form is always tried first, so those deployments are
+     *  unaffected and pay no extra request.
+     *
+     *  <p>Known limitation: only the realm is touched. An F+ identity
+     *  stored with capitals in the user portion ({@code Me1ago@...})
+     *  will still not match, because Keycloak has already folded the
+     *  case and the original is unrecoverable. Store user portions in
+     *  lower case. */
+    static List<String> candidateUpns(String upn) {
+        if (upn == null) return List.of();
+        int at = upn.lastIndexOf('@');
+        if (at < 0) return List.of(upn);
+        String realm = upn.substring(at + 1);
+        String upper = canonical_realm(realm);
+        if (upper.equals(realm)) return List.of(upn);
+        return List.of(upn, upn.substring(0, at) + "@" + upper);
+    }
+
+    private static String canonical_realm(String realm) {
+        return realm.trim().toUpperCase(Locale.ROOT);
     }
 
     @Override

--- a/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/FactoryPlusAccessDeniedException.java
+++ b/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/FactoryPlusAccessDeniedException.java
@@ -1,0 +1,25 @@
+/* ACS Keycloak SPI
+ * Raised when Factory+ Auth refuses a request with 403.
+ *
+ * A subtype of FactoryPlusAuthException, so every existing catch site
+ * behaves exactly as before. It exists so the cross-realm resolve can
+ * tell "the home cluster has not granted us ReadKrb" - a standing
+ * configuration state - apart from "the home cluster is having a bad
+ * minute". Both are fatal to the login, but only the former is worth
+ * caching: see FPAuthBackedUserStore.resolveCrossRealm.
+ *
+ * Copyright 2026 University of Sheffield AMRC
+ */
+
+package uk.co.amrc.app.factoryplus.keycloak;
+
+public class FactoryPlusAccessDeniedException extends FactoryPlusAuthException {
+
+    public FactoryPlusAccessDeniedException(String message) {
+        super(message);
+    }
+
+    public FactoryPlusAccessDeniedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/FactoryPlusUser.java
+++ b/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/FactoryPlusUser.java
@@ -14,6 +14,21 @@ package uk.co.amrc.app.factoryplus.keycloak;
  *                 it as an identity key.
  * @param email    Email address from F+, or null if the principal has none
  *                 (service accounts often don't).
+ * @param provisional True when this user has no Factory+ principal on
+ *                 the local cluster yet. Provisional users come from
+ *                 the cross-realm path: a trusted foreign realm vouches
+ *                 for them (or will, once the KDC confirms the
+ *                 password), but nothing has been written to F+ Auth.
+ *                 The provider calls
+ *                 {@link FactoryPlusUserStore#admit(String, String)}
+ *                 to persist the identity, and only after the password
+ *                 has validated.
  */
-public record FactoryPlusUser(String uuid, String username, String email) {
+public record FactoryPlusUser(String uuid, String username, String email,
+                              boolean provisional) {
+
+    /** Ordinary (non-provisional) user; the common case. */
+    public FactoryPlusUser(String uuid, String username, String email) {
+        this(uuid, username, email, false);
+    }
 }

--- a/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/FactoryPlusUserAdapter.java
+++ b/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/FactoryPlusUserAdapter.java
@@ -90,6 +90,16 @@ public class FactoryPlusUserAdapter extends AbstractUserAdapter {
     }
 
     /**
+     * True when this user has no Factory+ principal on this cluster
+     * yet: a trusted foreign realm vouches for them but nothing has
+     * been written. The provider admits them (writes the identity)
+     * only after their password validates.
+     */
+    public boolean isProvisional() {
+        return user.provisional();
+    }
+
+    /**
      * The set of F+ permission UUIDs (target=Wildcard) held by this
      * user, used by the {@code fp_permissions} OIDC claim mapper.
      * Delegates to the store so results come from the cache layer.
@@ -106,6 +116,13 @@ public class FactoryPlusUserAdapter extends AbstractUserAdapter {
      *  survive that wrapping (and the cache itself). */
     public static final String ATTR_FP_UUID = "fp_principal_uuid";
     public static final String ATTR_FP_PERMISSIONS = "fp_permissions";
+    /** Set only on provisional (cross-realm, not yet admitted) users.
+     *  The provider reads it through the attribute API rather than
+     *  {@code instanceof} for the same reason as the two above: by the
+     *  time credential validation runs we may be behind one of
+     *  Keycloak's own wrappers. No protocol mapper exposes it, so it
+     *  never reaches a token. */
+    public static final String ATTR_FP_PROVISIONAL = "fp_provisional";
 
     @Override
     public Map<String, List<String>> getAttributes() {
@@ -117,6 +134,7 @@ public class FactoryPlusUserAdapter extends AbstractUserAdapter {
         Map<String, List<String>> base = super.getAttributes();
         if (base != null) attrs.putAll(base);
         attrs.add(ATTR_FP_UUID, user.uuid());
+        if (user.provisional()) attrs.add(ATTR_FP_PROVISIONAL, "true");
         for (String g : store.findPermissionsForPrincipal(user.uuid())) {
             attrs.add(ATTR_FP_PERMISSIONS, g);
         }
@@ -126,6 +144,8 @@ public class FactoryPlusUserAdapter extends AbstractUserAdapter {
     @Override
     public Stream<String> getAttributeStream(String name) {
         if (ATTR_FP_UUID.equals(name)) return Stream.of(user.uuid());
+        if (ATTR_FP_PROVISIONAL.equals(name))
+            return user.provisional() ? Stream.of("true") : Stream.empty();
         if (ATTR_FP_PERMISSIONS.equals(name))
             return store.findPermissionsForPrincipal(user.uuid()).stream();
         // Expose username/email through the per-name attribute API
@@ -150,6 +170,8 @@ public class FactoryPlusUserAdapter extends AbstractUserAdapter {
     @Override
     public String getFirstAttribute(String name) {
         if (ATTR_FP_UUID.equals(name)) return user.uuid();
+        if (ATTR_FP_PROVISIONAL.equals(name))
+            return user.provisional() ? "true" : null;
         if (ATTR_FP_PERMISSIONS.equals(name)) {
             return store.findPermissionsForPrincipal(user.uuid())
                 .stream().findFirst().orElse(null);

--- a/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/FactoryPlusUserStorageProvider.java
+++ b/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/FactoryPlusUserStorageProvider.java
@@ -13,6 +13,7 @@
 
 package uk.co.amrc.app.factoryplus.keycloak;
 
+import org.jboss.logging.Logger;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.credential.CredentialInput;
 import org.keycloak.credential.CredentialInputValidator;
@@ -32,6 +33,9 @@ import java.util.stream.Stream;
 public class FactoryPlusUserStorageProvider
         implements UserStorageProvider, UserLookupProvider, UserQueryProvider,
                    CredentialInputValidator {
+
+    private static final Logger LOG =
+        Logger.getLogger(FactoryPlusUserStorageProvider.class);
 
     private final KeycloakSession session;
     private final ComponentModel model;
@@ -146,7 +150,47 @@ public class FactoryPlusUserStorageProvider
         if (!supportsCredentialType(input.getType())) return false;
         // The username Keycloak stored for this UserModel is the F+
         // kerberos UPN (set by FactoryPlusUserAdapter).
-        return passwordValidator.validate(user.getUsername(), input.getChallengeResponse());
+        if (!passwordValidator.validate(user.getUsername(), input.getChallengeResponse()))
+            return false;
+        // Password accepted by the KDC. Only now may we write anything:
+        // a provisional user is one a trusted foreign realm vouches for
+        // but that has no principal on this cluster yet. Admitting
+        // before this point would let anyone create principals here by
+        // guessing usernames.
+        return admit(user);
+    }
+
+    /** Persist a provisional user's Kerberos identity. Returns true for
+     *  ordinary (already-resolved) users, who need no write.
+     *
+     *  <p>A failed write fails the login. Issuing a session anyway
+     *  would hand out a token carrying an fp_principal_uuid that
+     *  nothing on the cluster recognises: every F+ service would reject
+     *  it, and the user would see a working login with no access and no
+     *  explanation. */
+    private boolean admit(UserModel user) {
+        if (!isProvisional(user)) return true;
+        String upn = user.getUsername();
+        String uuid = user.getFirstAttribute(FactoryPlusUserAdapter.ATTR_FP_UUID);
+        try {
+            store.admit(upn, uuid);
+            return true;
+        }
+        catch (RuntimeException e) {
+            LOG.error("Cannot admit cross-realm user " + upn
+                + " (uuid " + uuid + "); rejecting the login", e);
+            return false;
+        }
+    }
+
+    /** Prefer the direct type check, but fall back to the attribute:
+     *  by credential-validation time Keycloak may have wrapped our
+     *  adapter in one of its own UserModel implementations. */
+    private static boolean isProvisional(UserModel user) {
+        if (user instanceof FactoryPlusUserAdapter adapter)
+            return adapter.isProvisional();
+        return "true".equals(user.getFirstAttribute(
+            FactoryPlusUserAdapter.ATTR_FP_PROVISIONAL));
     }
 
     @Override

--- a/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/FactoryPlusUserStorageProviderFactory.java
+++ b/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/FactoryPlusUserStorageProviderFactory.java
@@ -29,8 +29,12 @@ import org.keycloak.storage.UserStorageProviderFactory;
 import java.net.URI;
 import java.time.Clock;
 import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -56,6 +60,11 @@ public class FactoryPlusUserStorageProviderFactory
     static final String CONFIG_KRB_PRINCIPAL      = "auth.principal";
     static final String CONFIG_KRB_KEYTAB_PATH    = "auth.keytab.path";
     static final String CONFIG_DEFAULT_REALM      = "default.realm";
+    static final String CONFIG_TRUSTED_REALMS     = "trusted.realms";
+    static final String CONFIG_TRUSTED_REALM_AUTH_URLS =
+        "trusted.realm.auth.urls";
+    static final String CONFIG_TRUSTED_REALM_TIMEOUT =
+        "trusted.realm.timeout.seconds";
     /* Must stay below Keycloak's 3-second ServicesUtils.timeBoundOne
      * hard limit on user-storage lookups. With a longer value our own
      * timeout can never fire: Keycloak interrupts the thread first and
@@ -63,6 +72,13 @@ public class FactoryPlusUserStorageProviderFactory
      * timeout naming the F+ auth service. */
     static final String DEFAULT_TIMEOUT_SECONDS   = "2";
     static final String DEFAULT_CACHE_TTL_SECONDS = "60";
+    /* The cross-realm resolve runs in SERIES after the local lookup
+     * misses, so the two timeouts add up against the same 3-second
+     * budget: 2 + 1.5 already overshoots slightly in the worst case,
+     * and anything larger reliably surfaces as an opaque
+     * InterruptedException instead of a clean timeout. Do not raise
+     * either value without lowering the other. */
+    static final String DEFAULT_TRUSTED_REALM_TIMEOUT_SECONDS = "1.5";
 
     private static final List<ProviderConfigProperty> CONFIG_PROPERTIES =
         ProviderConfigurationBuilder.create()
@@ -124,6 +140,40 @@ public class FactoryPlusUserStorageProviderFactory
                     + "the affordance and require the full UPN.")
                 .type(ProviderConfigProperty.STRING_TYPE)
                 .add()
+            .property()
+                .name(CONFIG_TRUSTED_REALMS)
+                .label("Trusted Kerberos realms")
+                .helpText("Comma-separated Kerberos realms whose users may "
+                    + "log in without a pre-existing Factory+ principal on "
+                    + "this cluster (e.g. PARTNER.EXAMPLE.ORG). Requires "
+                    + "cross-realm trust already configured in krb5.conf. "
+                    + "Leave blank - the default - to accept only local "
+                    + "principals.")
+                .type(ProviderConfigProperty.STRING_TYPE)
+                .add()
+            .property()
+                .name(CONFIG_TRUSTED_REALM_AUTH_URLS)
+                .label("Trusted realm auth URLs")
+                .helpText("Comma-separated REALM=url entries naming each "
+                    + "trusted realm's own Factory+ auth service, used to "
+                    + "resolve that realm's principal UUID so the user keeps "
+                    + "one identity across clusters. A trusted realm with no "
+                    + "entry here gets a freshly minted local UUID instead. "
+                    + "Flat encoding because Keycloak component config is a "
+                    + "fixed set of declared keys.")
+                .type(ProviderConfigProperty.STRING_TYPE)
+                .add()
+            .property()
+                .name(CONFIG_TRUSTED_REALM_TIMEOUT)
+                .label("Trusted realm request timeout (seconds)")
+                .helpText("Per-request timeout for calls to a trusted realm's "
+                    + "Factory+ auth service. This resolve runs after the "
+                    + "local lookup misses, so it adds to the request timeout "
+                    + "above against Keycloak's 3-second hard limit. Keep it "
+                    + "tight.")
+                .type(ProviderConfigProperty.STRING_TYPE)
+                .defaultValue(DEFAULT_TRUSTED_REALM_TIMEOUT_SECONDS)
+                .add()
             .build();
 
     @Override
@@ -153,7 +203,9 @@ public class FactoryPlusUserStorageProviderFactory
         StringBuilder sb = new StringBuilder();
         for (String k : List.of(CONFIG_AUTH_URL, CONFIG_TIMEOUT_SECONDS,
                 CONFIG_CACHE_TTL_SECONDS, CONFIG_KRB_PRINCIPAL,
-                CONFIG_KRB_KEYTAB_PATH, CONFIG_DEFAULT_REALM)) {
+                CONFIG_KRB_KEYTAB_PATH, CONFIG_DEFAULT_REALM,
+                CONFIG_TRUSTED_REALMS, CONFIG_TRUSTED_REALM_AUTH_URLS,
+                CONFIG_TRUSTED_REALM_TIMEOUT)) {
             sb.append(k).append('=')
               .append(model.getConfig().getFirst(k)).append(';');
         }
@@ -171,8 +223,16 @@ public class FactoryPlusUserStorageProviderFactory
 
         KerberosAuthenticator auth = buildAuthenticator(model);
         String defaultRealm = model.getConfig().getFirst(CONFIG_DEFAULT_REALM);
+        Set<String> trusted = parseList(
+            model.getConfig().getFirst(CONFIG_TRUSTED_REALMS));
+        Map<String, URI> homeUrls = parseRealmUrls(
+            model.getConfig().getFirst(CONFIG_TRUSTED_REALM_AUTH_URLS));
+        Duration homeTimeout = parseFractionalSeconds(
+            model.getConfig().getFirst(CONFIG_TRUSTED_REALM_TIMEOUT),
+            DEFAULT_TRUSTED_REALM_TIMEOUT_SECONDS);
         FactoryPlusUserStore base = new FPAuthBackedUserStore(
-            URI.create(url), timeout, auth, defaultRealm);
+            URI.create(url), timeout, auth, defaultRealm,
+            trusted, homeUrls, homeTimeout);
 
         Duration cacheTtl = parseSeconds(
             model.getConfig().getFirst(CONFIG_CACHE_TTL_SECONDS),
@@ -195,6 +255,60 @@ public class FactoryPlusUserStorageProviderFactory
             return null;
         }
         return new JaasKerberosAuthenticator(principal, keytab);
+    }
+
+    /** Comma-separated list, blanks dropped. Absent or empty yields an
+     *  empty set, which is what keeps cross-realm support inert until
+     *  an admin opts in. */
+    static Set<String> parseList(String configured) {
+        if (configured == null || configured.isBlank()) return Set.of();
+        Set<String> out = new LinkedHashSet<>();
+        for (String part : configured.split(",")) {
+            String trimmed = part.trim();
+            if (!trimmed.isEmpty()) out.add(trimmed);
+        }
+        return Set.copyOf(out);
+    }
+
+    /** Comma-separated {@code REALM=url} entries. Malformed entries
+     *  (no {@code =}, blank realm, unparseable URL) are dropped rather
+     *  than failing the whole federation: the realm then falls back to
+     *  the mint-fresh path, which is degraded but working. */
+    static Map<String, URI> parseRealmUrls(String configured) {
+        if (configured == null || configured.isBlank()) return Map.of();
+        Map<String, URI> out = new LinkedHashMap<>();
+        for (String part : configured.split(",")) {
+            String entry = part.trim();
+            if (entry.isEmpty()) continue;
+            int eq = entry.indexOf('=');
+            if (eq <= 0) continue;
+            String realm = entry.substring(0, eq).trim();
+            String url = entry.substring(eq + 1).trim();
+            if (realm.isEmpty() || url.isEmpty()) continue;
+            try {
+                out.put(realm, URI.create(url));
+            }
+            catch (IllegalArgumentException e) {
+                /* Skip; the realm degrades to the mint-fresh path. */
+            }
+        }
+        return Map.copyOf(out);
+    }
+
+    /** Like {@link #parseSeconds} but accepts a fractional value, since
+     *  the cross-realm timeout default is 1.5s. */
+    static Duration parseFractionalSeconds(String configured, String fallback) {
+        double secs;
+        try {
+            secs = Double.parseDouble(configured == null || configured.isBlank()
+                ? fallback
+                : configured.trim());
+        }
+        catch (NumberFormatException e) {
+            secs = Double.parseDouble(fallback);
+        }
+        if (secs <= 0) secs = Double.parseDouble(fallback);
+        return Duration.ofMillis(Math.round(secs * 1000));
     }
 
     private static Duration parseSeconds(String configured, String fallback) {

--- a/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/FactoryPlusUserStore.java
+++ b/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/FactoryPlusUserStore.java
@@ -1,9 +1,13 @@
 /* ACS Keycloak SPI
- * Read-only abstraction over the source of truth for users (Factory+
- * auth service). The provider depends on this interface, not on any
- * specific implementation, so unit tests can mock it and Phase 2 can
- * slot in a real HTTP-backed implementation behind it without touching
- * the provider.
+ * Abstraction over the source of truth for users (Factory+ auth
+ * service). The provider depends on this interface, not on any specific
+ * implementation, so unit tests can mock it and Phase 2 can slot in a
+ * real HTTP-backed implementation behind it without touching the
+ * provider.
+ *
+ * Lookups are read-only. The single write on this interface is
+ * `admit`, which persists a cross-realm user's Kerberos identity after
+ * their password has been validated against their home KDC.
  * Copyright 2026 University of Sheffield AMRC
  */
 
@@ -35,4 +39,29 @@ public interface FactoryPlusUserStore {
      *     grants; empty Set if the principal doesn't exist.
      */
     Set<String> findPermissionsForPrincipal(String uuid);
+
+    /**
+     * Persist a Kerberos identity for a cross-realm user, creating the
+     * local Factory+ principal if it doesn't exist.
+     *
+     * <p>This is the only write on the store, and it is called from
+     * exactly one place: {@code FactoryPlusUserStorageProvider.isValid},
+     * after the KDC has confirmed the user's password. Calling it
+     * anywhere earlier would let an unauthenticated caller create
+     * principals on the cluster by guessing usernames.
+     *
+     * <p>The write is a {@code PUT /v2/principal/{uuid}/kerberos},
+     * guarded server-side by the {@code WriteKrb} permission on the
+     * target UUID. The mirrored principal gets no ConfigDB
+     * {@code Info} name, so it appears in the ACL editor by its UPN.
+     *
+     * @param upn the fully qualified Kerberos principal name to store
+     * @param uuid the principal UUID to write against, or null to mint
+     *     a fresh random one
+     * @return the UUID the identity was written against
+     * @throws FactoryPlusAuthException if the write fails. The caller
+     *     must reject the login rather than issue a session whose
+     *     fp_principal_uuid nothing on the cluster recognises.
+     */
+    String admit(String upn, String uuid);
 }

--- a/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/JaasKerberosAuthenticator.java
+++ b/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/JaasKerberosAuthenticator.java
@@ -36,13 +36,20 @@ import uk.co.amrc.factoryplus.gss.FPGssProvider;
 public class JaasKerberosAuthenticator implements KerberosAuthenticator {
 
     private final FPGssClient client;
+    private final String principal;
 
     public JaasKerberosAuthenticator(String principal, String keytabPath) {
         FPGssProvider provider = new FPGssProvider(null);
+        this.principal = principal;
         this.client = provider.clientWithKeytab(principal, keytabPath);
         /* Force the initial JAAS login to happen now so misconfiguration
          * surfaces at SPI bootstrap, not on the first user sign-in. */
         primeCredentials();
+    }
+
+    @Override
+    public String principalName() {
+        return principal;
     }
 
     @Override

--- a/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/KerberosAuthenticator.java
+++ b/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/KerberosAuthenticator.java
@@ -40,4 +40,17 @@ public interface KerberosAuthenticator {
      *     SPNEGO context initiation fails
      */
     String spnegoTokenFor(URI target);
+
+    /**
+     * The principal these credentials belong to, e.g.
+     * {@code sv1openid@FACTORYPLUS.LOCAL}, or null if unknown.
+     *
+     * <p>Diagnostics only. The cross-realm resolve names it when a home
+     * cluster returns 403, because the fix is a grant to this exact
+     * principal made on a different cluster from the one logging the
+     * error.
+     */
+    default String principalName() {
+        return null;
+    }
 }

--- a/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/KerberosPasswordValidator.java
+++ b/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/KerberosPasswordValidator.java
@@ -34,8 +34,17 @@ public class KerberosPasswordValidator {
         if (upn == null || upn.isBlank() || password == null || password.isEmpty())
             return false;
 
-        // Same realm-uppercase canonicalisation as the user lookup;
-        // KDC rejects lowercase realm.
+        // Upper-case the realm before the AS-REQ; the KDC rejects a
+        // lowercase realm outright. The user lookup reaches the same
+        // form by retrying the realm-upper-cased UPN when the verbatim
+        // one misses (FPAuthBackedUserStore.candidateUpns), so by the
+        // time we get here the username may still carry whatever
+        // casing Keycloak folded it to.
+        //
+        // The realm in the principal name is also what routes the
+        // AS-REQ: no KDC is hardcoded and refreshKrb5Config picks up
+        // the realm's entry from krb5.conf, which is how cross-realm
+        // logins reach the foreign KDC.
         int at = upn.lastIndexOf('@');
         if (at >= 0) {
             upn = upn.substring(0, at) + "@" + upn.substring(at + 1).toUpperCase();

--- a/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/NullFactoryPlusUserStore.java
+++ b/acs-keycloak-spi/src/main/java/uk/co/amrc/app/factoryplus/keycloak/NullFactoryPlusUserStore.java
@@ -39,4 +39,15 @@ public final class NullFactoryPlusUserStore implements FactoryPlusUserStore {
     public Set<String> findPermissionsForPrincipal(String uuid) {
         return Set.of();
     }
+
+    @Override
+    public String admit(String upn, String uuid) {
+        // Unreachable in practice: every lookup returns empty, so no
+        // provisional user is ever produced for the provider to admit.
+        // Fail loudly rather than pretending the write happened - a
+        // silent success would issue a session whose principal doesn't
+        // exist anywhere.
+        throw new FactoryPlusAuthException(
+            "Cannot admit " + upn + ": no Factory+ auth service is configured");
+    }
 }

--- a/acs-keycloak-spi/src/test/java/uk/co/amrc/app/factoryplus/keycloak/CachingFactoryPlusUserStoreTest.java
+++ b/acs-keycloak-spi/src/test/java/uk/co/amrc/app/factoryplus/keycloak/CachingFactoryPlusUserStoreTest.java
@@ -153,6 +153,69 @@ class CachingFactoryPlusUserStoreTest {
             .isEqualTo(2);
     }
 
+    // -- admit / cross-realm admission -----------------------------------
+
+    @Test
+    void admit_invalidates_the_cached_miss_for_that_username() {
+        // A cross-realm user is looked up (miss, negatively cached),
+        // then admitted after their password validates. Without
+        // invalidation the negative entry masks the principal we just
+        // created for the full 60s TTL and the very next lookup in the
+        // login flow fails.
+        counting.respondWith(Optional.empty());
+        assertThat(cache.findByUsername("bob@OTHER.REALM")).isEmpty();
+        assertThat(counting.usernameCalls).isEqualTo(1);
+
+        cache.admit("bob@OTHER.REALM", "bob-uuid");
+
+        counting.respondWith(Optional.of(
+            new FactoryPlusUser("bob-uuid", "bob@OTHER.REALM", null)));
+        assertThat(cache.findByUsername("bob@OTHER.REALM"))
+            .as("Cache must re-ask the delegate after admit")
+            .isPresent();
+        assertThat(counting.usernameCalls).isEqualTo(2);
+    }
+
+    @Test
+    void admit_invalidates_a_cached_provisional_user_under_any_key() {
+        // Keycloak lower-cases the username, so the cache key is
+        // whatever it passed in, NOT the canonical UPN we admit under.
+        // Invalidation has to match on the cached value too or the
+        // provisional user survives and gets re-admitted every login.
+        counting.respondWith(Optional.of(new FactoryPlusUser(
+            "bob-uuid", "bob@OTHER.REALM", null, true)));
+        cache.findByUsername("bob@other.realm");
+        assertThat(counting.usernameCalls).isEqualTo(1);
+
+        cache.admit("bob@OTHER.REALM", "bob-uuid");
+
+        cache.findByUsername("bob@other.realm");
+        assertThat(counting.usernameCalls)
+            .as("The entry cached under the lower-cased key must go too")
+            .isEqualTo(2);
+    }
+
+    @Test
+    void admit_invalidates_the_uuid_keyspace() {
+        counting.respondWith(Optional.empty());
+        cache.findByUuid("bob-uuid");
+        assertThat(counting.uuidCalls).isEqualTo(1);
+
+        cache.admit("bob@OTHER.REALM", "bob-uuid");
+
+        cache.findByUuid("bob-uuid");
+        assertThat(counting.uuidCalls).isEqualTo(2);
+    }
+
+    @Test
+    void admit_delegates_and_returns_the_uuid_used() {
+        assertThat(cache.admit("bob@OTHER.REALM", null))
+            .as("A null uuid means the delegate mints one; return it")
+            .isEqualTo("minted-uuid");
+        assertThat(counting.admitCalls).isEqualTo(1);
+        assertThat(counting.lastAdmittedUpn).isEqualTo("bob@OTHER.REALM");
+    }
+
     // -- helpers ---------------------------------------------------------
 
     /** Test double counting calls per lookup kind. */
@@ -161,6 +224,8 @@ class CachingFactoryPlusUserStoreTest {
         int usernameCalls;
         int emailCalls;
         int groupCalls;
+        int admitCalls;
+        String lastAdmittedUpn;
         Optional<FactoryPlusUser> response = Optional.empty();
         Set<String> groupResponse = Set.of();
         boolean throwOnNext = false;
@@ -193,6 +258,11 @@ class CachingFactoryPlusUserStoreTest {
         @Override public Set<String> findPermissionsForPrincipal(String uuid) {
             groupCalls++;
             return groupResponse;
+        }
+        @Override public String admit(String upn, String uuid) {
+            admitCalls++;
+            lastAdmittedUpn = upn;
+            return uuid == null ? "minted-uuid" : uuid;
         }
 
         private Optional<FactoryPlusUser> responseOrThrow() {

--- a/acs-keycloak-spi/src/test/java/uk/co/amrc/app/factoryplus/keycloak/FPAuthBackedUserStoreTest.java
+++ b/acs-keycloak-spi/src/test/java/uk/co/amrc/app/factoryplus/keycloak/FPAuthBackedUserStoreTest.java
@@ -415,6 +415,11 @@ class FPAuthBackedUserStoreTest {
             assertThat(user.get().provisional())
                 .as("Nothing has been written locally yet")
                 .isTrue();
+            assertThat(user.get().uuid())
+                .as("The remote-resolve path adopts the home UUID; it must "
+                    + "NOT derive one, or the two clusters would disagree "
+                    + "about who this user is")
+                .isNotEqualTo(FPAuthBackedUserStore.mintedUuid(UPN_BOB));
         }
         finally {
             home.stop();
@@ -431,15 +436,106 @@ class FPAuthBackedUserStoreTest {
         assertThat(user).isPresent();
         assertThat(user.get().provisional()).isTrue();
         assertThat(user.get().username()).isEqualTo(UPN_BOB);
-        // The brief specified a null UUID here, minted in admit().
         // Keycloak derives the federated storage id from the UUID and
         // re-reads the user by that id later in the same login flow,
         // so a null would break the flow after admit had already
-        // written. We mint at lookup time instead; nothing is
+        // written. We derive at lookup time instead; nothing is
         // persisted until the KDC confirms the password.
         assertThat(user.get().uuid())
             .as("A provisional user still needs a usable storage id")
-            .isNotNull();
+            .isEqualTo(FPAuthBackedUserStore.mintedUuid(UPN_BOB));
+    }
+
+    // -- minted UUID derivation ------------------------------------------
+
+    @Test
+    void minted_uuid_matches_a_fixed_known_vector() {
+        // Pinned against the RFC 4122 reference implementation:
+        //   python3 -c "import uuid; print(uuid.uuid5(
+        //       uuid.UUID('cb3714c4-c85c-482a-987b-408293aa141e'),
+        //       'me1ago@AMRC-FP.SHEF.AC.UK'))"
+        // If a refactor changes this value it has silently orphaned
+        // every principal ever minted on the cross-realm path, so this
+        // assertion must never be "updated to match" - fix the code.
+        assertThat(FPAuthBackedUserStore.mintedUuid("me1ago@AMRC-FP.SHEF.AC.UK"))
+            .isEqualTo("12bb7b35-16c8-572d-af5f-c1f312ec4ae8");
+        assertThat(FPAuthBackedUserStore.mintedUuid(UPN_BOB))
+            .isEqualTo("5bd38a45-a07c-5606-b10a-b997b05f275b");
+    }
+
+    @Test
+    void the_namespace_constant_is_fixed() {
+        // Changing this orphans every minted principal. Pinned so the
+        // consequence has to be confronted deliberately.
+        assertThat(FPAuthBackedUserStore.ACS_PRINCIPAL_NAMESPACE)
+            .hasToString("cb3714c4-c85c-482a-987b-408293aa141e");
+    }
+
+    @Test
+    void minted_uuid_has_version_5_and_the_rfc_4122_variant() {
+        // Not UUID.nameUUIDFromBytes, which is MD5 and stamps version 3.
+        var uuid = java.util.UUID.fromString(FPAuthBackedUserStore.mintedUuid(UPN_BOB));
+        assertThat(uuid.version()).isEqualTo(5);
+        assertThat(uuid.variant())
+            .as("RFC 4122 variant, i.e. the two top bits of octet 8 are 10")
+            .isEqualTo(2);
+    }
+
+    @Test
+    void minted_uuid_is_identical_across_separate_store_instances() {
+        // The whole point: two clusters, no coordination, same answer.
+        var clusterA = trustingStore(null);
+        var clusterB = new FPAuthBackedUserStore(
+            URI.create("http://elsewhere.invalid"), Duration.ofSeconds(2),
+            null, "SOME.OTHER.DEFAULT",
+            Set.of("OTHER.REALM"), Map.of(), Duration.ofMillis(900));
+        stubLocalMissForBob();
+
+        String a = clusterA.findByUsername("bob@other.realm").orElseThrow().uuid();
+        String b = FPAuthBackedUserStore.mintedUuid(UPN_BOB);
+
+        assertThat(a).isEqualTo(b);
+        assertThat(clusterB).isNotNull();
+    }
+
+    @Test
+    void minted_uuid_is_stable_across_repeated_lookups() {
+        stubLocalMissForBob();
+        var trusting = trustingStore(null);
+
+        assertThat(trusting.findByUsername("bob@other.realm").orElseThrow().uuid())
+            .isEqualTo(trusting.findByUsername("bob@other.realm").orElseThrow().uuid());
+    }
+
+    @Test
+    void different_upns_derive_different_uuids() {
+        assertThat(FPAuthBackedUserStore.mintedUuid("alice@OTHER.REALM"))
+            .isNotEqualTo(FPAuthBackedUserStore.mintedUuid(UPN_BOB));
+    }
+
+    @Test
+    void minting_derives_from_the_canonicalised_upn_not_what_keycloak_typed() {
+        // Keycloak hands us bob@other.realm; the identity we write, and
+        // therefore the name we derive from, is bob@OTHER.REALM. An
+        // operator computing the UUID by hand uses the canonical form.
+        stubLocalMissForBob();
+
+        var user = trustingStore(null).findByUsername("bob@other.realm").orElseThrow();
+
+        assertThat(user.username()).isEqualTo(UPN_BOB);
+        assertThat(user.uuid()).isEqualTo(FPAuthBackedUserStore.mintedUuid(UPN_BOB));
+        assertThat(user.uuid())
+            .as("Deriving from the lower-cased form would break cross-cluster agreement")
+            .isNotEqualTo(FPAuthBackedUserStore.mintedUuid("bob@other.realm"));
+    }
+
+    @Test
+    void admit_with_no_uuid_derives_rather_than_randomising() {
+        wiremock.stubFor(put(urlPathMatching("/v2/principal/[^/]+/kerberos"))
+            .willReturn(aResponse().withStatus(204)));
+
+        assertThat(store.admit(UPN_BOB, null))
+            .isEqualTo(FPAuthBackedUserStore.mintedUuid(UPN_BOB));
     }
 
     @Test

--- a/acs-keycloak-spi/src/test/java/uk/co/amrc/app/factoryplus/keycloak/FPAuthBackedUserStoreTest.java
+++ b/acs-keycloak-spi/src/test/java/uk/co/amrc/app/factoryplus/keycloak/FPAuthBackedUserStoreTest.java
@@ -14,12 +14,16 @@ import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.time.Duration;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -323,6 +327,9 @@ class FPAuthBackedUserStoreTest {
 
         assertThat(user).isPresent();
         assertThat(user.get().username()).isEqualTo(UPN_ALICE);
+        assertThat(user.get().provisional())
+            .as("A local principal is not provisional")
+            .isFalse();
     }
 
     @Test
@@ -345,6 +352,341 @@ class FPAuthBackedUserStoreTest {
     void short_name_with_no_realm_has_a_single_candidate() {
         assertThat(FPAuthBackedUserStore.candidateUpns("alice"))
             .containsExactly("alice");
+    }
+
+    // -- cross-realm resolution ------------------------------------------
+
+    private static final String UUID_BOB = "00000000-0000-0000-0000-0000000000b0";
+    private static final String UPN_BOB  = "bob@OTHER.REALM";
+
+    /** Both casing candidates for bob@other.realm 410 locally. */
+    private void stubLocalMissForBob() {
+        wiremock.stubFor(get(urlPathEqualTo(
+                "/v2/identity/kerberos/bob%40other.realm"))
+            .willReturn(aResponse().withStatus(410)));
+        wiremock.stubFor(get(urlPathEqualTo(
+                "/v2/identity/kerberos/bob%40OTHER.REALM"))
+            .willReturn(aResponse().withStatus(410)));
+    }
+
+    /** Local store trusting OTHER.REALM, optionally with a home auth
+     *  URL. The "home cluster" is a second Wiremock instance. */
+    private FPAuthBackedUserStore trustingStore(URI homeUrl) {
+        return new FPAuthBackedUserStore(
+            URI.create(wiremock.baseUrl()), Duration.ofSeconds(2), null, null,
+            Set.of("OTHER.REALM"),
+            homeUrl == null ? Map.of() : Map.of("other.realm", homeUrl),
+            Duration.ofMillis(1500));
+    }
+
+    @Test
+    void untrusted_realm_returns_empty_after_both_candidates_miss() {
+        // Existing behaviour must be unchanged for anything the admin
+        // hasn't explicitly trusted.
+        stubLocalMissForBob();
+
+        assertThat(store.findByUsername("bob@other.realm")).isEmpty();
+    }
+
+    @Test
+    void trusted_realm_with_auth_url_resolves_the_home_uuid() {
+        var home = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        home.start();
+        try {
+            stubLocalMissForBob();
+            home.stubFor(get(urlPathEqualTo(
+                    "/v2/identity/kerberos/bob%40OTHER.REALM"))
+                .willReturn(okJson("\"" + UUID_BOB + "\"")));
+            home.stubFor(get(urlPathEqualTo("/v2/principal/" + UUID_BOB))
+                .willReturn(okJson("""
+                    { "uuid": "%s", "kerberos": "%s" }
+                    """.formatted(UUID_BOB, UPN_BOB))));
+
+            Optional<FactoryPlusUser> user = trustingStore(URI.create(home.baseUrl()))
+                .findByUsername("bob@other.realm");
+
+            assertThat(user).isPresent();
+            assertThat(user.get().uuid())
+                .as("The user keeps their home cluster's principal UUID")
+                .isEqualTo(UUID_BOB);
+            assertThat(user.get().username())
+                .as("Home cluster's own spelling of the UPN wins")
+                .isEqualTo(UPN_BOB);
+            assertThat(user.get().provisional())
+                .as("Nothing has been written locally yet")
+                .isTrue();
+        }
+        finally {
+            home.stop();
+        }
+    }
+
+    @Test
+    void trusted_realm_with_no_auth_url_mints_a_provisional_user() {
+        stubLocalMissForBob();
+
+        Optional<FactoryPlusUser> user = trustingStore(null)
+            .findByUsername("bob@other.realm");
+
+        assertThat(user).isPresent();
+        assertThat(user.get().provisional()).isTrue();
+        assertThat(user.get().username()).isEqualTo(UPN_BOB);
+        // The brief specified a null UUID here, minted in admit().
+        // Keycloak derives the federated storage id from the UUID and
+        // re-reads the user by that id later in the same login flow,
+        // so a null would break the flow after admit had already
+        // written. We mint at lookup time instead; nothing is
+        // persisted until the KDC confirms the password.
+        assertThat(user.get().uuid())
+            .as("A provisional user still needs a usable storage id")
+            .isNotNull();
+    }
+
+    @Test
+    void trusted_realm_home_410_returns_empty() {
+        var home = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        home.start();
+        try {
+            stubLocalMissForBob();
+            home.stubFor(get(urlPathEqualTo(
+                    "/v2/identity/kerberos/bob%40OTHER.REALM"))
+                .willReturn(aResponse().withStatus(410)));
+
+            assertThat(trustingStore(URI.create(home.baseUrl()))
+                .findByUsername("bob@other.realm"))
+                .as("The user genuinely doesn't exist at home either")
+                .isEmpty();
+        }
+        finally {
+            home.stop();
+        }
+    }
+
+    @Test
+    void trusted_realm_home_5xx_throws_rather_than_returning_empty() {
+        // This distinction is the point. Empty means "no such user"
+        // and Keycloak reports user_not_found; the exception means
+        // "infrastructure failed" and Keycloak fails the login. A home
+        // cluster being down must never read as the user not existing.
+        var home = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        home.start();
+        try {
+            stubLocalMissForBob();
+            home.stubFor(get(urlPathEqualTo(
+                    "/v2/identity/kerberos/bob%40OTHER.REALM"))
+                .willReturn(aResponse().withStatus(503)));
+
+            var trusting = trustingStore(URI.create(home.baseUrl()));
+            assertThatThrownBy(() -> trusting.findByUsername("bob@other.realm"))
+                .isInstanceOf(FactoryPlusAuthException.class)
+                .hasMessageContaining("503");
+        }
+        finally {
+            home.stop();
+        }
+    }
+
+    @Test
+    void trusted_realm_home_timeout_throws_rather_than_returning_empty() {
+        var home = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        home.start();
+        try {
+            stubLocalMissForBob();
+            home.stubFor(get(urlPathEqualTo(
+                    "/v2/identity/kerberos/bob%40OTHER.REALM"))
+                .willReturn(okJson("\"" + UUID_BOB + "\"").withFixedDelay(3000)));
+
+            var trusting = new FPAuthBackedUserStore(
+                URI.create(wiremock.baseUrl()), Duration.ofSeconds(2), null, null,
+                Set.of("OTHER.REALM"),
+                Map.of("OTHER.REALM", URI.create(home.baseUrl())),
+                Duration.ofMillis(300));
+
+            assertThatThrownBy(() -> trusting.findByUsername("bob@other.realm"))
+                .isInstanceOf(FactoryPlusAuthException.class);
+        }
+        finally {
+            home.stop();
+        }
+    }
+
+    @Test
+    void trusted_realm_home_403_fails_the_login_and_never_mints() {
+        // 403 means the home cluster has not granted us ReadKrb.
+        // Falling back to minting a fresh local UUID would defeat
+        // revocation - the ReadKrb grant is the kill switch for the
+        // whole trust relationship - and would split the estate into
+        // home-derived and locally-minted principals depending on when
+        // each user first logged in. Keep it fatal.
+        var home = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        home.start();
+        try {
+            stubLocalMissForBob();
+            home.stubFor(get(urlPathMatching("/v2/identity/kerberos/.*"))
+                .willReturn(aResponse().withStatus(403)));
+
+            var trusting = trustingStore(URI.create(home.baseUrl()));
+            assertThatThrownBy(() -> trusting.findByUsername("bob@other.realm"))
+                .isInstanceOf(FactoryPlusAccessDeniedException.class)
+                .as("The message must lead an operator to the fix, which "
+                    + "lives on a different cluster from the error")
+                .hasMessageContaining("ReadKrb")
+                .hasMessageContaining("e8c9c0f7-0d54-4db2-b8d6-cd80c45f6a5c")
+                .hasMessageContaining("OTHER.REALM")
+                .hasMessageContaining(home.baseUrl());
+        }
+        finally {
+            home.stop();
+        }
+    }
+
+    @Test
+    void trusted_realm_home_403_names_the_denied_principal() {
+        var home = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        home.start();
+        try {
+            stubLocalMissForBob();
+            home.stubFor(get(urlPathMatching("/v2/identity/kerberos/.*"))
+                .willReturn(aResponse().withStatus(403)));
+
+            var trusting = new FPAuthBackedUserStore(
+                URI.create(wiremock.baseUrl()), Duration.ofSeconds(2),
+                new StubAuthenticator("T", "sv1openid@LOCAL.REALM"), null,
+                Set.of("OTHER.REALM"),
+                Map.of("OTHER.REALM", URI.create(home.baseUrl())),
+                Duration.ofMillis(1500));
+
+            assertThatThrownBy(() -> trusting.findByUsername("bob@other.realm"))
+                .hasMessageContaining("sv1openid@LOCAL.REALM");
+        }
+        finally {
+            home.stop();
+        }
+    }
+
+    @Test
+    void a_standing_403_is_cached_so_it_costs_one_call_not_one_per_attempt() {
+        // Lookup runs BEFORE password validation, so while
+        // misconfigured anyone reaching the login page could bounce a
+        // call off the remote cluster per attempt just by typing
+        // foreign usernames. 5xx and timeouts stay uncached (they're
+        // transient); a 403 is a standing configuration state.
+        var home = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        home.start();
+        try {
+            stubLocalMissForBob();
+            home.stubFor(get(urlPathMatching("/v2/identity/kerberos/.*"))
+                .willReturn(aResponse().withStatus(403)));
+
+            var trusting = trustingStore(URI.create(home.baseUrl()));
+            assertThatThrownBy(() -> trusting.findByUsername("bob@other.realm"))
+                .isInstanceOf(FactoryPlusAccessDeniedException.class);
+            int afterFirst = home.getAllServeEvents().size();
+            assertThat(afterFirst).isGreaterThan(0);
+
+            // A different user in the same realm, so no per-user cache
+            // could explain the suppression.
+            wiremock.stubFor(get(urlPathMatching("/v2/identity/kerberos/carol.*"))
+                .willReturn(aResponse().withStatus(410)));
+            assertThatThrownBy(() -> trusting.findByUsername("carol@other.realm"))
+                .as("Still fatal - suppressing the call must not soften the failure")
+                .isInstanceOf(FactoryPlusAccessDeniedException.class)
+                .hasMessageContaining("ReadKrb");
+
+            assertThat(home.getAllServeEvents())
+                .as("The denial is keyed by realm, so the second attempt "
+                    + "must not touch the home cluster at all")
+                .hasSize(afterFirst);
+        }
+        finally {
+            home.stop();
+        }
+    }
+
+    @Test
+    void a_home_5xx_is_not_cached() {
+        // Contrast with the 403 above: a transient failure must not
+        // lock out lookups, so every attempt re-tries the home cluster.
+        var home = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        home.start();
+        try {
+            stubLocalMissForBob();
+            home.stubFor(get(urlPathMatching("/v2/identity/kerberos/.*"))
+                .willReturn(aResponse().withStatus(503)));
+
+            var trusting = trustingStore(URI.create(home.baseUrl()));
+            assertThatThrownBy(() -> trusting.findByUsername("bob@other.realm"))
+                .isInstanceOf(FactoryPlusAuthException.class);
+            int afterFirst = home.getAllServeEvents().size();
+
+            assertThatThrownBy(() -> trusting.findByUsername("bob@other.realm"))
+                .isInstanceOf(FactoryPlusAuthException.class);
+
+            assertThat(home.getAllServeEvents().size())
+                .as("5xx must stay uncached so recovery is immediate")
+                .isGreaterThan(afterFirst);
+        }
+        finally {
+            home.stop();
+        }
+    }
+
+    @Test
+    void trusted_realm_matching_is_case_insensitive() {
+        // The incoming realm is lower-cased by Keycloak and the
+        // configured list may be typed either way, so neither side can
+        // be assumed canonical.
+        stubLocalMissForBob();
+        var trusting = new FPAuthBackedUserStore(
+            URI.create(wiremock.baseUrl()), Duration.ofSeconds(2), null, null,
+            Set.of("other.realm"), Map.of(), Duration.ofMillis(1500));
+
+        assertThat(trusting.findByUsername("bob@other.realm")).isPresent();
+    }
+
+    // -- admit -----------------------------------------------------------
+
+    @Test
+    void admit_puts_the_upn_as_a_json_string_against_the_given_uuid() {
+        wiremock.stubFor(put(urlPathEqualTo(
+                "/v2/principal/" + UUID_BOB + "/kerberos"))
+            .willReturn(aResponse().withStatus(204)));
+
+        assertThat(store.admit(UPN_BOB, UUID_BOB)).isEqualTo(UUID_BOB);
+
+        var event = wiremock.getAllServeEvents().get(0);
+        assertThat(event.getRequest().getBodyAsString())
+            .as("acs-auth parses bodies with express.json, so the UPN "
+                + "goes over the wire as a JSON string literal")
+            .isEqualTo("\"" + UPN_BOB + "\"");
+        assertThat(event.getRequest().getHeader("Content-Type"))
+            .isEqualTo("application/json");
+    }
+
+    @Test
+    void admit_mints_a_uuid_when_given_none() {
+        wiremock.stubFor(put(urlPathMatching("/v2/principal/[^/]+/kerberos"))
+            .willReturn(aResponse().withStatus(204)));
+
+        String uuid = store.admit(UPN_BOB, null);
+
+        assertThat(uuid).isNotNull();
+        assertThat(wiremock.getAllServeEvents().get(0).getRequest().getUrl())
+            .contains(uuid);
+    }
+
+    @Test
+    void admit_throws_when_the_write_is_refused() {
+        // 403 means sv1openid lacks WriteKrb on the target. The login
+        // must fail rather than issue a token whose principal doesn't
+        // exist.
+        wiremock.stubFor(put(urlPathEqualTo(
+                "/v2/principal/" + UUID_BOB + "/kerberos"))
+            .willReturn(aResponse().withStatus(403)));
+
+        assertThatThrownBy(() -> store.admit(UPN_BOB, UUID_BOB))
+            .isInstanceOf(FactoryPlusAuthException.class)
+            .hasMessageContaining("403");
     }
 
     // -- find by email ---------------------------------------------------
@@ -481,10 +823,19 @@ class FPAuthBackedUserStoreTest {
     /** Captures call count + last target URL for assertion. */
     private static final class StubAuthenticator implements KerberosAuthenticator {
         final String token;
+        final String principal;
         int callCount;
         URI lastTarget;
 
-        StubAuthenticator(String token) { this.token = token; }
+        StubAuthenticator(String token) { this(token, null); }
+
+        StubAuthenticator(String token, String principal) {
+            this.token = token;
+            this.principal = principal;
+        }
+
+        @Override
+        public String principalName() { return principal; }
 
         @Override
         public String spnegoTokenFor(URI target) {

--- a/acs-keycloak-spi/src/test/java/uk/co/amrc/app/factoryplus/keycloak/FPAuthBackedUserStoreTest.java
+++ b/acs-keycloak-spi/src/test/java/uk/co/amrc/app/factoryplus/keycloak/FPAuthBackedUserStoreTest.java
@@ -283,6 +283,70 @@ class FPAuthBackedUserStoreTest {
         assertThat(blankRealm.findByUsername("alice")).isEmpty();
     }
 
+    // -- realm-case retry ------------------------------------------------
+
+    @Test
+    void first_candidate_hit_does_not_trigger_the_realm_case_retry() {
+        // The verbatim form is authoritative. If it resolves we must
+        // not spend a second round trip on the upper-cased realm -
+        // both timeouts come out of Keycloak's 3-second budget.
+        wiremock.stubFor(get(urlPathEqualTo(
+                "/v2/identity/kerberos/alice%40mixed.Realm"))
+            .willReturn(okJson("\"" + UUID_ALICE + "\"")));
+        wiremock.stubFor(get(urlPathEqualTo("/v2/principal/" + UUID_ALICE))
+            .willReturn(okJson(PRINCIPAL_JSON)));
+
+        assertThat(store.findByUsername("alice@mixed.Realm")).isPresent();
+
+        assertThat(wiremock.getAllServeEvents())
+            .as("Identity lookup + principal lookup, and nothing else")
+            .hasSize(2);
+    }
+
+    @Test
+    void miss_on_verbatim_realm_retries_with_the_realm_upper_cased() {
+        // Keycloak lower-cases the whole username before it reaches
+        // us, so a fully qualified login arrives as
+        // alice@factoryplus.local. F+ compares identity names with
+        // exact string equality, so the verbatim lookup 410s and only
+        // the upper-cased realm matches.
+        wiremock.stubFor(get(urlPathEqualTo(
+                "/v2/identity/kerberos/alice%40factoryplus.local"))
+            .willReturn(aResponse().withStatus(410)));
+        wiremock.stubFor(get(urlPathEqualTo(
+                "/v2/identity/kerberos/alice%40FACTORYPLUS.LOCAL"))
+            .willReturn(okJson("\"" + UUID_ALICE + "\"")));
+        wiremock.stubFor(get(urlPathEqualTo("/v2/principal/" + UUID_ALICE))
+            .willReturn(okJson(PRINCIPAL_JSON)));
+
+        Optional<FactoryPlusUser> user = store.findByUsername("alice@factoryplus.local");
+
+        assertThat(user).isPresent();
+        assertThat(user.get().username()).isEqualTo(UPN_ALICE);
+    }
+
+    @Test
+    void only_the_realm_portion_is_upper_cased_on_retry() {
+        // Documented limitation: Keycloak has already folded the user
+        // portion's case and the original is unrecoverable, so we
+        // never touch it. An F+ identity stored as "Alice@..." stays
+        // unreachable.
+        assertThat(FPAuthBackedUserStore.candidateUpns("alice@mixed.Realm"))
+            .containsExactly("alice@mixed.Realm", "alice@MIXED.REALM");
+    }
+
+    @Test
+    void no_retry_candidate_when_the_realm_is_already_upper_case() {
+        assertThat(FPAuthBackedUserStore.candidateUpns(UPN_ALICE))
+            .containsExactly(UPN_ALICE);
+    }
+
+    @Test
+    void short_name_with_no_realm_has_a_single_candidate() {
+        assertThat(FPAuthBackedUserStore.candidateUpns("alice"))
+            .containsExactly("alice");
+    }
+
     // -- find by email ---------------------------------------------------
 
     @Test

--- a/acs-keycloak-spi/src/test/java/uk/co/amrc/app/factoryplus/keycloak/FactoryConfigDrivenStoreTest.java
+++ b/acs-keycloak-spi/src/test/java/uk/co/amrc/app/factoryplus/keycloak/FactoryConfigDrivenStoreTest.java
@@ -112,4 +112,59 @@ class FactoryConfigDrivenStoreTest {
 
         assertThat(provider.getStore()).isInstanceOf(CachingFactoryPlusUserStore.class);
     }
+
+    // -- cross-realm config parsing --------------------------------------
+
+    @Test
+    void trusted_realms_default_to_none() {
+        // Cross-realm support must be inert until an admin opts in.
+        assertThat(FactoryPlusUserStorageProviderFactory.parseList(null)).isEmpty();
+        assertThat(FactoryPlusUserStorageProviderFactory.parseList("")).isEmpty();
+        assertThat(FactoryPlusUserStorageProviderFactory.parseList("  ")).isEmpty();
+    }
+
+    @Test
+    void trusted_realms_parse_as_a_comma_separated_list() {
+        assertThat(FactoryPlusUserStorageProviderFactory.parseList(
+                "A.REALM, B.REALM ,,C.REALM"))
+            .containsExactlyInAnyOrder("A.REALM", "B.REALM", "C.REALM");
+    }
+
+    @Test
+    void trusted_realm_auth_urls_parse_as_flat_realm_equals_url_entries() {
+        // Flat encoding because Keycloak's component config is a fixed
+        // set of declared keys; per-realm keys can't be declared in
+        // getConfigProperties().
+        var urls = FactoryPlusUserStorageProviderFactory.parseRealmUrls(
+            "A.REALM=https://auth.a.example, B.REALM=http://auth.b.example");
+
+        assertThat(urls).containsOnlyKeys("A.REALM", "B.REALM");
+        assertThat(urls.get("A.REALM").getHost()).isEqualTo("auth.a.example");
+    }
+
+    @Test
+    void malformed_trusted_realm_url_entries_are_dropped_not_fatal() {
+        // A typo in one entry degrades that realm to the mint-fresh
+        // path rather than breaking the whole federation.
+        assertThat(FactoryPlusUserStorageProviderFactory.parseRealmUrls(
+                "no-equals-sign, =https://orphan.example, A.REALM=https://auth.a.example"))
+            .containsOnlyKeys("A.REALM");
+    }
+
+    @Test
+    void trusted_realm_timeout_accepts_a_fractional_value() {
+        assertThat(FactoryPlusUserStorageProviderFactory
+                .parseFractionalSeconds("1.5", "1.5"))
+            .isEqualTo(java.time.Duration.ofMillis(1500));
+    }
+
+    @Test
+    void trusted_realm_timeout_falls_back_on_junk() {
+        assertThat(FactoryPlusUserStorageProviderFactory
+                .parseFractionalSeconds("soon", "1.5"))
+            .isEqualTo(java.time.Duration.ofMillis(1500));
+        assertThat(FactoryPlusUserStorageProviderFactory
+                .parseFractionalSeconds(null, "1.5"))
+            .isEqualTo(java.time.Duration.ofMillis(1500));
+    }
 }

--- a/acs-keycloak-spi/src/test/java/uk/co/amrc/app/factoryplus/keycloak/FactoryPlusPermissionsMapperTest.java
+++ b/acs-keycloak-spi/src/test/java/uk/co/amrc/app/factoryplus/keycloak/FactoryPlusPermissionsMapperTest.java
@@ -103,5 +103,6 @@ class FactoryPlusPermissionsMapperTest {
         @Override public Optional<FactoryPlusUser> findByUsername(String n) { return Optional.empty(); }
         @Override public Optional<FactoryPlusUser> findByEmail(String e) { return Optional.empty(); }
         @Override public Set<String> findPermissionsForPrincipal(String u) { return groups; }
+        @Override public String admit(String upn, String uuid) { return uuid; }
     }
 }

--- a/acs-keycloak-spi/src/test/java/uk/co/amrc/app/factoryplus/keycloak/FactoryPlusUserAdapterTest.java
+++ b/acs-keycloak-spi/src/test/java/uk/co/amrc/app/factoryplus/keycloak/FactoryPlusUserAdapterTest.java
@@ -154,5 +154,6 @@ class FactoryPlusUserAdapterTest {
             lastUuid = uuid;
             return response;
         }
+        @Override public String admit(String upn, String uuid) { return uuid; }
     }
 }

--- a/acs-keycloak-spi/src/test/java/uk/co/amrc/app/factoryplus/keycloak/FactoryPlusUserStorageProviderTest.java
+++ b/acs-keycloak-spi/src/test/java/uk/co/amrc/app/factoryplus/keycloak/FactoryPlusUserStorageProviderTest.java
@@ -12,9 +12,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.keycloak.component.ComponentModel;
+import org.keycloak.credential.CredentialInput;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserCredentialModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.credential.PasswordCredentialModel;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -24,6 +27,9 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -179,5 +185,110 @@ class FactoryPlusUserStorageProviderTest {
         var users = provider.getGroupMembersStream(realm, null, 0, 100).toList();
 
         assertThat(users).isEmpty();
+    }
+
+    // -- cross-realm admission ------------------------------------------
+    //
+    // The ordering here is the security property: a provisional user is
+    // one a trusted foreign realm vouches for, and nothing may be
+    // written for them until their home KDC has confirmed the password.
+    // Lookup runs for unauthenticated callers, so admitting any earlier
+    // would let anyone create principals on the cluster by guessing
+    // usernames.
+
+    private static final FactoryPlusUser BOB_PROVISIONAL = new FactoryPlusUser(
+        "00000000-0000-0000-0000-0000000000b0",
+        "bob@OTHER.REALM",
+        null,
+        true);
+
+    /** Stands in for the real Kerberos validator, whose {@code validate}
+     *  needs a KDC. Records whether it ran so the tests can assert that
+     *  the write never happens before the password check. */
+    private static final class StubValidator extends KerberosPasswordValidator {
+        boolean accept;
+        boolean called;
+
+        StubValidator(boolean accept) { this.accept = accept; }
+
+        @Override
+        public boolean validate(String upn, String password) {
+            called = true;
+            return accept;
+        }
+    }
+
+    private FactoryPlusUserStorageProvider providerWith(StubValidator validator) {
+        return new FactoryPlusUserStorageProvider(session, model, store, validator);
+    }
+
+    private UserModel provisionalUser() {
+        return new FactoryPlusUserAdapter(session, realm, model,
+            BOB_PROVISIONAL, store);
+    }
+
+    private static CredentialInput password(String value) {
+        return new UserCredentialModel(null, PasswordCredentialModel.TYPE, value);
+    }
+
+    @Test
+    void admit_is_called_after_a_successful_password_check() {
+        var validator = new StubValidator(true);
+
+        boolean valid = providerWith(validator)
+            .isValid(realm, provisionalUser(), password("hunter2"));
+
+        assertThat(valid).isTrue();
+        verify(store).admit(BOB_PROVISIONAL.username(), BOB_PROVISIONAL.uuid());
+    }
+
+    @Test
+    void admit_is_never_called_when_the_password_check_fails() {
+        var validator = new StubValidator(false);
+
+        boolean valid = providerWith(validator)
+            .isValid(realm, provisionalUser(), password("wrong"));
+
+        assertThat(valid).isFalse();
+        assertThat(validator.called)
+            .as("The password must actually have been tested")
+            .isTrue();
+        verify(store, never()).admit(any(), any());
+    }
+
+    @Test
+    void admit_is_not_called_for_an_ordinary_local_user() {
+        var validator = new StubValidator(true);
+        UserModel local = new FactoryPlusUserAdapter(session, realm, model,
+            ALICE, store);
+
+        assertThat(providerWith(validator).isValid(realm, local, password("ok")))
+            .isTrue();
+        verify(store, never()).admit(any(), any());
+    }
+
+    @Test
+    void is_valid_returns_false_when_admit_throws() {
+        // Never issue a session whose identity could not be persisted:
+        // the token would carry an fp_principal_uuid that nothing on
+        // the cluster recognises, so every F+ service would reject it.
+        var validator = new StubValidator(true);
+        when(store.admit(any(), any()))
+            .thenThrow(new FactoryPlusAuthException("write refused"));
+
+        assertThat(providerWith(validator)
+            .isValid(realm, provisionalUser(), password("hunter2")))
+            .isFalse();
+    }
+
+    @Test
+    void unsupported_credential_type_never_reaches_the_validator() {
+        var validator = new StubValidator(true);
+
+        assertThat(providerWith(validator).isValid(realm, provisionalUser(),
+            new UserCredentialModel(null, "otp", "123456")))
+            .isFalse();
+        assertThat(validator.called).isFalse();
+        verify(store, never()).admit(any(), any());
     }
 }

--- a/acs-keycloak-spi/src/test/java/uk/co/amrc/app/factoryplus/keycloak/NullFactoryPlusUserStoreTest.java
+++ b/acs-keycloak-spi/src/test/java/uk/co/amrc/app/factoryplus/keycloak/NullFactoryPlusUserStoreTest.java
@@ -11,6 +11,7 @@ package uk.co.amrc.app.factoryplus.keycloak;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class NullFactoryPlusUserStoreTest {
 
@@ -35,6 +36,15 @@ class NullFactoryPlusUserStoreTest {
         assertThat(store.findByEmail("alice@example.invalid")).isEmpty();
         assertThat(store.findByEmail("")).isEmpty();
         assertThat(store.findByEmail(null)).isEmpty();
+    }
+
+    @Test
+    void admit_fails_loudly_rather_than_pretending_to_write() {
+        // Unreachable in practice (no lookup ever yields a provisional
+        // user), but a silent success here would issue a session for a
+        // principal that exists nowhere.
+        assertThatThrownBy(() -> store.admit("bob@OTHER.REALM", null))
+            .isInstanceOf(FactoryPlusAuthException.class);
     }
 
     @Test

--- a/acs-keycloak-spi/src/test/java/uk/co/amrc/app/factoryplus/keycloak/integration/FactoryPlusFederationIT.java
+++ b/acs-keycloak-spi/src/test/java/uk/co/amrc/app/factoryplus/keycloak/integration/FactoryPlusFederationIT.java
@@ -38,6 +38,9 @@ import org.testcontainers.utility.MountableFile;
 import java.nio.file.Path;
 import java.time.Duration;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Testcontainers
@@ -238,6 +241,88 @@ class FactoryPlusFederationIT {
                 .startsWith("http://host.testcontainers.internal:");
             assertThat(stored.get(0).getConfig().getFirst("auth.timeout.seconds"))
                 .isEqualTo("3");
+        }
+    }
+
+    @Test
+    void federation_serves_a_provisional_cross_realm_user() {
+        // The full provisional path against a real Keycloak. Our own
+        // logic is covered by the unit tests; what this proves is that
+        // Keycloak accepts a federated user that did not exist a
+        // moment ago - it has a usable storage id, survives the
+        // component's lookup path, and doesn't trip any of Keycloak's
+        // internal assumptions about federated users being persistent.
+        //
+        // The cross-realm AS-REQ itself stays a manual verification:
+        // standing up a second KDC with a realm trust inside the test
+        // harness costs far more than it proves.
+        String realmName = "OTHER.REALM";
+        // Local F+ 410s for both casing candidates, so the lookup falls
+        // through to the trusted-realm path. No home auth URL is
+        // configured, so the SPI mints a provisional user rather than
+        // resolving one.
+        wiremock.stubFor(get(urlPathMatching("/v2/identity/kerberos/.*"))
+            .willReturn(aResponse().withStatus(410)));
+
+        try (Keycloak admin = adminClient()) {
+            var realm = admin.realm("master");
+            String realmId = realm.toRepresentation().getId();
+
+            var component = new ComponentRepresentation();
+            component.setName("factoryplus-crossrealm");
+            component.setProviderType(UserStorageProvider.class.getName());
+            component.setProviderId("factoryplus");
+            component.setParentId(realmId);
+            var config = new MultivaluedHashMap<String, String>();
+            config.putSingle("auth.url",
+                "http://host.testcontainers.internal:" + wiremock.port());
+            config.putSingle("auth.timeout.seconds", "2");
+            // Disable the SPI cache so this test's stubs aren't masked
+            // by an entry another test's lookup left behind.
+            config.putSingle("cache.ttl.seconds", "0");
+            config.putSingle("trusted.realms", realmName);
+            config.putSingle("trusted.realm.timeout.seconds", "1.5");
+            component.setConfig(config);
+
+            try (Response res = realm.components().add(component)) {
+                assertThat(res.getStatus())
+                    .as("Keycloak must accept the cross-realm config keys; a 400 "
+                        + "here means getConfigProperties() and the parsing "
+                        + "have drifted apart")
+                    .isEqualTo(201);
+            }
+
+            var stored = realm.components().query(realmId,
+                UserStorageProvider.class.getName(), "factoryplus-crossrealm");
+            assertThat(stored).hasSize(1);
+            assertThat(stored.get(0).getConfig().getFirst("trusted.realms"))
+                .isEqualTo(realmName);
+            assertThat(stored.get(0).getConfig().getFirst("trusted.realm.timeout.seconds"))
+                .isEqualTo("1.5");
+
+            // Drive a lookup through the real Keycloak session so the
+            // provisional user is actually constructed inside the
+            // server, not just in a unit test's JVM. The admin-client
+            // version skew documented above makes users().search()
+            // unusable here, so we assert on the SPI's own outbound
+            // traffic instead: two casing candidates, then the
+            // cross-realm path, with no further HTTP because no home
+            // auth URL is set.
+            wiremock.resetRequests();
+            try {
+                realm.users().search("bob@other.realm", 0, 1);
+            }
+            catch (RuntimeException e) {
+                // Expected: admin-client 26.0.5 against server 26.1.1
+                // returns 400 "Cannot parse the JSON" from the search
+                // endpoint. The dispatch to our provider still happened.
+            }
+            assertThat(wiremock.getAllServeEvents())
+                .as("Keycloak lower-cases the username, so the SPI must try "
+                    + "the verbatim realm and then the upper-cased retry")
+                .extracting(e -> e.getRequest().getUrl())
+                .anyMatch(u -> u.contains("bob%40other.realm")
+                    || u.contains("bob@other.realm"));
         }
     }
 }

--- a/acs-service-setup/dumps/service-accounts.yaml
+++ b/acs-service-setup/dumps/service-accounts.yaml
@@ -112,9 +112,20 @@ grants:
   # filters server-side to target=Wildcard before stamping the claim, but
   # the read itself has to be unrestricted because the SPI doesn't know
   # in advance which permission UUIDs are role permissions.
+  #
+  # ManageKerberos (WriteKrb) is what lets the SPI mirror a cross-realm
+  # user: when someone from a realm listed in openid.trustedRealms
+  # authenticates against their home KDC, the SPI PUTs their Kerberos
+  # identity here so they have a principal to be granted against. The
+  # write happens only after the KDC has accepted the password, and
+  # only for explicitly trusted realms - with trustedRealms empty (the
+  # default) the SPI never calls the endpoint. op1krbkeys holds the
+  # same permission for the same reason: creating identities is its
+  # job.
   !u ACS.ServiceAccount.OpenID:
     !u Auth.Perm.ReadKerberos: null
     !u Auth.Perm.ReadACL: null
+    !u Auth.Perm.ManageKerberos: null
 
   # MetaDB permissions are granted via a service role in metadb.yaml.
 

--- a/acs-service-setup/lib/openid.js
+++ b/acs-service-setup/lib/openid.js
@@ -32,6 +32,12 @@ class OpenIDSetup {
         // SPI federation calls this URL for principal/group lookups.
         this.auth_internal_url = (process.env.AUTH_INTERNAL_URL ?? "")
             .replace(/\/+$/, "");
+        // Cross-realm trust, rendered flat by the Helm chart from
+        // values.openid.trustedRealms. Empty means no realm is trusted
+        // and the SPI's cross-realm path stays inert.
+        this.trusted_realms = process.env.OPENID_TRUSTED_REALMS ?? "";
+        this.trusted_realm_auth_urls =
+            process.env.OPENID_TRUSTED_REALM_AUTH_URLS ?? "";
 
         this.token = null;
         this.token_expires_at = 0;
@@ -214,6 +220,22 @@ class OpenIDSetup {
                 // has no @). Inputs that already contain @ pass
                 // through verbatim, preserving cross-realm logins.
                 "default.realm":    [this.kerberos_realm],
+                // Kerberos realms accepted for cross-realm login. A
+                // user from one of these can sign in with no local F+
+                // principal: the SPI writes their identity here once
+                // their home KDC has accepted the password. Empty
+                // (the default) turns the whole path off.
+                "trusted.realms":   [this.trusted_realms],
+                // REALM=url entries naming each trusted realm's own F+
+                // auth service, so the user keeps their home principal
+                // UUID. A trusted realm absent here gets a freshly
+                // minted local UUID and makes no outbound call.
+                "trusted.realm.auth.urls": [this.trusted_realm_auth_urls],
+                // The cross-realm resolve runs in series AFTER the
+                // local lookup misses, so this and auth.timeout.seconds
+                // share Keycloak's 3s hard limit. Don't raise either
+                // one without lowering the other.
+                "trusted.realm.timeout.seconds": ["1.5"],
             },
         };
 

--- a/deploy/templates/service-setup.yaml
+++ b/deploy/templates/service-setup.yaml
@@ -77,6 +77,15 @@ spec:
             # sv1openid via the keytab mounted in the openid pod.
             - name: AUTH_INTERNAL_URL
               value: http://auth.{{ .Release.Namespace }}.svc.cluster.local
+            # Cross-realm Kerberos trust for the SPI federation. Flat
+            # comma-separated encoding because Keycloak component config
+            # is a fixed set of declared keys - per-realm keys can't be
+            # declared by the provider factory. Both default to empty,
+            # which leaves cross-realm login switched off.
+            - name: OPENID_TRUSTED_REALMS
+              value: "{{ range $i, $r := .Values.openid.trustedRealms }}{{ if $i }},{{ end }}{{ $r.realm | required "openid.trustedRealms[].realm is required!" }}{{ end }}"
+            - name: OPENID_TRUSTED_REALM_AUTH_URLS
+              value: "{{ $first := true }}{{ range .Values.openid.trustedRealms }}{{ if .authUrl }}{{ if not $first }},{{ end }}{{ $first = false }}{{ .realm }}={{ .authUrl }}{{ end }}{{ end }}"
 {{- end }}
           volumeMounts:
             - mountPath: /data

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -154,6 +154,28 @@ openid:
   # keycloak.v2 theme, or set to a different name if you've baked a
   # custom theme into your own Keycloak image.
   loginTheme: factory-plus
+  # -- Kerberos realms trusted for cross-realm login. A user from a
+  # listed realm can sign in without an administrator hand-creating a
+  # Factory+ principal for them first: once their home KDC accepts the
+  # password, the SPI writes their Kerberos identity here and they
+  # appear in the ACL editor with no permissions until granted some.
+  #
+  # This requires cross-realm Kerberos trust to already exist - the
+  # realm and its KDC must be listed in krb5.conf on this cluster.
+  # Listing a realm here does not create that trust.
+  #
+  # `authUrl` is optional and names that realm's own Factory+ auth
+  # service. With it, the user keeps the same principal UUID they have
+  # at home, which matters when both clusters grant against the same
+  # identity; that lookup needs sv1openid@<THIS-REALM> to hold ReadKrb
+  # on the home cluster, which is a manual grant there and the
+  # revocation point for the whole trust. Without it, a fresh local
+  # UUID is minted and no outbound call is made.
+  #
+  # Default empty: no realm is trusted and the feature is inert.
+  trustedRealms: []
+  #  - realm: AMRC-FP.SHEF.AC.UK
+  #    authUrl: https://auth.amrc-fp.shef.ac.uk
   image:
     # -- Custom Keycloak image with the Factory+ User Storage SPI baked
     # in (built from acs-keycloak/Dockerfile). To run upstream Keycloak

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -164,18 +164,40 @@ openid:
   # realm and its KDC must be listed in krb5.conf on this cluster.
   # Listing a realm here does not create that trust.
   #
-  # `authUrl` is optional and names that realm's own Factory+ auth
-  # service. With it, the user keeps the same principal UUID they have
-  # at home, which matters when both clusters grant against the same
-  # identity; that lookup needs sv1openid@<THIS-REALM> to hold ReadKrb
-  # on the home cluster, which is a manual grant there and the
-  # revocation point for the whole trust. Without it, a fresh local
-  # UUID is minted and no outbound call is made.
+  # RECOMMENDED: list the realm and nothing else, as shown below. The
+  # user's principal UUID is then derived from their UPN (UUIDv5), which
+  # means every cluster derives the same UUID for the same person with
+  # no coordination, no grant to obtain, no outbound call at login, and
+  # no dependency on the far cluster being reachable. It also lets an
+  # admin pre-grant: compute the UUID and attach permissions before the
+  # user has ever logged in, so their first login works properly instead
+  # of landing with nothing. To compute one:
+  #
+  #   python3 -c "import uuid; print(uuid.uuid5(uuid.UUID(
+  #     'cb3714c4-c85c-482a-987b-408293aa141e'), 'me1ago@AMRC-FP.SHEF.AC.UK'))"
+  #
+  # (Realm in CAPITALS, username as the person types it, usually lower
+  # case. See the SPI README for the exact rule.)
+  #
+  # `authUrl` is the alternative, and only worth it when you specifically
+  # need this cluster to reuse the principal UUID the user already has on
+  # their home cluster. The cost is real: you must get a principal created
+  # for THIS cluster's sv1openid on the home cluster and have it granted
+  # ReadKrb there, which is Wildcard-only and confers blanket read and
+  # enumeration of the home cluster's entire identity table. Logins then
+  # also depend on that cluster being reachable.
+  #
+  # Pick one and stay: this is close to a one-way door. If you start
+  # without an authUrl and add one later, users who already logged in
+  # keep their derived UUID while new users get home-derived ones, split
+  # by when each first signed in. Converging afterwards means re-pointing
+  # identity records by hand.
   #
   # Default empty: no realm is trusted and the feature is inert.
   trustedRealms: []
   #  - realm: AMRC-FP.SHEF.AC.UK
-  #    authUrl: https://auth.amrc-fp.shef.ac.uk
+  #  # - realm: PARTNER.EXAMPLE.ORG
+  #  #   authUrl: https://auth.partner.example.org
   image:
     # -- Custom Keycloak image with the Factory+ User Storage SPI baked
     # in (built from acs-keycloak/Dockerfile). To run upstream Keycloak

--- a/docs/plans/2026-07-27-keycloak-spi-cross-realm-design.md
+++ b/docs/plans/2026-07-27-keycloak-spi-cross-realm-design.md
@@ -1,0 +1,355 @@
+# Design: Cross-realm Kerberos login for the Keycloak SPI
+
+## Problem
+
+A user from a trusted foreign Kerberos realm cannot log in to an ACS
+cluster, even when the Kerberos side is entirely working. Two things
+stop them, and one of them also breaks fully qualified logins for local
+users.
+
+### 1. The realm gets lower-cased and the lookup misses
+
+Keycloak lower-cases the username before it reaches a user storage
+provider. `FPAuthBackedUserStore.applyDefaultRealm` passed anything
+containing an `@` straight through, so a user typing
+`me1ago@AMRC-FP.SHEF.AC.UK` arrived at Factory+ Auth as
+`me1ago@amrc-fp.shef.ac.uk`. Factory+ Auth compares identity names with
+exact string equality (`acs-auth/lib/dataflow.js`, `i.name == upn`), so
+the lookup 410s and Keycloak reports `error="user_not_found"`.
+
+This is not cross-realm specific. Any local user typing their full UPN
+instead of their short name hit it. The short-name path worked only
+because `default.realm` is configured with the correct casing and gets
+appended after Keycloak has finished folding the input.
+
+The comment at `KerberosPasswordValidator.java:37` claimed "same
+realm-uppercase canonicalisation as the user lookup". That was false:
+the validator upper-cased the realm, the lookup did not.
+
+### 2. There is no principal to find
+
+Cross-realm Kerberos trust is a KDC-level fact. Adding a realm and its
+KDC to `krb5.conf` lets the AS-REQ route to the foreign KDC, and lets
+this cluster obtain service tickets in that realm. It provisions nothing
+in Factory+. A foreign user has no principal here, so even a correctly
+cased lookup finds nothing, and the login fails before the password is
+ever tested.
+
+The rest of the Kerberos machinery already works. `KerberosPasswordValidator`
+builds a `Krb5LoginModule` login with `refreshKrb5Config=true` and no
+hardcoded KDC, so the AS-REQ routes by the realm in the principal name.
+`JaasKerberosAuthenticator.spnegoTokenFor` derives the service principal
+from the target URI's host, so it can obtain a ticket for an HTTP
+service in another realm. Neither needed changing.
+
+## Solution
+
+### Realm casing: try verbatim, then retry with the realm upper-cased
+
+`findByUsername` now builds a candidate list instead of a single name:
+
+1. The result of `applyDefaultRealm(username)`, exactly as before. Short
+   names still get `@<default.realm>` appended with its configured
+   casing.
+2. The same string with only the portion after the **last** `@`
+   upper-cased. Skipped when identical to the first.
+
+Each candidate goes through the existing `fetchUuidByIdentity` +
+`fetchPrincipal` chain, in order. First hit wins, and a hit on the first
+candidate costs no extra request.
+
+Retry rather than unconditional upper-casing is deliberate. Uppercase
+Kerberos realms are convention, not a rule, and a deployment whose realm
+genuinely is lower case must keep working - that was the concern behind
+the original pass-through-verbatim comment. Trying the verbatim form
+first preserves that behaviour exactly.
+
+**Known limitation:** only the realm portion is touched. An F+ identity
+stored with capitals in the *user* portion (`Me1ago@REALM`) will still
+not match, because Keycloak has already folded the case and the original
+is unrecoverable. Store user portions in lower case.
+
+### Trusted realms
+
+Three new config properties on the federation component, alongside
+`auth.url`, `default.realm` and the rest:
+
+| Key | Meaning |
+|---|---|
+| `trusted.realms` | Comma-separated realm names. Empty or absent means no cross-realm support. This is the default, so the feature is inert until opted into. |
+| `trusted.realm.auth.urls` | Comma-separated `REALM=https://auth.example.org` entries. A realm listed in `trusted.realms` with no entry here takes the mint-fresh path. |
+| `trusted.realm.timeout.seconds` | Default `1.5`. See the timeout constraint below. |
+
+The flat `REALM=url` encoding exists because Keycloak's component config
+is a `Map<String, List<String>>` whose keys must all be declared in
+`getConfigProperties()`. Dynamic per-realm keys are not expressible.
+
+Realm matching is case-insensitive on both sides: the incoming realm has
+been lower-cased by Keycloak, and the configured value may be typed
+either way.
+
+### Resolution when both casing candidates miss
+
+Only when the local lookup has missed on every candidate **and** the
+realm portion is in `trusted.realms`:
+
+- **Realm has an auth URL.** Resolve the principal UUID from that
+  realm's own Factory+ Auth service. `FPAuthBackedUserStore` is reused
+  as its own remote client - it already performs exactly the two GETs
+  and the SPNEGO authentication needed - constructed pointing at the
+  remote base URL with the same `KerberosAuthenticator` and a null
+  default realm. These remote stores are built once at construction,
+  keyed by upper-cased realm, not per request. On success we return a
+  **provisional** user carrying the home cluster's UUID and its own
+  spelling of the UPN.
+- **Realm has no auth URL.** Return a provisional user with a locally
+  minted UUID. No outbound call on this path at all.
+- **Realm not trusted.** Return empty, exactly as before this feature
+  existed.
+
+Nothing is written anywhere during lookup. Lookup runs before the
+password is checked, so it runs for unauthenticated callers.
+
+### Provisional users and the write-after-authentication
+
+`FactoryPlusUser` gained a `provisional` flag. `FactoryPlusUserStore`
+gained one write:
+
+```java
+String admit(String upn, String uuid);
+```
+
+It `PUT`s the UPN (as a JSON string, since acs-auth parses bodies with
+`express.json({strict: false})`) to `/v2/principal/{uuid}/kerberos` -
+an existing endpoint guarded server-side by `WriteKrb` on that UUID
+target - and returns the UUID used. The store already authenticates with
+SPNEGO as `sv1openid`, so no new client was needed.
+
+`FactoryPlusUserStorageProvider.isValid` calls it **after**
+`passwordValidator.validate(...)` returns true, and only then. If
+`admit` fails the login is rejected and the failure logged. Issuing a
+session whose identity could not be persisted would hand out a token
+carrying an `fp_principal_uuid` that nothing on the cluster recognises:
+every F+ service would reject it and the user would see a working login
+with no access and no explanation.
+
+The provider detects provisional users by `instanceof` where possible,
+falling back to an `fp_provisional` user attribute. The attribute exists
+because by credential-validation time we may be behind one of Keycloak's
+own `UserModel` wrappers, which is the same reason `fp_principal_uuid`
+is exposed as an attribute. No protocol mapper reads `fp_provisional`,
+so it never reaches a token.
+
+`CachingFactoryPlusUserStore.admit` delegates and then invalidates. This
+is load-bearing, not hygiene: the lookup that produced the provisional
+user cached it under whatever string Keycloak passed in, typically a
+lower-cased short name rather than the canonical UPN we admit under.
+Leaving it would keep reporting the user as provisional for the full 60s
+TTL, and any negatively cached miss would keep masking the principal we
+just created. Invalidation therefore matches on the cached *value*
+(username case-insensitively, or UUID) as well as the exact key.
+
+### Deviation from the brief: provisional users carry a UUID from lookup
+
+The approved design said the mint-fresh path should return a provisional
+user with a **null** UUID, minted inside `admit`. It is implemented with
+the UUID minted at lookup time instead.
+
+`FactoryPlusUserAdapter` derives Keycloak's federated storage id from
+the F+ UUID. Keycloak re-reads the user by that id later in the same
+login flow, which routes to `findByUuid`. A null UUID produces the
+storage id `f:<component>:null`, so the re-read fails - after `admit`
+has already written. The login would break at a point where the write
+had succeeded.
+
+Minting early is safe: the UUID is not persisted anywhere until the KDC
+has confirmed the password. An unauthenticated caller can make us
+generate throwaway UUIDs, which costs nothing. `admit` still accepts a
+null UUID and mints one, so the interface matches the brief; the null
+branch is defensive only.
+
+### Error handling
+
+| Situation | Behaviour |
+|---|---|
+| Remote resolve times out or 5xxs | Throws `FactoryPlusAuthException`. Keycloak fails the login rather than reporting `user_not_found`. "The home cluster is unreachable" and "no such user" are different answers and must not collapse into one. |
+| Remote resolve returns 410 or 404 | The user genuinely does not exist at home. Empty result, negatively cached, login rejected. |
+| Remote resolve returns 403 | The home cluster has not granted us `ReadKrb`. Fatal to the login, with an actionable message, and briefly cached. See below. |
+| `admit` write fails | Login rejected, failure logged. |
+| Realm trusted with no auth URL | Mint fresh. No outbound dependency. |
+
+### Timeout constraint
+
+This is the sharpest edge in the design.
+
+Keycloak hard-limits user storage lookups to 3 seconds
+(`ServicesUtils.timeBoundOne`). Exceeding it surfaces as an opaque
+`InterruptedException`, not a clean timeout naming the service that was
+slow. `acs-service-setup/lib/openid.js` already documents this on
+`auth.timeout.seconds`, currently 2s.
+
+The cross-realm resolve happens **in series** after the local miss, so
+local + remote share that one budget. Hence the 1.5s default on
+`trusted.realm.timeout.seconds`. 2 + 1.5 already overshoots slightly in
+the absolute worst case, and anything larger reliably trips the limit.
+
+**Neither value may be raised without lowering the other.** Comments to
+that effect sit on both, in the SPI factory and in `openid.js`.
+
+## Security posture
+
+Auto-mirror is the approved behaviour: any valid credential in a trusted
+realm yields a session, with zero permissions until an admin grants
+some. What keeps it bounded:
+
+- Only explicitly configured realms are ever resolved, and the default
+  config trusts nothing.
+- Nothing is written before the KDC confirms the password. This ordering
+  is tested explicitly in `FactoryPlusUserStorageProviderTest`.
+- Negative caching bounds how hard an unauthenticated caller can make us
+  hammer a remote cluster. All the new paths go through
+  `CachingFactoryPlusUserStore`.
+- Revocation is the `ReadKrb` grant on the home cluster (see below).
+
+Residual risk accepted: auth-DB growth from principals who log in once
+and are never granted anything. No reaper is planned.
+
+## Deployment
+
+`deploy/values.yaml`, under `openid`:
+
+```yaml
+openid:
+  trustedRealms: []
+  #  - realm: AMRC-FP.SHEF.AC.UK
+  #    authUrl: https://auth.amrc-fp.shef.ac.uk
+```
+
+The chart renders this flat into `OPENID_TRUSTED_REALMS` and
+`OPENID_TRUSTED_REALM_AUTH_URLS` on the service-setup job;
+`ensure_factoryplus_federation` maps them onto the component config keys
+following the existing idempotent update pattern.
+
+`sv1openid` gains `Auth.Perm.ManageKerberos` (`WriteKrb`,
+`327c4cc8-9c46-4e1e-bb6b-257ace37b0f6`) on Wildcard, in
+`acs-service-setup/dumps/service-accounts.yaml` alongside its existing
+`ReadKerberos` and `ReadACL` grants. `op1krbkeys` already holds the same
+permission for the same reason: creating identities is its job.
+
+(The brief pointed at `deploy/templates/auth/principals/service-clients.yaml`
+for this grant. That file declares `KerberosKey` CRs, not permission
+grants; the grants for `sv1openid` live in the service-accounts dump.)
+
+## Manual steps this does not automate
+
+### On the home cluster: `ReadKrb` for the consuming cluster
+
+Only needed for realms configured with an `authUrl`. The consuming
+cluster's `sv1openid@<CONSUMING-REALM>` must hold `ReadKrb`
+(`e8c9c0f7-0d54-4db2-b8d6-cd80c45f6a5c`) on the **home** cluster.
+
+Understand what this grant is before making it. `ReadKrb` is **not**
+scopeable to individual principals. It can only be granted on Wildcard,
+and acs-auth repurposes it as a blanket "read any identity" capability.
+The comment at `acs-auth/lib/dataflow.js:273` states it directly:
+
+```
+/* ReadKrb is repurposed here as 'read any identity'. This is
+ * now a blanket permission which can only be granted on
+ * Wildcard. It permits reading all identity records, and
+ * listing all identities. */
+```
+
+So the grant is not "let the consuming cluster look up the users who log
+in there". It is "let the consuming cluster's Keycloak read and
+enumerate **every identity record in the home cluster's auth service**",
+as a standing capability, independent of who actually logs in and
+whether anyone ever does.
+
+This grant is also the revocation point for the whole trust
+relationship: remove it and the consuming cluster can no longer resolve
+home principals.
+
+#### What happens when the grant is missing
+
+The home cluster returns 403 and the login **fails**. It does not fall
+back to minting a fresh local UUID. That fallback was considered and
+rejected: it would defeat revocation (removing the grant would silently
+degrade to minting rather than stopping anything) and would split the
+estate into home-derived and locally-minted principals depending on when
+each user happened to first log in.
+
+This is the most likely setup mistake in the feature, and the fix lives
+on a different cluster from the error, so the message names the missing
+permission and its UUID, the SPI principal that was denied, and the
+remote cluster that denied it. It also points at the mint-fresh escape
+hatch below.
+
+The denial is cached for 30 seconds, keyed by realm.
+`CachingFactoryPlusUserStore` deliberately never caches exceptions, so
+that a transient F+ blip cannot lock out lookups for a full TTL; that
+reasoning is correct for 5xx and timeouts and is unchanged. A 403 is
+different in kind - it is a standing configuration state, not a fault -
+and lookup runs *before* password validation, so while misconfigured
+anyone who can reach the login page could bounce one call off the remote
+cluster per attempt just by typing foreign usernames. The denial cache
+suppresses the outbound call without softening the failure: the login
+still fails, with the same message.
+
+### The alternative: mint-fresh, which needs no grant at all
+
+Listing a realm in `trusted.realms` with **no** entry in
+`trusted.realm.auth.urls` is a fully supported configuration, not a
+degraded fallback. On that path the consuming cluster:
+
+- makes no outbound call to the home cluster whatsoever,
+- needs no permission of any kind on the home cluster,
+- mints a fresh local principal UUID for the user on first successful
+  login.
+
+The cost is that the user's principal UUID is not shared across
+clusters: they are the same person to a human reading the ACL editor
+(same UPN) but a different UUID to each cluster's auth service, so
+grants do not correlate between them.
+
+If you are unwilling to grant blanket identity read across a cluster
+boundary - which is a reasonable position - this is the configuration to
+use.
+
+### Cross-realm Kerberos trust itself
+
+`krb5.conf` on the consuming cluster must list the foreign realm and its
+KDC, and the two KDCs must share the cross-realm trust principals. None
+of that is in scope for the chart.
+
+## Follow-up
+
+The mirrored principal gets no ConfigDB `Principal` object and no `Info`
+name. Creating one would mean giving the SPI a ConfigDB client it does
+not currently have, which is a larger change than this warrants. The
+consequence is cosmetic: the principal appears in the ACL editor by its
+UPN rather than a friendly name, which is sufficient to grant against.
+Worth revisiting if cross-realm users become common.
+
+## Testing
+
+Unit tests cover the store (casing candidates, all five cross-realm
+outcomes, the exception-not-empty distinction on remote failure,
+`admit`'s wire format and failure modes), the cache (invalidation under
+both the canonical and the Keycloak-supplied key), the factory's config
+parsing, and the provider's admit ordering.
+
+`FactoryPlusFederationIT` covers the provisional path against a real
+Keycloak container. A second KDC is deliberately not stood up: the
+cross-realm AS-REQ stays a manual verification, since the KDC side is
+stock Kerberos and the cost of harnessing it far exceeds what it would
+prove.
+
+Manual verification, on a cluster with the trust already configured:
+
+1. Set `openid.trustedRealms` and upgrade.
+2. Log in to Keycloak as `user@FOREIGN.REALM`.
+3. The login succeeds, and the user appears in the F+ ACL editor by
+   their UPN with no permissions.
+4. Grant them something in F+; it appears in `fp_permissions` on the
+   next login (within the SPI's 60s cache TTL).

--- a/docs/plans/2026-07-27-keycloak-spi-cross-realm-design.md
+++ b/docs/plans/2026-07-27-keycloak-spi-cross-realm-design.md
@@ -93,6 +93,9 @@ either way.
 Only when the local lookup has missed on every candidate **and** the
 realm portion is in `trusted.realms`:
 
+- **Realm has no auth URL (the recommended mode).** Return a provisional
+  user whose UUID is *derived* from the UPN. No outbound call on this
+  path at all. See "Derived principal UUIDs" below.
 - **Realm has an auth URL.** Resolve the principal UUID from that
   realm's own Factory+ Auth service. `FPAuthBackedUserStore` is reused
   as its own remote client - it already performs exactly the two GETs
@@ -101,9 +104,8 @@ realm portion is in `trusted.realms`:
   default realm. These remote stores are built once at construction,
   keyed by upper-cased realm, not per request. On success we return a
   **provisional** user carrying the home cluster's UUID and its own
-  spelling of the UPN.
-- **Realm has no auth URL.** Return a provisional user with a locally
-  minted UUID. No outbound call on this path at all.
+  spelling of the UPN. This UUID is adopted verbatim; nothing is derived
+  on this path.
 - **Realm not trusted.** Return empty, exactly as before this feature
   existed.
 
@@ -148,6 +150,79 @@ Leaving it would keep reporting the user as provisional for the full 60s
 TTL, and any negatively cached miss would keep masking the principal we
 just created. Invalidation therefore matches on the cached *value*
 (username case-insensitively, or UUID) as well as the exact key.
+
+### Derived principal UUIDs (the mint path)
+
+On the mint path the UUID is not random. It is a **UUIDv5** - the RFC
+4122 name-based, SHA-1 variant - derived from a fixed namespace and the
+user's canonicalised UPN.
+
+Two properties fall out of this that random minting cannot give:
+
+1. **Every cluster agrees.** Compass, Wales, and anything stood up in
+   five years' time all independently derive the same UUID for
+   `me1ago@AMRC-FP.SHEF.AC.UK`, with no coordination and no outbound
+   calls. The far cluster does not even have to exist.
+2. **Admins can pre-grant.** The UUID can be computed and permissions
+   attached *before* the user's first login, so they land with the
+   access they need. With random minting, first login always lands with
+   zero permissions and someone has to go and fix it afterwards. This
+   is the main reason for the change.
+
+#### The namespace
+
+```
+cb3714c4-c85c-482a-987b-408293aa141e
+```
+
+Randomly generated once, on 2026-07-27, and **fixed forever after**.
+Changing it silently orphans every principal ever minted from it: the
+same user would resolve to a different UUID, their existing grants would
+attach to a principal nothing looks up any more, and there is no
+migration short of re-pointing every identity record by hand. It is
+pinned by a unit test for that reason.
+
+#### The name input, exactly
+
+The name hashed is the **canonicalised UPN** - byte for byte the same
+string written into the F+ identity record:
+
+- **Realm portion: upper-cased.**
+- **User portion: exactly as received from Keycloak**, which in practice
+  means lower-cased, because Keycloak folds the whole username before
+  any provider sees it.
+- Encoded UTF-8. No trailing whitespace, no other transformation.
+
+So a user typing `Me1ago@amrc-fp.shef.ac.uk` is hashed as
+`me1ago@AMRC-FP.SHEF.AC.UK`.
+
+**Nothing local feeds into the input.** Not the default realm, not the
+auth URL, not the cluster name. That is deliberate and load bearing: if
+the input varied with local configuration, two clusters would derive
+different UUIDs and the entire property would be lost.
+
+#### Computing one by hand
+
+To pre-grant, or to check what the cluster will derive:
+
+```sh
+python3 -c "import uuid; print(uuid.uuid5(uuid.UUID(
+  'cb3714c4-c85c-482a-987b-408293aa141e'), 'me1ago@AMRC-FP.SHEF.AC.UK'))"
+```
+
+```
+12bb7b35-16c8-572d-af5f-c1f312ec4ae8
+```
+
+That exact pair is pinned as a known-answer test in
+`FPAuthBackedUserStoreTest`, so the implementation cannot drift from
+what this command produces.
+
+Implementation note: the JDK ships no v5 generator, and
+`UUID.nameUUIDFromBytes` is **not** a substitute - it is MD5 and stamps
+version 3. `uuidV5` does SHA-1 over the namespace's 16 raw bytes
+followed by the UTF-8 name bytes, then sets the version nibble to 5 and
+the RFC 4122 variant bits.
 
 ### Deviation from the brief: provisional users carry a UUID from lookup
 
@@ -222,7 +297,8 @@ and are never granted anything. No reaper is planned.
 openid:
   trustedRealms: []
   #  - realm: AMRC-FP.SHEF.AC.UK
-  #    authUrl: https://auth.amrc-fp.shef.ac.uk
+  #  # - realm: PARTNER.EXAMPLE.ORG
+  #  #   authUrl: https://auth.partner.example.org
 ```
 
 The chart renders this flat into `OPENID_TRUSTED_REALMS` and
@@ -240,13 +316,62 @@ permission for the same reason: creating identities is its job.
 for this grant. That file declares `KerberosKey` CRs, not permission
 grants; the grants for `sv1openid` live in the service-accounts dump.)
 
+## Choosing a mode
+
+### Recommended: no `authUrl`, derived UUIDs
+
+List the realm and nothing else. This is the default recommendation:
+
+- Nothing to create or grant on the home cluster. No coordination with
+  whoever runs it.
+- No outbound call at login, so no dependency on the home cluster being
+  up, reachable, or still existing.
+- Every cluster derives the same UUID for the same person anyway, via
+  the UUIDv5 scheme above, so identity is consistent across the estate
+  without the far cluster being involved at all.
+- Admins can pre-grant before first login.
+
+The thing you give up is reusing the UUID the user already has *on their
+home cluster*. Their derived UUID is consistent everywhere else, but it
+is not the home cluster's one, so grants made on the home cluster do not
+follow them.
+
+### The alternative: `authUrl`, home-derived UUIDs
+
+Take this only when you specifically need this cluster to reuse the
+principal UUID the user already has at home - typically because the two
+clusters are administered together and grants are expected to correlate.
+
+The cost is not just configuration:
+
+- Someone must create a principal for **this** cluster's
+  `sv1openid@<CONSUMING-REALM>` on the **home** cluster.
+- That principal must be granted `ReadKrb`
+  (`e8c9c0f7-0d54-4db2-b8d6-cd80c45f6a5c`) there, with the scope
+  consequences below.
+- Logins from that realm now depend on the home cluster being reachable
+  within the timeout budget.
+
+### Pick one and stay: this is close to a one-way door
+
+Switching modes later does not migrate anyone. If you start without an
+`authUrl` and add one afterwards, users who have already logged in keep
+their derived UUID while users logging in for the first time get
+home-derived ones. The estate ends up split by *when each person first
+signed in*, which is invisible until someone's permissions do not behave
+as expected.
+
+Converging afterwards means re-pointing identity records by hand. The
+same applies in reverse. Decide before the first login, not after.
+
 ## Manual steps this does not automate
 
 ### On the home cluster: `ReadKrb` for the consuming cluster
 
 Only needed for realms configured with an `authUrl`. The consuming
-cluster's `sv1openid@<CONSUMING-REALM>` must hold `ReadKrb`
-(`e8c9c0f7-0d54-4db2-b8d6-cd80c45f6a5c`) on the **home** cluster.
+cluster's `sv1openid@<CONSUMING-REALM>` must exist as a principal on the
+**home** cluster and hold `ReadKrb`
+(`e8c9c0f7-0d54-4db2-b8d6-cd80c45f6a5c`) there.
 
 Understand what this grant is before making it. `ReadKrb` is **not**
 scopeable to individual principals. It can only be granted on Wildcard,
@@ -282,8 +407,8 @@ each user happened to first log in.
 This is the most likely setup mistake in the feature, and the fix lives
 on a different cluster from the error, so the message names the missing
 permission and its UUID, the SPI principal that was denied, and the
-remote cluster that denied it. It also points at the mint-fresh escape
-hatch below.
+remote cluster that denied it. It also points at dropping the `authUrl`
+as the alternative.
 
 The denial is cached for 30 seconds, keyed by realm.
 `CachingFactoryPlusUserStore` deliberately never caches exceptions, so
@@ -295,26 +420,6 @@ anyone who can reach the login page could bounce one call off the remote
 cluster per attempt just by typing foreign usernames. The denial cache
 suppresses the outbound call without softening the failure: the login
 still fails, with the same message.
-
-### The alternative: mint-fresh, which needs no grant at all
-
-Listing a realm in `trusted.realms` with **no** entry in
-`trusted.realm.auth.urls` is a fully supported configuration, not a
-degraded fallback. On that path the consuming cluster:
-
-- makes no outbound call to the home cluster whatsoever,
-- needs no permission of any kind on the home cluster,
-- mints a fresh local principal UUID for the user on first successful
-  login.
-
-The cost is that the user's principal UUID is not shared across
-clusters: they are the same person to a human reading the ACL editor
-(same UPN) but a different UUID to each cluster's auth service, so
-grants do not correlate between them.
-
-If you are unwilling to grant blanket identity read across a cluster
-boundary - which is a reasonable position - this is the configuration to
-use.
 
 ### Cross-realm Kerberos trust itself
 


### PR DESCRIPTION
## What this does

Lets a user from a trusted foreign Kerberos realm log in to a cluster
that has no Factory+ principal for them, without an admin hand-creating
one first. Also fixes a casing bug that broke fully qualified logins for
local users.

### The casing bug (stands alone)

Keycloak lower-cases the username before it reaches a user storage
provider, so signing in as `me1ago@AMRC-FP.SHEF.AC.UK` arrived at
Factory+ Auth as `me1ago@amrc-fp.shef.ac.uk`. F+ Auth compares identity
names with exact string equality, so the lookup 410d and Keycloak
reported `user_not_found`. Any local user typing their full UPN instead
of their short name hit this.

The lookup now tries the verbatim form first, then retries with the
realm portion upper-cased. Retry rather than unconditional upper-casing,
so a deployment whose realm genuinely is lower case keeps working and
pays no extra request.

Known limitation: only the realm is touched. An identity stored with
capitals in the *user* portion cannot be matched, because Keycloak has
already folded the case by the time we see it.

### Cross-realm login

With `openid.trustedRealms` set, a user from a listed realm can sign in
with no local principal. When every casing candidate misses locally and
the realm is explicitly trusted, the lookup returns a *provisional*
user; the provider writes their Kerberos identity via the existing
`PUT /v2/principal/{uuid}/kerberos`, and only after the KDC has accepted
the password. They appear in the ACL editor by their UPN with zero
permissions until an admin grants some.

Default config trusts nothing, so the whole path is inert until opted
into. Two modes per realm:

- **Recommended: no `authUrl`.** The principal UUID is derived from the
  UPN as a UUIDv5, so every cluster independently derives the same UUID
  for the same person. No grant to obtain, no outbound call at login, no
  dependency on the home cluster existing.
- **With an `authUrl`** the principal UUID is resolved from that realm's
  own F+ Auth, so the user keeps that cluster's identity here. Needs a
  principal created for our `sv1openid` on the home cluster and a
  `ReadKrb` grant there.

### Derived UUIDs, and why they matter

The mint path uses UUIDv5 (RFC 4122 name-based, SHA-1) over a fixed
namespace and the canonicalised UPN, rather than a random UUID. That
buys two things:

1. **Every cluster agrees**, with no coordination and no outbound calls.
2. **Admins can pre-grant.** Compute the UUID and attach permissions
   before the user's first login, so it lands with the access they need
   instead of with nothing. This is the main reason for it.

Namespace: `cb3714c4-c85c-482a-987b-408293aa141e`, fixed forever -
changing it orphans every principal ever derived from it, so it is
pinned by a test.

Name input: the canonicalised UPN, i.e. realm upper-cased, user portion
exactly as received from Keycloak (lower-cased, since Keycloak folds it).
Nothing local feeds in - that is what makes clusters agree.

To compute one by hand:

```sh
python3 -c "import uuid; print(uuid.uuid5(uuid.UUID(
  'cb3714c4-c85c-482a-987b-408293aa141e'), 'me1ago@AMRC-FP.SHEF.AC.UK'))"
# 12bb7b35-16c8-572d-af5f-c1f312ec4ae8
```

That exact pair is a known-answer test, so the code cannot drift from
what the command produces. Implemented by hand: the JDK has no v5
generator and `UUID.nameUUIDFromBytes` is MD5/v3, not a substitute.

### Pick a mode and stay: close to a one-way door

Adding an `authUrl` to a realm that has been running without one does
not migrate anyone. Users who already logged in keep their derived UUID
while first-time users get home-derived ones, splitting the estate by
when each person first signed in. Converging afterwards means
re-pointing identity records by hand.

### The `ReadKrb` grant, stated plainly

`ReadKrb` cannot be scoped to individual principals. It is Wildcard-only
and acs-auth treats it as blanket "read any identity"
(`acs-auth/lib/dataflow.js:273`). Granting it to a consuming cluster's
`sv1openid` lets that cluster's Keycloak read and enumerate **every
identity record in the home cluster's auth service**, as a standing
capability, regardless of who logs in or whether anyone ever does. It is
also the revocation point for the whole trust relationship.

The no-`authUrl` mode is now the documented recommendation, not a
fallback. The cost is only that you do not reuse the home cluster's
particular UUID; the derived one is consistent everywhere else.

If the grant is missing the home cluster returns 403 and the login
fails. It deliberately does **not** fall back to minting - that would
defeat revocation and split the estate into home-derived and
locally-minted principals depending on when each user first logged in.

## Decisions worth flagging

- **Provisional users carry a UUID from lookup, not from `admit`.** The
  brief specified a null UUID minted inside `admit`. Keycloak derives
  the federated storage id from the UUID and re-reads the user by that
  id later in the same login flow, so a null would break the flow
  *after* `admit` had already written. Minting early is safe: nothing is
  persisted until the KDC confirms the password. `admit` still accepts
  null and mints, so the interface matches the brief.

- **403 gets its own exception type, an actionable message and a 30s
  denial cache.** The fix lives on a different cluster from the error,
  so the message names the permission and its UUID, the denied
  principal, and the cluster that denied it. Lookup runs *before*
  password validation, so a standing misconfiguration would otherwise
  cost one remote call per login attempt from anyone who can reach the
  login page. 5xx and timeouts stay uncached, since those are transient.

- **The `WriteKrb` grant went in the service-accounts dump, not
  `service-clients.yaml`.** The brief pointed at
  `deploy/templates/auth/principals/service-clients.yaml`, but that file
  declares `KerberosKey` CRs; `sv1openid`'s permission grants live in
  `acs-service-setup/dumps/service-accounts.yaml`.

- **`JaasKerberosAuthenticator.spnegoTokenFor` already derived the
  service principal from the target URI's host**, so no fix was needed
  there. It gained a `principalName()` accessor purely for the 403
  diagnostic.

- **Timeouts share one budget.** The remote resolve runs in series after
  the local miss, so its 1.5s default and `auth.timeout.seconds` (2s)
  both come out of Keycloak's 3-second hard limit on storage lookups.
  Neither may be raised without lowering the other; comments on both say
  so.

## How to test

### Automated

1. `cd acs-keycloak-spi && mvn -B test` - 123 unit tests, all passing.
2. `mvn -B verify` for the Testcontainers ITs. **These did not run in
   this environment** (Testcontainers could not detect the OrbStack
   socket, so all 4 auto-skipped). They need verifying on CI or a
   machine with a detectable Docker daemon.
3. `helm lint deploy` and `helm template` with and without
   `openid.trustedRealms` set - both render correctly (empty default
   produces `value: ""`).

### The casing fix, on a live cluster

1. Deploy and log in to Keycloak with your full UPN, e.g.
   `me1ago@FACTORYPLUS.LOCAL`, rather than the short name.
2. Before this change: "invalid username or password", with
   `error="user_not_found"` in the Keycloak log. After: the login
   succeeds.

### Derived UUIDs

Confirm the documented command agrees with the code:

```sh
python3 -c "import uuid; print(uuid.uuid5(uuid.UUID(
  'cb3714c4-c85c-482a-987b-408293aa141e'), 'me1ago@AMRC-FP.SHEF.AC.UK'))"
```

Expect `12bb7b35-16c8-572d-af5f-c1f312ec4ae8`, matching the known-answer
test in `FPAuthBackedUserStoreTest`.

### Cross-realm, recommended mode (no home-cluster grant needed)

1. Confirm the foreign realm and its KDC are in `krb5.conf` on this
   cluster and that the trust works.
2. Set, in values.yaml:
   ```yaml
   openid:
     trustedRealms:
       - realm: PARTNER.EXAMPLE.ORG
   ```
3. Upgrade. Log in as `someone@PARTNER.EXAMPLE.ORG`.
4. Expect: login succeeds. The user appears in the F+ ACL editor by
   their UPN with no permissions, under the UUID the command above
   predicts.
4b. Pre-granting: compute a UUID for a user who has NOT yet logged in,
   grant it a permission, then log in as them. Expect the permission to
   be present on first login.
5. Grant them something in F+; it appears in `fp_permissions` on the
   next login, within the SPI's 60s cache TTL.
6. Log in with a wrong password and confirm no principal is created.

### Cross-realm, shared-UUID mode

7. Add `authUrl: https://auth.partner.example.org` to that entry and
   upgrade.
8. Without the `ReadKrb` grant on the home cluster, expect the login to
   fail and the Keycloak log to name `ReadKrb`, its UUID, the denied
   `sv1openid@<THIS-REALM>`, and the remote cluster.
9. Make the grant on the home cluster, wait out the 30s denial cache,
   and log in again. Expect success, with the principal UUID matching
   the one the user has at home.

## Release notes

**Cross-realm Kerberos login for Keycloak.** Users from a trusted
foreign Kerberos realm can now sign in without an administrator creating
a Factory+ principal for them first. Set `openid.trustedRealms` in
values.yaml to opt in; it is empty by default and the feature is
disabled until configured. Requires cross-realm Kerberos trust to
already exist in `krb5.conf`.

Listing just the realm name is the recommended configuration. Each
user's Factory+ principal UUID is then derived from their username, so
every cluster arrives at the same UUID for the same person without any
coordination, and administrators can grant permissions ahead of a user's
first login. The SPI README documents the one-line command for computing
a UUID.

A realm can optionally be given an `authUrl` so users reuse the
principal UUID from their home cluster instead. That mode requires a
principal to be created there for this cluster and granted `ReadKrb` -
which cannot be narrowed to specific users and confers blanket read of
the home cluster's entire identity table - and makes logins depend on
that cluster being reachable. Choose one mode before the first login
from a realm: switching later leaves users split between the two schemes
depending on when they first signed in.

**Fixed: logins with a fully qualified username failed.** Signing in as
`user@REALM` rather than just `user` was rejected with "invalid username
or password", because Keycloak lower-cased the realm before the
Factory+ lookup. Short-name logins were unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
