### PR TITLE
deploy: request resources for InfluxDB

### DIFF
--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -658,6 +658,22 @@ grafana:
 
 influxdb2:
   enabled: true
+  # InfluxDB holds the historian data and is on the critical path for
+  # every dashboard. With no resource requests at all it is BestEffort,
+  # which puts it first in line for the kernel OOM killer and first to
+  # be evicted when a node comes under memory pressure - and when it
+  # goes, the historians exit on the failed write and take a while to
+  # come back. Requesting resources moves it to Burstable so it is not
+  # the first thing sacrificed.
+  #
+  # Requests only. InfluxDB's memory use scales with series cardinality,
+  # so a limit that is comfortable on one site will OOM another; set
+  # limits per site if you want a ceiling, but note that a limit which
+  # is too low turns node pressure into a guaranteed restart loop.
+  resources:
+    requests:
+      cpu: 250m
+      memory: 1Gi
   adminUser:
     organization: default
     existingSecret: influxdb-auth


### PR DESCRIPTION
## Summary

Nothing in the ACS chart sets resource requests or limits for anything, so **every ACS pod runs as BestEffort**. BestEffort pods are scored worst by the kernel OOM killer and evicted first when a node comes under memory pressure.

InfluxDB is on the critical path for every dashboard, and when it goes down the historians exit on the failed write rather than retrying.

### What happened

On one production install, InfluxDB was killed with **exit 137** and no limits configured — a node-level OOM kill, not a container limit. The Sparkplug historian died with:

```
ERROR: Write to InfluxDB failed. Error: connect ECONNREFUSED <influxdb-service-ip>:80
node:internal/process/promises:394
    triggerUncaughtException(err, true /* fromPromise */);
```

It took **11 restarts** to settle; the UNS historian took 8.

This PR requests CPU and memory for InfluxDB so it lands in Burstable rather than BestEffort.

### Requests only, deliberately

No memory limit is set. InfluxDB's memory use scales with series cardinality, so a limit that is comfortable on one site will OOM another, and a limit set too low turns transient node pressure into a guaranteed restart loop — strictly worse than today. Sites that want a ceiling can set one themselves; the comment in `values.yaml` says so.

The values chosen (250m CPU, 1Gi memory) are above observed steady-state usage on the affected install (~535 Mi, ~30m CPU) with headroom.

## Test plan

- [x] `helm template` renders the requests into the InfluxDB StatefulSet (verified locally; no cluster contact)
- [ ] Deploy and confirm `kubectl get pod acs-influxdb2-0 -o jsonpath='{.status.qosClass}'` reports `Burstable` rather than `BestEffort`

## Notes for review

This fixes the component that actually got killed, but the underlying gap is chart-wide: **no ACS component sets requests or limits**, so the scheduler has no idea what the stack needs and the whole namespace is equally exposed. Worth a wider pass, but that is a bigger design conversation about sensible defaults per component and I did not want to bundle it here.

## Release notes

InfluxDB now requests CPU and memory from Kubernetes. Previously it was scheduled with no resource reservation at all, which meant that if a node ran short of memory the kernel was likely to kill InfluxDB first, taking the historians down with it and interrupting data collection.

