### PR TITLE
Mark which schemas a device can be built on directly

### DIFF
--- a/acs-admin/preview/fixtures.js
+++ b/acs-admin/preview/fixtures.js
@@ -10,10 +10,17 @@ import library from '../test/fixtures/library-schemas.json'
 
 const uuidOf = body => body.properties?.Schema_UUID?.const
 
+const markedBody = (path) => {
+  const body = library[path]
+  if (TOP_LEVEL.has(path)) return { ...body, topLevel: true }
+  if (COMPONENT.has(path)) return { ...body, topLevel: false }
+  return body
+}
+
 const libraryEntry = (path, name) => ({
   uuid: uuidOf(library[path]),
   name,
-  schema: library[path],
+  schema: markedBody(path),
   schemaInformation: {
     name,
     version: 1,
@@ -22,6 +29,16 @@ const libraryEntry = (path, name) => ({
     modified: 1700000000,
   },
 })
+
+/* A few marked either way, so the preview can show the picker's
+ * top-level filter. The real marks land in the acs-schemas repo. */
+const TOP_LEVEL = new Set([
+  'CNC/CNC-v1.yaml', 'Robot/Robot-v1.yaml', 'Press/Press-v1.yaml',
+])
+const COMPONENT = new Set([
+  'CNC/Spindle-v1.yaml', 'CNC/Axis-v1.yaml', 'CNC/Channel-v1.yaml',
+  'Common/Metric-v1.yaml', 'Common/Device_Information-v1.yaml',
+])
 
 const CNC = libraryEntry('CNC/CNC-v1.yaml', 'CNC Machine')
 const SPINDLE = libraryEntry('CNC/Spindle-v1.yaml', 'CNC Spindle')

--- a/acs-admin/src/components/Schemas/SchemaPanel.vue
+++ b/acs-admin/src/components/Schemas/SchemaPanel.vue
@@ -1,0 +1,97 @@
+<!--
+  - Copyright (c) University of Sheffield AMRC 2026.
+  -->
+
+<!--
+  - The schema itself, shown when nothing in the tree is selected.
+  -
+  - Settings that belong to the whole schema rather than to one node had
+  - nowhere to live, and the detail pane was otherwise an empty state
+  - telling you to go and click something.
+  -->
+
+<template>
+  <div class="flex max-w-2xl flex-col gap-5">
+    <div class="flex flex-col gap-1.5">
+      <label class="text-sm font-medium leading-none">Name</label>
+      <Input :model-value="name" :disabled="readonly"
+          @update:model-value="v => $emit('update:name', v)"/>
+      <p class="text-xs text-gray-500">
+        What this schema describes, for example CNC Machine or Robot Arm.
+      </p>
+    </div>
+
+    <div class="flex items-start justify-between gap-6 rounded-md border
+                border-slate-200 p-4">
+      <div>
+        <div class="text-sm font-medium">A device can use this directly</div>
+        <p class="mt-1 text-xs leading-relaxed text-gray-500">
+          Machines are built on a top-level schema. Parts of a machine, like an
+          axis or a spindle, are used inside another schema instead and are
+          hidden when choosing a schema for a device.
+        </p>
+      </div>
+      <Switch class="mt-0.5 shrink-0" :model-value="topLevel" :disabled="readonly"
+          @update:model-value="v => $emit('update:topLevel', v)"/>
+    </div>
+
+    <div class="flex flex-col gap-2 rounded-md border border-slate-200 p-4">
+      <div class="flex items-center justify-between gap-4">
+        <span class="text-xs text-gray-500">Schema UUID</span>
+        <span class="truncate font-mono text-xs">{{ uuid }}</span>
+      </div>
+      <div class="flex items-center justify-between gap-4">
+        <span class="text-xs text-gray-500">Contents</span>
+        <span class="text-xs">{{ summary }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { Input } from '@components/ui/input'
+import { Switch } from '@components/ui/switch'
+
+import { NodeKind } from '@/lib/schema/constants.js'
+
+export default {
+  name: 'SchemaPanel',
+
+  components: { Input, Switch },
+
+  props: {
+    name: { type: String, default: '' },
+    uuid: { type: String, default: '' },
+    /* Undefined when the schema says nothing about it. The switch shows
+     * that as off, and touching it writes an explicit answer. */
+    topLevel: { type: Boolean, default: false },
+    doc: { type: Object, default: null },
+    readonly: { type: Boolean, default: false },
+  },
+
+  emits: ['update:name', 'update:topLevel'],
+
+  computed: {
+    summary () {
+      const counts = {}
+      const walk = (children) => {
+        for (const child of children ?? []) {
+          counts[child.kind] = (counts[child.kind] ?? 0) + 1
+          if (child.kind === NodeKind.GROUP) walk(child.children)
+        }
+      }
+      walk(this.doc?.children)
+
+      const parts = []
+      if (counts[NodeKind.METRIC]) parts.push(`${counts[NodeKind.METRIC]} metrics`)
+      if (counts[NodeKind.COMPONENT] || counts[NodeKind.COMPONENT_LIST]) {
+        const n = (counts[NodeKind.COMPONENT] ?? 0)
+          + (counts[NodeKind.COMPONENT_LIST] ?? 0)
+        parts.push(`${n} ${n === 1 ? 'component' : 'components'}`)
+      }
+      if (counts[NodeKind.GROUP]) parts.push(`${counts[NodeKind.GROUP]} groups`)
+      return parts.length ? parts.join(', ') : 'Empty'
+    },
+  },
+}
+</script>

--- a/acs-admin/src/components/Schemas/SchemaPicker.vue
+++ b/acs-admin/src/components/Schemas/SchemaPicker.vue
@@ -32,6 +32,15 @@
       </Tabs>
     </div>
 
+    <!-- Only offered once something in the deployment is marked.
+         Before then there is nothing to hide and the choice would be
+         meaningless. -->
+    <label v-if="canFilterTopLevel"
+        class="flex cursor-pointer items-center gap-2 text-xs text-gray-500">
+      <Checkbox :model-value="showAll" @update:model-value="v => showAll = v === true"/>
+      <span>Show schemas that are parts of a machine</span>
+    </label>
+
     <div class="h-80 overflow-y-auto rounded-md border border-slate-200">
       <table class="w-full text-sm">
         <tbody>
@@ -75,7 +84,10 @@
     </div>
 
     <div class="flex justify-between text-xs text-gray-500">
-      <span>Showing {{ rows.length }} of {{ allRows.length }}</span>
+      <span>
+        Showing {{ rows.length }} of {{ allRows.length }}<template
+            v-if="hiddenCount">, {{ hiddenCount }} hidden</template>
+      </span>
       <span v-if="newerAvailable" class="text-gray-500">
         <i class="fa-solid fa-circle-arrow-up mr-1.5 text-[11px] text-slate-400"></i>
         A newer version of this schema exists
@@ -86,17 +98,20 @@
 
 <script>
 import { Badge } from '@components/ui/badge'
+import { Checkbox } from '@components/ui/checkbox'
 import { Input } from '@components/ui/input'
 import { Tabs, TabsList, TabsTrigger } from '@components/ui/tabs'
 
 import { originOf } from '@/lib/schema/presentation.js'
-import { isLibrarySchema, successorIndex, versionOf } from '@/lib/schema/registry.js'
+import {
+  anyTopLevelMarked, isLibrarySchema, successorIndex, topLevelOf, versionOf,
+} from '@/lib/schema/registry.js'
 import { buildUsageIndex } from '@/lib/schema/usage.js'
 
 export default {
   name: 'SchemaPicker',
 
-  components: { Badge, Input, Tabs, TabsList, TabsTrigger },
+  components: { Badge, Checkbox, Input, Tabs, TabsList, TabsTrigger },
 
   props: {
     modelValue: { type: String, default: null },
@@ -110,12 +125,18 @@ export default {
   emits: ['update:modelValue'],
 
   data () {
-    return { search: '', tab: 'all' }
+    return { search: '', tab: 'all', showAll: false }
   },
 
   computed: {
     successors () {
       return successorIndex(this.schemas)
+    },
+
+    /* Until the library ships marked schemas nothing carries the flag,
+     * and filtering on it would empty the list. */
+    canFilterTopLevel () {
+      return anyTopLevelMarked(this.schemas)
     },
 
     /* Built once over the whole store rather than once per row. */
@@ -133,6 +154,7 @@ export default {
           isLibrary: isLibrarySchema(entry),
           usedBy: this.usage.devices.get(entry.uuid) ?? 0,
           supersededBy: this.successors.get(entry.uuid)?.uuid ?? null,
+          topLevel: topLevelOf(entry),
         }
         row.glyph = originOf(row)
         return row
@@ -166,6 +188,11 @@ export default {
         .filter((row) => {
           if (this.tab === 'yours' && row.isLibrary) return false
           if (this.tab === 'library' && !row.isLibrary) return false
+          /* An unmarked schema is not hidden: it predates the flag
+           * rather than having been declared a component. The schema a
+           * device is already on is always shown. */
+          if (this.canFilterTopLevel && !this.showAll
+            && row.topLevel === false && row.uuid !== this.modelValue) return false
           if (!term) return true
           return row.name.toLowerCase().includes(term)
             || row.uuid.toLowerCase().includes(term)
@@ -176,6 +203,11 @@ export default {
           if (a.isLibrary !== b.isLibrary) return a.isLibrary ? 1 : -1
           return a.name.localeCompare(b.name) || a.version - b.version
         })
+    },
+
+    hiddenCount () {
+      if (!this.canFilterTopLevel || this.showAll) return 0
+      return this.allRows.filter(r => r.topLevel === false).length
     },
 
     newerAvailable () {

--- a/acs-admin/src/lib/schema/classify.js
+++ b/acs-admin/src/lib/schema/classify.js
@@ -234,6 +234,16 @@ export function classify (publishedBody, draftBody) {
   if ((before.title ?? null) !== (after.title ?? null))
     changes.push(change(ChangeKind.MODIFIED, ['title'], 'Title changed', false))
 
+  /* Whether a schema is offered as a device's own schema says nothing
+   * about the data it describes, so it cannot invalidate a device that
+   * is already using it. */
+  if (before.topLevel !== after.topLevel)
+    changes.push(change(ChangeKind.MODIFIED, ['topLevel'],
+      after.topLevel
+        ? 'Marked as a top-level schema'
+        : 'No longer a top-level schema',
+      false))
+
   compareChildren(before, after, [], changes)
   compareRequired(before, after, changes)
 

--- a/acs-admin/src/lib/schema/constants.js
+++ b/acs-admin/src/lib/schema/constants.js
@@ -99,6 +99,20 @@ export const SPARKPLUG_TYPES = [
   'DataSet', 'Bytes', 'File', 'Template',
 ]
 
+/**
+ * Marks a schema as one a device can be built on directly, rather than a
+ * component used inside another schema.
+ *
+ * A non-standard keyword, which JSON Schema validators ignore. It sits
+ * in the schema body so it travels with the file in the acs-schemas
+ * repo and reaches the ConfigDB through the existing loader.
+ *
+ * Reference counting cannot replace it: Robot is referenced by Cell and
+ * is still a device you would put on a machine, while Bean_Hopper is
+ * referenced by nothing and is not.
+ */
+export const TOP_LEVEL_KEY = 'topLevel'
+
 /** The JSON Schema dialect new schemas declare. */
 export const SCHEMA_DIALECT = 'https://json-schema.org/draft/2020-12/schema'
 

--- a/acs-admin/src/lib/schema/document.js
+++ b/acs-admin/src/lib/schema/document.js
@@ -28,6 +28,7 @@ import {
   NodeKind,
   RESERVED_PROPERTIES,
   SCHEMA_DIALECT,
+  TOP_LEVEL_KEY,
   refToUuid,
   uuidToRef,
 } from './constants.js'
@@ -170,6 +171,9 @@ export function parse (body) {
     raw: clone(body),
     uuid: body.properties?.Schema_UUID?.const ?? refToUuid(body.$id) ?? null,
     title: typeof body.title === 'string' ? body.title : null,
+    /* Absent means unmarked, which is not the same as false: a
+     * deployment where nothing is marked behaves as it always did. */
+    topLevel: TOP_LEVEL_KEY in body ? body[TOP_LEVEL_KEY] === true : undefined,
     children: Object.entries(properties).map(([k, v]) => parseNode(k, v)),
   }
 }
@@ -305,6 +309,11 @@ export function serialise (doc) {
   if (doc.title) out.title = doc.title
   else delete out.title
 
+  /* Undefined means the schema says nothing about it, so the key is
+   * left off entirely rather than written as false. */
+  if (doc.topLevel === undefined) delete out[TOP_LEVEL_KEY]
+  else out[TOP_LEVEL_KEY] = doc.topLevel
+
   out.properties = serialiseChildren(doc.children ?? [])
 
   if (doc.uuid) {
@@ -326,6 +335,10 @@ export function newDocument (uuid, title) {
     $id: uuidToRef(uuid),
     $schema: SCHEMA_DIALECT,
     title,
+    /* A schema someone sits down to author is usually a machine rather
+     * than a part of one. Components are more often forked from the
+     * library, which carries its own marking. */
+    [TOP_LEVEL_KEY]: true,
     type: 'object',
     properties: {
       Schema_UUID: { const: uuid },

--- a/acs-admin/src/lib/schema/lineage.js
+++ b/acs-admin/src/lib/schema/lineage.js
@@ -17,6 +17,32 @@
 /** The provenance marker this editor writes into SchemaInformation. */
 export const LOCAL_SOURCE = 'acs-admin'
 
+/** Key marking a schema as one a device can be built on directly. */
+const TOP_LEVEL_KEY = 'topLevel'
+
+/**
+ * Is this a schema a device can be built on, rather than a component
+ * used inside another schema?
+ *
+ * Undefined rather than false when the schema says nothing, so callers
+ * can tell "not a device schema" from "this library predates the flag".
+ */
+export function topLevelOf (entry) {
+  const body = entry?.schema
+  if (!body || !(TOP_LEVEL_KEY in body)) return undefined
+  return body[TOP_LEVEL_KEY] === true
+}
+
+/**
+ * Does any schema here carry the flag?
+ *
+ * Until the library ships marked schemas nothing does, and filtering by
+ * it would empty the list. In that case the filter stays inert.
+ */
+export function anyTopLevelMarked (schemas) {
+  return (schemas ?? []).some(e => topLevelOf(e) !== undefined)
+}
+
 /**
  * Is this schema part of the AMRC library rather than locally authored?
  *

--- a/acs-admin/src/lib/schema/registry.js
+++ b/acs-admin/src/lib/schema/registry.js
@@ -35,11 +35,13 @@ import { LOCAL_SOURCE } from './lineage.js'
 
 export {
   LOCAL_SOURCE,
+  anyTopLevelMarked,
   derivedFromOf,
   isLibrarySchema,
   newestVersion,
   replacesOf,
   successorIndex,
+  topLevelOf,
   unresolvedReferences,
   versionOf,
 } from './lineage.js'

--- a/acs-admin/src/pages/Schemas/SchemaEditor.vue
+++ b/acs-admin/src/pages/Schemas/SchemaEditor.vue
@@ -183,15 +183,28 @@
             </div>
           </template>
 
-          <div v-else class="flex flex-1 items-center justify-center">
-            <div class="text-center">
-              <i class="fa-solid fa-gauge fa-2x text-slate-300"></i>
-              <h3 class="mt-3 text-sm font-medium text-gray-700">Nothing selected</h3>
-              <p class="mt-1 text-sm text-gray-400">
-                Pick something on the left to edit it.
-              </p>
+          <template v-else>
+            <div class="flex shrink-0 items-center justify-between border-b
+                        border-slate-200 px-5 py-3.5">
+              <div>
+                <div class="mb-1 text-xs text-slate-500">{{ name }}</div>
+                <div class="flex items-center gap-2">
+                  <i class="fa-solid fa-fw fa-shapes text-slate-500"></i>
+                  <span class="text-xl font-semibold tracking-tight">Schema</span>
+                </div>
+              </div>
             </div>
-          </div>
+            <div class="flex-1 overflow-y-auto p-5">
+              <SchemaPanel
+                  :name="name"
+                  :uuid="schemaUuid"
+                  :top-level="topLevel === true"
+                  :doc="doc"
+                  :readonly="readonly"
+                  @update:name="v => { name = v; touch() }"
+                  @update:top-level="setTopLevel"/>
+            </div>
+          </template>
         </div>
       </div>
     </template>
@@ -224,6 +237,7 @@ import StructureTree from '@components/Schemas/StructureTree.vue'
 import MetricPanel from '@components/Schemas/MetricPanel.vue'
 import ComponentPanel from '@components/Schemas/ComponentPanel.vue'
 import GroupPanel from '@components/Schemas/GroupPanel.vue'
+import SchemaPanel from '@components/Schemas/SchemaPanel.vue'
 import OpaquePanel from '@components/Schemas/OpaquePanel.vue'
 import ComponentPickerDialog from '@components/Schemas/ComponentPickerDialog.vue'
 import RawSchemaDialog from '@components/Schemas/RawSchemaDialog.vue'
@@ -251,7 +265,7 @@ export default {
     Badge, Button, ComponentPanel, ComponentPickerDialog, DropdownMenu,
     DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator,
     DropdownMenuTrigger, GroupPanel, Input, MetricPanel, OpaquePanel,
-    RawSchemaDialog, Skeleton, StructureTree,
+    RawSchemaDialog, SchemaPanel, Skeleton, StructureTree,
   },
 
   setup () {
@@ -481,6 +495,10 @@ export default {
       return null
     },
 
+    topLevel () {
+      return this.doc?.topLevel
+    },
+
     rawBody () {
       return this.doc ? serialise(this.doc) : {}
     },
@@ -554,6 +572,12 @@ export default {
 
     touch () {
       this.dirty = true
+    },
+
+    setTopLevel (value) {
+      if (!this.doc) return
+      this.doc.topLevel = value === true
+      this.touch()
     },
 
     rename (value) {

--- a/acs-admin/test/schema-classify.test.js
+++ b/acs-admin/test/schema-classify.test.js
@@ -315,3 +315,35 @@ describe('every library schema is stable against itself', () => {
     expect(classify(library[path], library[path]).changes).toEqual([])
   })
 })
+
+describe('top-level flag', () => {
+  const mark = (path, value) => {
+    const doc = parse(library[path])
+    doc.topLevel = value
+    return serialise(doc)
+  }
+
+  it('marking a schema top-level is additive', () => {
+    const result = classify(library[SPINDLE], mark(SPINDLE, true))
+    expect(result.breaking).toBe(false)
+    expect(summaries(result)).toEqual(['Marked as a top-level schema'])
+  })
+
+  it('unmarking is additive too', () => {
+    const before = mark(SPINDLE, true)
+    const after = mark(SPINDLE, false)
+    const result = classify(before, after)
+    expect(result.breaking).toBe(false)
+    expect(summaries(result)).toEqual(['No longer a top-level schema'])
+  })
+
+  /* It says nothing about the data a device publishes, so it cannot
+   * invalidate a device already using the schema. */
+  it('does not force a new version on its own', () => {
+    expect(classify(library[SPINDLE], mark(SPINDLE, true)).additive).toBe(true)
+  })
+
+  it('is noticed at all, so publishing is not refused as a no-op', () => {
+    expect(classify(library[SPINDLE], mark(SPINDLE, true)).changes).toHaveLength(1)
+  })
+})

--- a/acs-admin/test/schema-document.test.js
+++ b/acs-admin/test/schema-document.test.js
@@ -297,3 +297,71 @@ describe('navigation helpers', () => {
     for (const ref of components) expect(all).toContain(ref)
   })
 })
+
+describe('top-level flag', () => {
+  const uuid = '99999999-9999-9999-9999-999999999999'
+
+  it('reads the flag when a schema sets it', () => {
+    const doc = parse({
+      $id: `urn:uuid:${uuid}`,
+      topLevel: true,
+      type: 'object',
+      properties: { Schema_UUID: { const: uuid } },
+    })
+    expect(doc.topLevel).toBe(true)
+  })
+
+  it('reads false when a schema declares itself a component', () => {
+    const doc = parse({
+      $id: `urn:uuid:${uuid}`,
+      topLevel: false,
+      type: 'object',
+      properties: { Schema_UUID: { const: uuid } },
+    })
+    expect(doc.topLevel).toBe(false)
+  })
+
+  /* Undefined is not false. A library that predates the flag says
+   * nothing, and the picker treats that differently from a schema that
+   * has declared itself a component. */
+  it('is undefined when the schema says nothing', () => {
+    expect(parse(library['CNC/CNC-v1.yaml']).topLevel).toBeUndefined()
+  })
+
+  it('leaves the key off entirely when undefined', () => {
+    const body = serialise(parse(library['CNC/CNC-v1.yaml']))
+    expect('topLevel' in body).toBe(false)
+  })
+
+  it('writes the key once set', () => {
+    const doc = parse(library['CNC/CNC-v1.yaml'])
+    doc.topLevel = true
+    expect(serialise(doc).topLevel).toBe(true)
+  })
+
+  it('writes false when a schema is marked as a component', () => {
+    const doc = parse(library['CNC/Axis-v1.yaml'])
+    doc.topLevel = false
+    expect(serialise(doc).topLevel).toBe(false)
+  })
+
+  it('round-trips a schema that already carries the flag', () => {
+    const body = {
+      $id: `urn:uuid:${uuid}`,
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      title: 'Marked',
+      topLevel: true,
+      type: 'object',
+      properties: { Schema_UUID: { const: uuid } },
+      required: ['Schema_UUID'],
+    }
+    expect(JSON.stringify(serialise(parse(body)), null, 2))
+      .toEqual(JSON.stringify(body, null, 2))
+  })
+
+  it('marks a newly authored schema as top-level', () => {
+    /* Someone sitting down to author a schema is usually describing a
+     * machine, not a part of one. */
+    expect(serialise(newDocument(uuid, 'New')).topLevel).toBe(true)
+  })
+})

--- a/acs-admin/test/schema-usage.test.js
+++ b/acs-admin/test/schema-usage.test.js
@@ -23,9 +23,11 @@ import {
   buildUsageIndex,
 } from '../src/lib/schema/usage.js'
 import {
+  anyTopLevelMarked,
   isLibrarySchema,
   newestVersion,
   successorIndex,
+  topLevelOf,
   unresolvedReferences,
   versionOf,
   LOCAL_SOURCE,
@@ -322,5 +324,39 @@ describe('usage index', () => {
     const started = performance.now()
     buildUsageIndex(all, devices)
     expect(performance.now() - started).toBeLessThan(150)
+  })
+})
+
+describe('top-level marking', () => {
+  const marked = (value) => ({
+    uuid: 'x', schema: value === undefined ? {} : { topLevel: value },
+  })
+
+  it('reads the flag off a schema record', () => {
+    expect(topLevelOf(marked(true))).toBe(true)
+    expect(topLevelOf(marked(false))).toBe(false)
+  })
+
+  /* Undefined means the schema predates the flag, which the picker
+   * treats differently from a schema declaring itself a component. */
+  it('is undefined when the schema says nothing', () => {
+    expect(topLevelOf(marked(undefined))).toBeUndefined()
+    expect(topLevelOf({ uuid: 'x' })).toBeUndefined()
+  })
+
+  it('reports when nothing in a deployment is marked', () => {
+    expect(anyTopLevelMarked([marked(undefined), marked(undefined)])).toBe(false)
+    expect(anyTopLevelMarked([])).toBe(false)
+  })
+
+  it('reports when something is marked, either way', () => {
+    expect(anyTopLevelMarked([marked(undefined), marked(true)])).toBe(true)
+    expect(anyTopLevelMarked([marked(false)])).toBe(true)
+  })
+
+  it('sees nothing marked in the current library', () => {
+    /* The whole reason the filter stays inert on upgrade. */
+    const all = Object.values(library).map(schema => ({ uuid: '', schema }))
+    expect(anyTopLevelMarked(all)).toBe(false)
   })
 })

--- a/docs/services/schema-editor.md
+++ b/docs/services/schema-editor.md
@@ -75,6 +75,44 @@ It is displayed read-only and round-trips byte for byte. There is no
 schema that fails to load, and opening a hand-written schema cannot
 damage it. A raw JSON view is available as an escape hatch.
 
+## Top-level schemas
+
+A schema body may carry a `topLevel` boolean:
+
+```yaml
+$id: urn:uuid:4701e66e-0f77-42b0-8ddd-cef60db6ef4a
+$schema: https://json-schema.org/draft/2020-12/schema
+topLevel: true
+title: CNC Machine
+```
+
+`true` means a device can be built on this schema directly. `false`
+means it is a part used inside another schema, like an axis or a
+spindle, and it is hidden when choosing a schema for a device.
+
+The flag lives in the body so it travels with the file in the
+`acs-schemas` repo and reaches the ConfigDB through the existing loader.
+It is a non-standard keyword, which JSON Schema validators ignore, and
+nothing in ACS validates schema bodies.
+
+**Absent is not false.** A schema that says nothing is treated as still
+worth showing, and the filter is switched off entirely until at least
+one schema in the deployment carries the flag. A library that predates
+the flag therefore behaves exactly as it always did.
+
+Reference counting does not replace the flag. It gets most cases right,
+but `Robot` is referenced by `Cell` and is still a machine, while
+`Bean_Hopper` is referenced by nothing and is not.
+
+Changing the flag is an additive change: it says nothing about the data
+a device publishes, so it cannot invalidate a device already using the
+schema.
+
+The editor sets it in the schema panel, shown in the detail pane when
+nothing in the tree is selected. A newly authored schema starts marked
+`true`, since someone sitting down to write one is usually describing a
+machine.
+
 ## The change classifier
 
 When a local schema is published, its draft is compared against what is


### PR DESCRIPTION
Choosing a schema for a device offered all 139 of them, including `Axis`, `Spindle` and `Metric`. Those are parts of a machine, not things a machine is.

Schemas can now declare `topLevel` in their body, and the picker defaults to showing only those, with a checkbox to show everything.

## Why a flag rather than deriving it

Reference counting nearly works, and I checked it against the real library before proposing anything. It gets `Axis` (referenced once), `Spindle` (twice) and `Metric` (105 times) right, and correctly leaves `CNC` and `Cell` alone.

It fails in both directions. `Robot` is referenced by `Cell` and is still obviously a machine. `Bean_Hopper` is referenced by nothing and is obviously not. So the flag is explicit.

## Absent is not false

A schema that says nothing is still shown, and the filter is switched off entirely until at least one schema in the deployment carries the flag.

That means this is safe to ship before the library catches up: on an unmarked deployment the picker behaves exactly as it does today, and the checkbox does not even appear. The companion library PR is [acs-schemas#12](https://github.com/AMRC-FactoryPlus/acs-schemas/pull/12).

## Where the toggle lives

The editor's detail pane previously showed an empty state telling you to click something. It now shows the schema itself when nothing is selected: name, contents, and the top-level toggle. A newly authored schema starts marked top-level, since someone sitting down to write one is usually describing a machine rather than a part of one.

## Notes

- The flag is a non-standard JSON Schema keyword, so validators ignore it. Nothing in ACS validates schema bodies, and the document model already round-trips unknown top-level keys untouched, so the byte-identical round-trip over all 139 library schemas still passes.
- Changing the flag classifies as **additive**. It says nothing about the data a device publishes, so it cannot invalidate a device already using the schema. It is deliberately *noticed* by the classifier, though, so publishing a schema whose only change is the flag is not refused as a no-op.

## How to test

1. `cd acs-admin && npm test` — 393 tests.
2. Open a schema in the editor and click on empty space in the tree, or deselect. The schema panel appears with the toggle.
3. On a device, choose a schema. With no library schema marked, the list is unchanged and there is no checkbox.
4. Mark one schema as top-level and publish it, then reopen the device picker: the checkbox appears and the list narrows.
