### PR TITLE
i3X: stop history reads leaking other devices, and validate GET history time bounds

### DIFF
--- a/acs-i3x/lib/api-v1.ts
+++ b/acs-i3x/lib/api-v1.ts
@@ -415,6 +415,9 @@ export class APIv1 {
         if (!startTime || !endTime) {
             return next(badRequest("startTime and endTime query parameters are required"));
         }
+        if(!validator.isRFC3339(startTime) || !validator.isRFC3339(endTime)) {
+            return next(badRequest("startTime and endTime must be an RFC 3339 timestamp"));
+        }
         const values = await this.history.queryHistory(req.params.elementId, startTime, endTime);
         res.json({ elementId: req.params.elementId, values });
     }

--- a/acs-i3x/lib/history.ts
+++ b/acs-i3x/lib/history.ts
@@ -123,40 +123,34 @@ export class History {
 
     /**
      * Build a Flux query for historical data of a leaf metric.
+     *
+     * Returns null when the elementId has no MetricMeta. Without meta we
+     * have no measurement name and no topLevelInstance to filter on, so
+     * there is no safe query to build: the caller-supplied elementId must
+     * never be used as a tag value itself.
      */
     buildFluxQuery(
         elementId: string,
         startTime: string,
         endTime: string,
-    ): string {
+    ): string | null {
         const meta = this.objectTree.getMetricMeta(elementId);
+        if (!meta) return null;
 
-        if (meta) {
-            // Leaf metric with metadata — precise query
-            const measurement = `${meta.metricName}:${meta.typeSuffix}`;
-            const pathFilter = meta.metricPath
-                ? `  |> filter(fn: (r) => r["path"] == "${meta.metricPath}")`
-                : "";
+        const measurement = `${meta.metricName}:${meta.typeSuffix}`;
+        const pathFilter = meta.metricPath
+            ? `  |> filter(fn: (r) => r["path"] == "${meta.metricPath}")`
+            : "";
 
-            return [
-                `from(bucket: "${this.bucket}")`,
-                `  |> range(start: ${startTime}, stop: ${endTime})`,
-                `  |> filter(fn: (r) => r["_measurement"] == "${measurement}")`,
-                `  |> filter(fn: (r) => r["topLevelInstance"] == "${meta.topLevelInstanceUuid}")`,
-                pathFilter,
-                `  |> filter(fn: (r) => r["_field"] == "value")`,
-                `  |> sort(columns: ["_time"])`,
-            ].filter(Boolean).join("\n");
-        }
-
-        // Fallback: use the elementId directly as topLevelInstance UUID
         return [
             `from(bucket: "${this.bucket}")`,
             `  |> range(start: ${startTime}, stop: ${endTime})`,
-            `  |> filter(fn: (r) => r["topLevelInstance"] == "${elementId}")`,
+            `  |> filter(fn: (r) => r["_measurement"] == "${measurement}")`,
+            `  |> filter(fn: (r) => r["topLevelInstance"] == "${meta.topLevelInstanceUuid}")`,
+            pathFilter,
             `  |> filter(fn: (r) => r["_field"] == "value")`,
             `  |> sort(columns: ["_time"])`,
-        ].join("\n");
+        ].filter(Boolean).join("\n");
     }
 
     /**
@@ -174,7 +168,11 @@ export class History {
         const obj = this.objectTree.getObject(elementId);
         if (obj?.isComposition) return [];
 
+        // No MetricMeta means we cannot identify a metric series for this
+        // elementId. Return no data rather than guessing at a filter: a
+        // leaf with no meta is indistinguishable from an unknown element.
         const query = this.buildFluxQuery(elementId, startTime, endTime);
+        if (query === null) return [];
 
         const rows: Array<{ _value: unknown; _time: string }> =
             await this.queryApi.collectRows(query);

--- a/acs-i3x/test/api-v1.test.ts
+++ b/acs-i3x/test/api-v1.test.ts
@@ -663,6 +663,45 @@ describe("APIv1", () => {
 
             expect(res.status).toBe(400);
         });
+
+        it("returns 400 for a non-RFC3339 startTime", async () => {
+            const { app, history } = createApp();
+
+            const res = await request(app)
+                .get("/objects/obj-1/history")
+                .query({ startTime: "-30d)", endTime: "2026-04-01T00:00:00Z" });
+
+            expect(res.status).toBe(400);
+            expect(res.body.success).toBe(false);
+            expect(history.queryHistory).not.toHaveBeenCalled();
+        });
+
+        it("returns 400 for a non-RFC3339 endTime", async () => {
+            const { app, history } = createApp();
+
+            const res = await request(app)
+                .get("/objects/obj-1/history")
+                .query({ startTime: "2026-01-01T00:00:00Z", endTime: "now()" });
+
+            expect(res.status).toBe(400);
+            expect(history.queryHistory).not.toHaveBeenCalled();
+        });
+
+        it("accepts valid RFC 3339 bounds and passes them through", async () => {
+            const { app, history } = createApp();
+            history.queryHistory.mockResolvedValue([sampleVqt]);
+
+            const res = await request(app)
+                .get("/objects/obj-1/history")
+                .query({ startTime: "2026-01-01T00:00:00Z", endTime: "2026-04-01T00:00:00+01:00" });
+
+            expect(res.status).toBe(200);
+            expect(history.queryHistory).toHaveBeenCalledWith(
+                "obj-1",
+                "2026-01-01T00:00:00Z",
+                "2026-04-01T00:00:00+01:00",
+            );
+        });
     });
 
     describe("POST /objects/history", () => {

--- a/acs-i3x/test/history.test.ts
+++ b/acs-i3x/test/history.test.ts
@@ -52,6 +52,22 @@ const INFLUX_URL = "http://influx:8086";
 const INFLUX_TOKEN = "test-token";
 const INFLUX_ORG = "amrc";
 
+/*
+ * MetricMeta for a leaf, keyed by elementId. Anything not in here has
+ * no meta and must not produce a query.
+ */
+function leafMeta(elementId: string, metricName: string = "Temperature") {
+    return new Map([
+        [elementId, {
+            topLevelInstanceUuid: "aaaa-1111-2222-3333",
+            metricPath: "",
+            metricName,
+            sparkplugType: "Double",
+            typeSuffix: "d",
+        }],
+    ]);
+}
+
 function makeHistory(opts?: {
     queryApi?: ReturnType<typeof createMockQueryApi>;
     objectTree?: ObjectTree;
@@ -126,7 +142,7 @@ describe("History", () => {
             expect(query).not.toContain("path");
         });
 
-        it("for a device UUID (no MetricMeta) uses elementId as topLevelInstance", () => {
+        it("returns null for an elementId with no MetricMeta", () => {
             const objectTree = createMockObjectTree();
             const { history } = makeHistory({ objectTree });
 
@@ -136,18 +152,41 @@ describe("History", () => {
                 "2024-01-02T00:00:00Z",
             );
 
-            expect(query).toContain(`r["topLevelInstance"] == "device-uuid-1234"`);
-            expect(query).toContain(`r["_field"] == "value"`);
-            expect(query).not.toContain("_measurement");
+            expect(query).toBeNull();
+        });
+
+        it("never interpolates an unknown elementId into a tag filter", () => {
+            const objectTree = createMockObjectTree();
+            const { history } = makeHistory({ objectTree });
+
+            // A device object UUID is also its InfluxDB topLevelInstance
+            // tag value, so this must not become a query at all.
+            const query = history.buildFluxQuery(
+                "e1f2a3b4-5566-7788-99aa-bbccddeeff00",
+                "2024-01-01T00:00:00Z",
+                "2024-01-02T00:00:00Z",
+            );
+
+            expect(query).toBeNull();
         });
 
         it("includes correct bucket, startTime, and endTime", () => {
-            const { history } = makeHistory();
+            const metricMeta = new Map([
+                ["leaf-element-1", {
+                    topLevelInstanceUuid: "aaaa-1111-2222-3333",
+                    metricPath: "Phases/1",
+                    metricName: "Temperature",
+                    sparkplugType: "FloatLE",
+                    typeSuffix: "d",
+                }],
+            ]);
+            const objectTree = createMockObjectTree({ metricMeta });
+            const { history } = makeHistory({ objectTree });
             const start = "2024-06-01T12:00:00Z";
             const end = "2024-06-02T12:00:00Z";
 
             const query = history.buildFluxQuery(
-                "device-uuid-1234",
+                "leaf-element-1",
                 start,
                 end,
             );
@@ -167,7 +206,10 @@ describe("History", () => {
             ];
             mockQueryApi.collectRows.mockResolvedValue(rows);
 
-            const { history } = makeHistory({ queryApi: mockQueryApi });
+            const objectTree = createMockObjectTree({
+                metricMeta: leafMeta("device-uuid/Temperature"),
+            });
+            const { history } = makeHistory({ queryApi: mockQueryApi, objectTree });
 
             const result = await history.queryHistory(
                 "device-uuid/Temperature",
@@ -197,7 +239,10 @@ describe("History", () => {
             const mockQueryApi = createMockQueryApi();
             mockQueryApi.collectRows.mockResolvedValue([]);
 
-            const { history } = makeHistory({ queryApi: mockQueryApi });
+            const objectTree = createMockObjectTree({
+                metricMeta: leafMeta("device-uuid/Temperature"),
+            });
+            const { history } = makeHistory({ queryApi: mockQueryApi, objectTree });
 
             const result = await history.queryHistory(
                 "device-uuid/Temperature",
@@ -219,7 +264,10 @@ describe("History", () => {
             ];
             mockQueryApi.collectRows.mockResolvedValue(rows);
 
-            const { history } = makeHistory({ queryApi: mockQueryApi });
+            const objectTree = createMockObjectTree({
+                metricMeta: leafMeta("device-uuid/Metric", "Metric"),
+            });
+            const { history } = makeHistory({ queryApi: mockQueryApi, objectTree });
 
             const result = await history.queryHistory(
                 "device-uuid/Metric",
@@ -234,7 +282,10 @@ describe("History", () => {
 
         it("calls collectRows with the correct Flux query", async () => {
             const mockQueryApi = createMockQueryApi();
-            const { history } = makeHistory({ queryApi: mockQueryApi });
+            const objectTree = createMockObjectTree({
+                metricMeta: leafMeta("instance-uuid/Pressure", "Pressure"),
+            });
+            const { history } = makeHistory({ queryApi: mockQueryApi, objectTree });
 
             const elementId = "instance-uuid/Pressure";
             const start = "2024-03-01T00:00:00Z";
@@ -245,6 +296,46 @@ describe("History", () => {
             expect(mockQueryApi.collectRows).toHaveBeenCalledTimes(1);
             const calledQuery = mockQueryApi.collectRows.mock.calls[0][0];
             expect(calledQuery).toBe(history.buildFluxQuery(elementId, start, end));
+        });
+
+        it("returns [] and issues no query for an elementId with no MetricMeta", async () => {
+            const mockQueryApi = createMockQueryApi();
+            const objectTree = createMockObjectTree();
+            const { history } = makeHistory({ queryApi: mockQueryApi, objectTree });
+
+            const result = await history.queryHistory(
+                "e1f2a3b4-5566-7788-99aa-bbccddeeff00",
+                "2024-01-01T00:00:00Z",
+                "2024-01-02T00:00:00Z",
+            );
+
+            expect(result).toEqual([]);
+            expect(mockQueryApi.collectRows).not.toHaveBeenCalled();
+        });
+
+        it("does not read another device's history when its UUID is passed as an elementId", async () => {
+            const mockQueryApi = createMockQueryApi();
+            // The victim device's data, as Influx would return it if the
+            // old fallback filter were still built.
+            mockQueryApi.collectRows.mockResolvedValue([
+                { _value: 99.9, _time: "2024-01-01T00:00:00Z" },
+            ]);
+            // The victim UUID is not in the tree at all, so getObject
+            // returns undefined and the composition guard does not fire:
+            // this is exactly the path the old fallback branch took.
+            const objectTree = createMockObjectTree({
+                metricMeta: leafMeta("mine/Temperature"),
+            });
+            const { history } = makeHistory({ queryApi: mockQueryApi, objectTree });
+
+            const result = await history.queryHistory(
+                "victim-device-uuid",
+                "2024-01-01T00:00:00Z",
+                "2024-01-02T00:00:00Z",
+            );
+
+            expect(result).toEqual([]);
+            expect(mockQueryApi.collectRows).not.toHaveBeenCalled();
         });
     });
 });


### PR DESCRIPTION
Two defects in the `acs-i3x` history path. Both are on the read side of the i3X API and both let a caller reach further into InfluxDB than intended.

## Defect 1: any caller could read any device's history

`History.buildFluxQuery` had a fallback branch. When the requested `elementId` had no `MetricMeta` in the object tree, instead of refusing it built a query filtered on the caller's raw `elementId`:

```
|> filter(fn: (r) => r["topLevelInstance"] == "${elementId}")
```

`queryHistory` only bailed out early when the object was a composition. An `elementId` that is not in the object tree at all has no object, so the composition guard did not fire and the request went straight into the fallback.

That matters because since ConfigDB v13 the device's object UUID, the originMap `Instance_UUID` and the InfluxDB `topLevelInstance` tag are all the same value. So `GET /v1/objects/<any-device-uuid>/history?startTime=...&endTime=...` returned that device's entire history for the window, for every metric it publishes, regardless of whether the caller had any business with that device. The InfluxDB connection uses the **admin** token (`INFLUX_TOKEN` from the `influxdb-auth`/`admin-token` secret, see `deploy/templates/i3x/i3x.yaml`), so nothing further down the stack narrowed it.

It was also the one place a caller-supplied string reached the Flux query text without ever being checked.

The fallback is gone. `buildFluxQuery` now requires `MetricMeta` and returns `null` when there is none.

### Why an empty result rather than a 404

`queryHistory` already returns `[]` for composition objects, on the grounds that history over a composition would be a meaningless mix of child metrics. The no-meta case is the same shape of answer: there is no single metric series to return.

More importantly, from inside `buildFluxQuery` a leaf that genuinely has no meta is indistinguishable from an `elementId` that does not exist at all. If the no-meta case 404'd while a real-but-empty leaf returned `[]`, the response would become an existence oracle over the object tree - a caller could enumerate which UUIDs are real by watching the status code. Returning `[]` for both keeps the two indistinguishable and keeps the route consistent with the composition behaviour that is already there.

A caller who wants to know whether an element exists still has `GET /objects/:elementId`, which 404s properly and is the right place for that question.

## Defect 2: the GET history route did not validate its time bounds

`get_object_history` took `startTime`/`endTime` from `req.query` and passed them into `queryHistory`, where they land inside the Flux `range(start: ..., stop: ...)`. It checked only that they were present.

The bulk `POST /objects/history` route in the same file already did this properly with `validator.isRFC3339`. The same check is now on the GET route, with the same error message and the same `badRequest` call, so the two routes reject the same inputs the same way.

## How to test

1. `cd acs-i3x && npm install && npm test` - 13 suites, 348 tests.
2. Against a running instance, pick a device object UUID that is not one of your own leaf metrics and call `GET /v1/objects/<device-uuid>/history?startTime=2026-01-01T00:00:00Z&endTime=2026-02-01T00:00:00Z`. Before this change you got that device's full history back; now you get `{"elementId": "...", "values": []}`.
3. Call the same route for a real leaf metric elementId with valid bounds. It returns history exactly as before - the precise measurement + `topLevelInstance` + `path` query is unchanged.
4. Call `GET /v1/objects/<leaf>/history?startTime=-30d)&endTime=now()`. You get a 400 with `startTime and endTime must be an RFC 3339 timestamp`.
5. Call `POST /v1/objects/history` with the same bad bounds. Same 400, same message.

## Tests added

In `test/history.test.ts`:
- `buildFluxQuery` returns `null` for an elementId with no `MetricMeta`, and specifically for a device-shaped UUID.
- `queryHistory` returns `[]` and issues **no** Influx query at all for an unknown elementId - `collectRows` is asserted not to have been called, so the query never even reaches the client.
- The existing leaf-with-meta cases still assert the exact same query text as before; the queryHistory tests were given meta so they exercise the real path rather than the deleted fallback.

In `test/api-v1.test.ts`:
- GET history rejects a non-RFC3339 `startTime` and a non-RFC3339 `endTime` with 400, and `queryHistory` is asserted not to have been called.
- GET history accepts valid RFC 3339 bounds, including an offset form (`2026-04-01T00:00:00+01:00`), and passes them through unmodified.

## Test results

```
Test Suites: 13 passed, 13 total
Tests:       348 passed, 348 total
```

Note on flakiness, which predates this branch: `test/e2e.test.ts` fails intermittently, roughly one run in four, on a different assertion each time (`Content-Type headers`, `Cross-endpoint consistency`, `Response envelope compliance`). The failures are always a response body arriving empty on one of several `supertest` requests fired in parallel, on endpoints unrelated to history. I reproduced it on the unmodified base commit as well, so it is a pre-existing test-harness flake rather than anything introduced here. It is not in this PR's scope to fix but somebody should.

## Noticed, not fixed

- `getCurrentValue` correctly requires `MetricMeta`, so the same hole never existed on the value path. Worth knowing when reviewing.
- The `[VALUE]` `console.log` lines in `api-v1.ts` log element ids and values on every request. Out of scope here; I understand logging hygiene is being handled separately.
- `acs-i3x/docs/2026-04-01-acs-i3x.md` still documents the old `buildFluxQuery` signature including the fallback. Left alone to avoid colliding with the docs work in flight.

## Release notes

- **i3X: history could be read for any device.** The i3X history endpoints had a fallback that treated an unrecognised element id as a device identifier and returned that device's full history. Because i3X queries InfluxDB with an administrative token, this let a caller retrieve history for any device on the installation by supplying its UUID. History now requires a known metric and returns an empty result set otherwise.
- **i3X: `GET /v1/objects/:elementId/history` now validates `startTime` and `endTime`.** Both must be RFC 3339 timestamps, matching the existing behaviour of `POST /v1/objects/history`. Malformed bounds now return 400 instead of being passed into the underlying query.
