### PR TITLE
Directory: key online/alert tracking by address string

### DIFF
--- a/acs-directory/lib/mqttcli.js
+++ b/acs-directory/lib/mqttcli.js
@@ -74,6 +74,9 @@ export default class MQTTCli {
 
         this.seq = 0;
 
+        /* Keyed by Address.toString(). Address has no value semantics,
+         * so Sets and Maps must never be keyed on the object itself;
+         * they compare by reference and would never match. */
         this.online = new Set();
         this.rebirths = {
             pending: {},
@@ -446,7 +449,7 @@ export default class MQTTCli {
 
     async on_birth(address, payload) {
         this.log("device", `Registering BIRTH for ${address}`);
-        this.online.add(address);
+        this.online.add(address.toString());
 
         let tree;
         if (payload.uuid === UUIDs.FactoryPlus) {
@@ -478,8 +481,8 @@ export default class MQTTCli {
 
         this.log("device", `Registering DEATH for ${address}`);
 
-        this.alerts.delete(address);
-        this.online.delete(address);
+        this.alerts.delete(address.toString());
+        this.online.delete(address.toString());
         await this.model.death({address, time});
 
         this.log("device", `Finished DEATH for ${address}`);
@@ -546,7 +549,7 @@ export default class MQTTCli {
          * rebirth any device we haven't seen a birth for, even if the
          * database says it's online. This is important because we might
          * have the wrong schema information. */
-        if (this.online.has(addr) || pending[addr]) return false;
+        if (this.online.has(addr.toString()) || pending[addr]) return false;
 
         /* Mark that we're working on this device and wait 5-10s to see if
          * it rebirths on its own. */
@@ -555,7 +558,7 @@ export default class MQTTCli {
 
         /* Clear our marker first so we retry next time */
         delete (pending[addr]);
-        if (this.online.has(addr)) return false;
+        if (this.online.has(addr.toString())) return false;
 
         sent[addr] = Date.now();
         return true;

--- a/acs-directory/package.json
+++ b/acs-directory/package.json
@@ -16,7 +16,8 @@
   "type": "module",
   "scripts": {
     "mqtt": "node bin/directory-mqtt",
-    "webapi": "node bin/directory-webapi"
+    "webapi": "node bin/directory-webapi",
+    "test": "node --test test/"
   },
   "dependencies": {
     "@amrc-factoryplus/rx-client": "file:../lib/js-rx-client",

--- a/acs-directory/test/rebirth-online.test.js
+++ b/acs-directory/test/rebirth-online.test.js
@@ -1,0 +1,75 @@
+/*
+ * ACS Directory
+ * Tests for the online-device tracking used to suppress rebirths
+ * Copyright 2026 University of Sheffield
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { Address } from "@amrc-factoryplus/service-client";
+
+import MQTTCli from "../lib/mqttcli.js";
+
+/* do_we_rebirth only touches this.online and this.rebirths, so we can
+ * exercise it against a bare object rather than building a whole
+ * MQTTCli. */
+function mk_cli (online) {
+    return {
+        online:     new Set(online),
+        rebirths:   { pending: {}, sent: {} },
+        log:        () => {},
+    };
+}
+
+const do_we_rebirth = MQTTCli.prototype.do_we_rebirth;
+
+test("a device we have seen born is not rebirthed", async () => {
+    /* The Set is populated from on_birth, which keys by toString. The
+     * address we are asked about is a different object with the same
+     * value; keying on the object itself would compare by reference and
+     * never match, so we would rebirth a device that is already online. */
+    const cli = mk_cli(["Group/Node/Device"]);
+    const addr = new Address("Group", "Node", "Device");
+
+    assert.equal(await do_we_rebirth.call(cli, addr), false);
+    assert.deepEqual(cli.rebirths.sent, {},
+        "must not record a rebirth for an online device");
+});
+
+test("a node address we have seen born is not rebirthed", async () => {
+    const cli = mk_cli(["Group/Node"]);
+    const addr = new Address("Group", "Node");
+
+    assert.equal(await do_we_rebirth.call(cli, addr), false);
+});
+
+test("a device we have not seen is rebirthed", async () => {
+    const cli = mk_cli(["Group/Node/Other"]);
+    const addr = new Address("Group", "Node", "Device");
+
+    assert.equal(await do_we_rebirth.call(cli, addr), true);
+    assert.ok("Group/Node/Device" in cli.rebirths.sent,
+        "must record that we have rebirthed this device");
+});
+
+test("a device rebirthed recently is not rebirthed again", async () => {
+    const cli = mk_cli([]);
+    cli.rebirths.sent["Group/Node/Device"] = Date.now();
+    const addr = new Address("Group", "Node", "Device");
+
+    assert.equal(await do_we_rebirth.call(cli, addr), false);
+});
+
+test("Address does not have value semantics", () => {
+    /* This is the property that makes the toString keys necessary. If
+     * this ever stops being true the keying can be simplified, but
+     * until then Sets and Maps must be keyed on the string. */
+    const one = new Address("Group", "Node", "Device");
+    const two = new Address("Group", "Node", "Device");
+
+    assert.notEqual(one, two);
+    assert.ok(one.equals(two));
+    assert.equal(one.toString(), two.toString());
+    assert.equal(new Set([one]).has(two), false);
+});


### PR DESCRIPTION
## Summary

`MQTTCli` tracked online devices in a `Set` of `Address` objects, and removed alert state with an `Address` object key. `Address` has no value semantics — it carries an `equals()` method precisely because `===` does not work — so `Set.has()` and `Map.delete()` compared by reference and never matched.

Two consequences:

1. **Runaway rebirths.** The guard in `do_we_rebirth` that says *"if we think this device is online, everything's OK"* never fired. The Directory therefore requested a rebirth for **every device it saw traffic from**, limited only by the five-minute `sent` window. Every rebirth inserts a `session` row — this is the mechanism driving the unbounded growth of the `session` table.
2. **Leaked alert state.** `this.alerts` is a `Map` keyed by `address.toString()` when written (`mqttcli.js:388`, `:403`) but was deleted with the object (`:481`), so entries were never removed on DEATH.

Both collections are now keyed by `Address.toString()`, matching `pending`/`sent`, which already worked because property-name coercion calls `toString()` for them.

### Observed impact

On one long-running production install this produced a `session` table of 1.8 GB heap plus ~3.8 GB of indexes, in a 5.6 GB `directory` database where every other database on the server is ~10 MB. Queries against the `device_status` view — which joins `session` — were taking **60–115 seconds each**, saturating all 10 of the Directory's connections and pinning Postgres at ~2.9 CPU cores. The user-visible symptoms were the admin UI hanging at login and dashboards showing no data.

This PR stops the growth at source. Pruning the history that has already accumulated is a follow-up PR.

### History

This half of the change was originally part of #614 and was lost when that PR was reverted by #617. The revert was correct — but it was aimed at the *session cleanup* half, which had genuine FK and change-notify problems. This part was collateral damage and has never been re-landed.

## Test plan

Adds `npm test` to `acs-directory` using the built-in `node:test` runner — no new dependencies.

- [x] `cd acs-directory && npm test` — 5 tests pass
- [x] Verified the tests **fail against `main`**: 2 of 5 fail without the fix (`a device we have seen born is not rebirthed`, `a node address we have seen born is not rebirthed`)

## How to test

1. Deploy to a cluster with devices actively publishing.
2. `kubectl logs -n factory-plus deploy/directory-mqtt | grep -c "Registering BIRTH"` over a fixed window, before and after.
3. Before: births arrive continuously for devices that are already online. After: births only on genuine device restarts/reconnects.
4. Confirm the Directory still rebirths a device it has genuinely not seen — stop and restart an edge agent and check it is registered.

## Release notes

Fixed a bug in the Directory that caused it to continuously request rebirths from devices that were already online. On long-running installations this caused the Directory database to grow very large, which could make the admin UI slow or unresponsive and stop dashboards loading data. Also fixed a related memory leak in the Directory's alert tracking.

