### PR TITLE
Directory: bound the session table

### DIFF
--- a/acs-directory/lib/mqttcli.js
+++ b/acs-directory/lib/mqttcli.js
@@ -299,6 +299,10 @@ export default class MQTTCli {
 
     async on_session_notify(id) {
         const session = await this.model.session_notification_info(id);
+        /* The session may have been pruned between the notification
+         * being queued and us getting to it. Nothing to announce. */
+        if (session == null) return;
+
         const schemas = await this.model.session_schemas(id);
 
         const notify = [];
@@ -324,6 +328,18 @@ export default class MQTTCli {
 
         if (notify.length)
             this.publish_changed(notify);
+
+        /* Now the change-notify is out, and we have read the schemas of
+         * the session this one replaced, the history for this device is
+         * no longer needed. Only prune from the current session, so we
+         * do this once per birth rather than once per notification. */
+        if (session.next_for_device == null) {
+            const pruned = await this.model
+                .prune_device_sessions(session.devid);
+            if (pruned)
+                this.log("device",
+                    `Pruned ${pruned} old session(s) for ${session.device}`);
+        }
     }
 
     async on_service_notify(id) {

--- a/acs-directory/lib/queries.js
+++ b/acs-directory/lib/queries.js
@@ -94,6 +94,7 @@ export default class Queries {
     async session_notification_info(id) {
         const dbr = await this.query(`
             select dev.uuid device,
+                   ses.device devid,
                    adr.group_id,
                    adr.node_id,
                    adr.device_id,
@@ -181,6 +182,51 @@ export default class Queries {
         `, [id]);
 
         return dbr.rows.map(r => r.uuid);
+    }
+
+    /* Prune session history for the device owning this session.
+     *
+     * Sessions are chained twice over, by next_for_device and by
+     * next_for_address, and both columns are foreign keys back into
+     * session. An address may be reused by a different device, so the
+     * two chains interleave and a session belonging to one device can
+     * be referenced by a session belonging to another. Deleting on the
+     * device chain alone therefore breaks referential integrity; this
+     * is what went wrong in #614.
+     *
+     * We keep, in each chain, the current session and the one directly
+     * before it. The predecessor is required: on_session_notify reads
+     * it to compute the Schema_Usage difference, and without it every
+     * birth would republish every schema. Nothing else reads history -
+     * the sessions() endpoint is disabled - so anything older goes.
+     *
+     * Only rows which nothing at all points at are deleted, which
+     * makes the delete safe whatever order the planner picks. That
+     * means we take the tail off each chain, so on an install with a
+     * long backlog this converges over several births rather than all
+     * at once; use sql/prune-sessions.sql to clear a backlog in bulk.
+     */
+    async prune_device_sessions(device) {
+        const dbr = await this.query(`
+            delete from session old
+            where old.device = $1
+              and old.next_for_device is not null
+              and old.next_for_address is not null
+              and not exists (
+                  select 1 from session cur
+                  where cur.id = old.next_for_device
+                    and cur.next_for_device is null)
+              and not exists (
+                  select 1 from session cur
+                  where cur.id = old.next_for_address
+                    and cur.next_for_address is null)
+              and not exists (
+                  select 1 from session ref
+                  where ref.next_for_device = old.id
+                     or ref.next_for_address = old.id)
+        `, [device]);
+
+        return dbr.rowCount;
     }
 
     async record_schema(session, schema) {

--- a/acs-directory/lib/queries.js
+++ b/acs-directory/lib/queries.js
@@ -28,7 +28,7 @@ function sym_diff(one, two) {
  * the database directly, and sometimes we need to query using a query
  * function for a transaction. The model inherits from this class. */
 export default class Queries {
-    static DBVersion = 13;
+    static DBVersion = 14;
 
     constructor(query) {
         this.query = query;

--- a/acs-directory/sql/migrate.sql
+++ b/acs-directory/sql/migrate.sql
@@ -29,6 +29,7 @@ BEGIN;
 \ir v11.sql
 \ir v12.sql
 \ir v13.sql
+\ir v14.sql
 
 \ir permissions.sql
 

--- a/acs-directory/sql/v14.sql
+++ b/acs-directory/sql/v14.sql
@@ -1,0 +1,99 @@
+-- Factory+ / AMRC Connectivity Stack (ACS) Directory component
+-- Database creation/upgrade DDL.
+-- Copyright 2026 University of Sheffield AMRC
+
+
+call migrate_to(14, $migrate$
+    -- Nothing has ever deleted from session, so an install which has
+    -- been running for a while arrives here with a row per birth for
+    -- its whole history. We prune that down here and keep it pruned
+    -- from now on (see Queries.prune_device_sessions).
+    --
+    -- Take the notify trigger off for the duration. Everything below
+    -- is storage bookkeeping and none of it is a change any client
+    -- should be told about; the sessions still exist as far as the
+    -- outside world is concerned. It goes back on at the end, without
+    -- the DELETE, because a notification naming a pruned session
+    -- refers to a row which can no longer be looked up.
+    drop trigger mqtt_notify on session;
+
+    -- What to keep: for each device, and for each address, the current
+    -- session and the one before it. The predecessor is load bearing -
+    -- on_session_notify reads it to work out which schemas have been
+    -- added and removed, and without it every birth would republish
+    -- every schema.
+    --
+    -- Sessions are chained twice over, by next_for_device and by
+    -- next_for_address, and both are foreign keys back into session.
+    -- An address may be reused by a different device, so the chains
+    -- interleave: a session belonging to one device can be referenced
+    -- by a session belonging to another. A row is kept if either chain
+    -- still wants it. Pruning along the device chain alone is what
+    -- caused the foreign key errors that got #614 reverted.
+    create temporary table session_keep on commit drop as
+        select id
+        from (
+            select id,
+                row_number() over (partition by device  order by id desc) rn_dev,
+                row_number() over (partition by address order by id desc) rn_adr
+            from session
+        ) ranked
+        where rn_dev <= 2 or rn_adr <= 2;
+    create unique index on session_keep (id);
+
+    -- Close the gaps: point each surviving session at the next session
+    -- which also survives. Sessions which are current in a chain have
+    -- a null pointer and are skipped, so this cannot manufacture a
+    -- second current session for a device or an address, which would
+    -- break device_status, is_addr_online and addr_uuid.
+    update session s
+    set next_for_device = (
+            select k.id
+            from session k
+                join session_keep sk on sk.id = k.id
+            where k.device = s.device
+              and k.id > s.id
+            order by k.id
+            limit 1)
+    from session_keep sk
+    where sk.id = s.id
+      and s.next_for_device is not null;
+
+    update session s
+    set next_for_address = (
+            select k.id
+            from session k
+                join session_keep sk on sk.id = k.id
+            where k.address = s.address
+              and k.id > s.id
+            order by k.id
+            limit 1)
+    from session_keep sk
+    where sk.id = s.id
+      and s.next_for_address is not null;
+
+    -- Everything else goes, and takes its schema_used rows with it.
+    -- Every surviving session now points only at other survivors, so
+    -- there is nothing left to violate the foreign keys.
+    delete from session
+    where id not in (select id from session_keep);
+
+    -- Version 8 dropped the session_device_key and session_address_key
+    -- unique constraints, and with them the only indexes on these
+    -- columns. Nothing replaced them, so finding the current session
+    -- for a device or an address has been a sequential scan ever
+    -- since. That is the join device_status makes, and on a large
+    -- session table it dominates the cost of every device query.
+    --
+    -- Built after the prune, so they are built against the pruned
+    -- table rather than the full history.
+    create index on session (device);
+    create index on session (address);
+
+    create trigger mqtt_notify
+        after insert or update on session
+        for each row execute function mqtt_notify();
+    -- ENABLE ALWAYS so it is also called on replicas, matching
+    -- setup_mqtt_notify.
+    alter table session enable always trigger mqtt_notify;
+$migrate$);

--- a/acs-directory/test/session-prune.sql
+++ b/acs-directory/test/session-prune.sql
@@ -1,0 +1,137 @@
+-- Factory+ / AMRC Connectivity Stack (ACS) Directory component
+-- Integrity test for session pruning.
+-- Copyright 2026 University of Sheffield AMRC
+--
+-- PR #614 pruned the session table and was reverted by #617 because it
+-- caused foreign key errors: sessions are chained both by device and by
+-- address, an address may be reused by a different device, and deleting
+-- along the device chain alone leaves a surviving session of one device
+-- pointing at a deleted session of another. This builds exactly that
+-- shape and asserts the prune leaves the table consistent.
+--
+-- Seed a pre-v14 database, then apply v14 and re-run to assert the
+-- migration left the table consistent:
+--
+--     docker run -d --name dirtest -e POSTGRES_PASSWORD=test \
+--         -e POSTGRES_DB=directory postgres:16
+--     docker cp acs-directory/sql dirtest:/sql
+--     docker cp acs-directory/test/session-prune.sql dirtest:/t.sql
+--     # migrate to v13 only, then seed history
+--     docker exec dirtest sh -c 'cd /sql && psql -U postgres -d directory \
+--         -f migration.sql && for v in 5 6 7 8 9 10 11 12 13; do \
+--         psql -U postgres -d directory -f v$v.sql; done'
+--     docker exec dirtest psql -U postgres -d directory -f /t.sql
+--     # now apply the migration under test
+--     docker exec dirtest psql -U postgres -d directory -f /sql/v14.sql
+--     docker exec dirtest psql -U postgres -d directory -f /t.sql
+--
+-- The first run seeds and records the expected device_status; the run
+-- after v14 re-checks it and asserts the invariants.
+
+\set ON_ERROR_STOP
+
+-- Replicates Queries.record_birth.
+create or replace function mk_birth (p_dev integer, p_adr integer, p_t timestamp)
+    returns integer language plpgsql as $$
+    declare
+        sess integer;
+    begin
+        insert into session (device, address, start)
+            values (p_dev, p_adr, p_t) returning id into sess;
+        update session set next_for_device = sess,
+                finish = coalesce(finish, p_t)
+            where device = p_dev and next_for_device is null and id != sess;
+        update session set next_for_address = sess,
+                finish = coalesce(finish, p_t)
+            where address = p_adr and next_for_address is null and id != sess;
+        return sess;
+    end;
+$$;
+
+-- Seed once only, so the file can be re-run after pruning to re-check.
+do $seed$
+    declare
+        t timestamp := '2024-01-01'::timestamp;
+        i integer;
+    begin
+        if exists (select 1 from session) then
+            raise notice 'Already seeded, checking only.';
+            return;
+        end if;
+
+        insert into device (uuid)
+            select gen_random_uuid() from generate_series(1, 6);
+        insert into address (group_id, node_id, device_id)
+            select 'G', 'N', 'D' || g from generate_series(1, 4) g;
+        insert into schema (uuid)
+            select gen_random_uuid() from generate_series(1, 3);
+
+        -- Address 1 runs device 1 then device 2. This is the case that
+        -- broke #614.
+        for i in 1..50 loop
+            perform mk_birth(1, 1, t); t := t + interval '1 hour';
+        end loop;
+        for i in 1..50 loop
+            perform mk_birth(2, 1, t); t := t + interval '1 hour';
+        end loop;
+
+        -- Two devices swapping between two addresses.
+        for i in 1..30 loop
+            perform mk_birth(3, 2, t); t := t + interval '1 hour';
+            perform mk_birth(4, 3, t); t := t + interval '1 hour';
+            perform mk_birth(3, 3, t); t := t + interval '1 hour';
+            perform mk_birth(4, 2, t); t := t + interval '1 hour';
+        end loop;
+
+        -- A device that never moves, and one with a single session.
+        for i in 1..40 loop
+            perform mk_birth(5, 4, t); t := t + interval '1 hour';
+        end loop;
+        perform mk_birth(6, 4, t);
+
+        insert into schema_used (session, schema)
+            select s.id, sc.id from session s cross join schema sc
+            where s.id % 3 = 0
+            on conflict do nothing;
+
+        -- Record what clients can see, so we can prove pruning does not
+        -- change it. Schemas are a set, so store them sorted.
+        create table expected_status as
+            select uuid, group_id, node_id, device_id, online, last_change,
+                (select array_agg(x order by x) from unnest(schemas) x) schemas
+            from device_status;
+    end
+$seed$;
+
+-- Assertions. Every one of these must report 0.
+select 'devices with != 1 current session' check_name,
+        count(*) bad from (
+            select device from session where next_for_device is null
+            group by device having count(*) <> 1) x
+union all
+select 'addresses with != 1 current session', count(*) from (
+            select address from session where next_for_address is null
+            group by address having count(*) <> 1) y
+union all
+select 'dangling next_for_device', count(*) from session s
+    where s.next_for_device is not null
+      and not exists (select 1 from session t where t.id = s.next_for_device)
+union all
+select 'dangling next_for_address', count(*) from session s
+    where s.next_for_address is not null
+      and not exists (select 1 from session t where t.id = s.next_for_address)
+union all
+select 'orphaned schema_used', count(*) from schema_used su
+    where not exists (select 1 from session s where s.id = su.session)
+union all
+select 'device_status rows changed', count(*) from (
+        select uuid, group_id, node_id, device_id, online, last_change,
+            (select array_agg(x order by x) from unnest(schemas) x) schemas
+        from device_status
+        except select * from expected_status) d
+union all
+select 'device_status rows missing', count(*) from (
+        select * from expected_status
+        except select uuid, group_id, node_id, device_id, online, last_change,
+            (select array_agg(x order by x) from unnest(schemas) x) schemas
+        from device_status) e;


### PR DESCRIPTION
## Summary

The Directory has never deleted a `session` row. Every birth inserts one and it stays for the life of the install, along with its `schema_used` rows. On a long-running cluster this reaches millions of rows.

On one long-running install the `directory` database was **5.6 GB** — a 1.8 GB `session` heap plus ~3.8 GB of indexes — against ~10 MB for every other database on the same server. `device_status` joins `session`, so `select * from device_status where uuid = $1` was taking **60–115 seconds**, with all ten of the Directory's pool connections stuck in it simultaneously and Postgres pinned at ~2.9 CPU cores. The user-visible symptoms were the admin UI hanging at login and dashboards showing no data.

### Missing indexes

v8 dropped the `session_device_key` and `session_address_key` unique constraints (`v8.sql:13-14`) and with them the only indexes on those columns. Nothing replaced them, so finding the current session for a device or an address has been a **sequential scan** ever since — and that is exactly the join `device_status` makes. This PR adds both back. They are created after the prune, so they are built against the pruned table rather than the full history.

### Retention

The current session plus the one immediately before it, per device chain and per address chain.

The predecessor is load bearing: `on_session_notify` reads it to compute the `Schema_Usage` symmetric difference, and without it every birth would republish every schema. Nothing else reads history — `sessions()` has been disabled since it was written (*"XXX This endpoint is disabled for now, while I decide what to do about storing the potentially large volume of session history"*), and `device_status`, `is_addr_online` and `addr_uuid` all select the current session only.

**No API changes, and nothing a client can observe changes.** The test asserts `device_status` is byte-identical across the migration.

### Why this is not #614 again

#614 did this and was reverted by #617:

> These changes are not complete. Clearing the session table causes more notifications, which need to be ignored, and also causes FK errors where a previous session still references the session to be deleted.

Both were real, and both are fixed here.

**Foreign keys.** Sessions are chained twice over — `next_for_device` and `next_for_address`, both FKs back into `session`. An address may be reused by a different device, so the chains interleave and a session of device A can be referenced by a session of device B. #614 deleted on `device` alone, which orphans those references. Here a row survives if *either* chain still wants it, and survivors are repointed at the next surviving session before anything is deleted, so no survivor ever references a deleted row. `test/session-prune.sql` builds exactly this shape (address 1 runs device 1 for 50 sessions then device 2 for 50) and asserts there are no dangling pointers afterwards.

**Notifications.** `setup_mqtt_notify('session')` created the trigger `after insert or update or delete`. Deleting sessions therefore emitted notifications naming rows that could no longer be looked up — and `on_session_notify` dereferences the result with no null guard, so those notifications would throw. The trigger now fires on insert and update only, and `on_session_notify` returns early if the session has gone. The migration drops the trigger for its own duration, since repointing chain pointers is bookkeeping no client should hear about.

### Existing installs

The prune runs as part of `v14.sql`, so sites are fixed by upgrading — nothing to run by hand. `Queries.prune_device_sessions` then keeps it bounded as devices are born.

## Test plan

`test/session-prune.sql` seeds a v13 database with interleaved chains, applies v14, and asserts seven invariants. Run instructions are in the file header.

- [x] Full v5→v14 chain applies cleanly to a fresh database
- [x] **261 → 11** sessions on the interleaved fixture; all 7 assertions 0, including `device_status rows changed` and `device_status rows missing`
- [x] No FK errors, no dangling `next_for_device`/`next_for_address`, no orphaned `schema_used`
- [x] Exactly one current session per device and per address afterwards
- [x] `schema_used` cascades (261 → 9)
- [x] Trigger verified as `AFTER INSERT OR UPDATE` only; both new indexes present
- [x] Re-running v14 is a no-op (version guard)
- [x] **Scale:** 500,000 sessions + 500,000 `schema_used` rows → **6.1 s** in a single transaction, pruned to 400, all assertions clean. Extrapolates to roughly a minute on the 1.8 GB install above, which is why this does not need batching.

Tested against `postgres:16` in a local container. Nothing was run against any cluster.

## Notes for review

- Deleted rows leave the space reusable by Postgres but do not return it to the filesystem, and the pre-existing `session_pkey` / `next_for_*` indexes stay bloated until reindexed. On a badly affected install a `vacuum full analyze session; reindex table session;` (Directory down) or `pg_repack` will reclaim it. Neither can run inside a transaction so neither is in the migration — but they are optional, since the table will not grow again.
- Best merged **after** #706, which stops the runaway rebirths that caused the growth. This PR cleans up; #706 stops it recurring.

## Release notes

The Directory now keeps only recent session history rather than a record of every device birth since the system was installed. On long-running installations this removes a large amount of accumulated data, and restores two database indexes that had been missing since ACS v3, which together could make device queries take over a minute, hang the admin UI at login and stop dashboards loading. Existing installations are cleaned up automatically when they upgrade.

