### PR TITLE
Load the marked schema library, and release notes for v6.5.0

### DIFF
--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -39,7 +39,7 @@ acs:
     image:
       registry: ghcr.io
       repository: amrc-factoryplus/acs-schemas
-      tag: v1.5.1
+      tag: v1.6.0
 
 coredns:
   # -- An option to enable the redirecting of external URL's back

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -8,6 +8,47 @@ chronological order.
 These changes have not been released yet, but are likely to appear in
 the next release.
 
+## v6.5.0
+
+### Choosing a schema for a device offers only the ones that fit
+
+Setting a device's schema previously listed every schema in the
+deployment, including `Axis`, `Spindle` and `Metric`. Those are parts of
+a machine rather than things a machine is, and on a full library they
+buried the twenty or so schemas anyone actually picks.
+
+Schemas now declare whether a device can be built on them directly. The
+picker shows those by default, with a checkbox to show everything, and
+the schema editor has a toggle for it on locally authored schemas.
+
+The flag lives in the schema body as `topLevel`, so it travels with the
+file in the AMRC schema library. It is a non-standard JSON Schema
+keyword, which validators ignore, and nothing in ACS validates schema
+bodies, so it is inert for every other consumer.
+
+A schema that says nothing is still shown, and the filter is switched
+off entirely until at least one schema in the deployment carries the
+flag. Nothing disappears from anyone's list unless it has been
+explicitly marked as a component.
+
+### The AMRC schema library ships marked
+
+The bundled schema library moves to v1.6.0, in which all 139 schemas
+carry the flag: 32 are machines and systems a device can be built on,
+and the rest are parts used inside them.
+
+This reaches existing installations, not just fresh ones. The loader
+replaces a schema body whenever the stored `source` matches its own, so
+a `helm upgrade` brings the marked library with it. Locally authored
+schemas record a different source and are skipped, so anything you have
+written or forked is untouched.
+
+### Upgrading
+
+A plain `helm upgrade`. Sites that pin `acs.schemas.image.tag`
+themselves should move it to `v1.6.0` to pick up the marked library;
+until they do, the picker behaves exactly as it did in v6.4.0.
+
 ## v6.4.0
 
 ### Schemas can be authored in the admin UI


### PR DESCRIPTION
Bumps the bundled schema library to `v1.6.0` and adds release notes for **v6.5.0**.

## Why the bump is needed

The `topLevel` flag merged in #704 does nothing on its own. The schemas are loaded by an init container in the `service-setup` Job, pinned in `values.yaml`:

```yaml
acs:
  schemas:
    image:
      tag: v1.5.1
```

So an `acs-schemas` release does not reach any site until that pin moves. Without this, every deployment keeps loading the unmarked v1.5.1 library and the picker filter stays inert forever.

## This reaches existing installations

Not just fresh ones. `load-schemas.js` replaces a schema body whenever the stored `source` matches its own:

```js
if (existing && existing.source && existing.source != metadata.source) continue;
await cdb.put_config(App.Schema, uuid, schema);
```

Library schemas record the acs-schemas repo as their source, so they are overwritten on upgrade and pick up the flag. Locally authored schemas record `acs-admin` and are skipped, so anything written or forked in the editor is untouched.

## Release notes

#704 merged without notes, so `main` was not releasable as it stood. The notes here cover both it and this bump, which is why they are in the same PR rather than a separate one. Happy to split them if you would rather keep to the usual shape.

## Ordering

This depends on [acs-schemas#12](https://github.com/AMRC-FactoryPlus/acs-schemas/pull/12) being merged and released **as v1.6.0**. If you tag that release differently, this pin needs to match before the ACS release is cut, or `service-setup` will fail to pull the image.

`helm lint deploy` passes.
