### PR TITLE
acs-i3x: clear the ground before adding access control

### DIFF
--- a/acs-i3x/bin/api.ts
+++ b/acs-i3x/bin/api.ts
@@ -83,6 +83,7 @@ const api = await new WebAPI({
         subscriptions,
         mcpServer,
         maxDepthCap: parseInt(env.I3X_MAX_DEPTH_CAP || "0"),
+        debug: fplus.debug,
     }),
 }).init();
 

--- a/acs-i3x/lib/api-v1.ts
+++ b/acs-i3x/lib/api-v1.ts
@@ -127,7 +127,17 @@ export class APIv1 {
     setup_routes() {
         /* ---- /info router (unauthenticated) ---- */
 
-        this.infoRoute.get("/info", this.get_info.bind(this));
+        /* The i3X OpenAPI spec types the 200 response of GET /info as
+         * SuccessResponse_ServerInfo_, i.e. { success, result }, the
+         * same as every other non-bulk endpoint. Only the router is
+         * separate here (so /info can bypass auth and the readiness
+         * gate); the envelope still applies.
+         *
+         * The middleware is attached to the route rather than via
+         * `infoRoute.use()`: both routers are mounted on the same /v1
+         * path, so a router-level `use()` here would also run for every
+         * request destined for the main router and wrap it twice. */
+        this.infoRoute.get("/info", i3xEnvelope, this.get_info.bind(this));
 
         /* ---- Main router (authenticated) ---- */
 

--- a/acs-i3x/lib/api-v1.ts
+++ b/acs-i3x/lib/api-v1.ts
@@ -27,6 +27,11 @@ interface APIv1Opts {
      * clamped and the response is returned with HTTP 206.
      */
     maxDepthCap?: number;
+    /**
+     * The service-client Debug object. Used to build the module
+     * logger; omitted in tests, where logging is silenced.
+     */
+    debug?: any;
 }
 
 /**
@@ -68,6 +73,7 @@ export class APIv1 {
     private history: History;
     private subscriptions: SubscriptionManager;
     private maxDepthCap: number;
+    private log: (msg: string, ...args: any[]) => void;
 
     /**
      * Stores the collaborator services and builds both routers.
@@ -78,11 +84,26 @@ export class APIv1 {
         this.history = opts.history;
         this.subscriptions = opts.subscriptions;
         this.maxDepthCap = opts.maxDepthCap ?? 0;
+        this.log = opts.debug?.bound("api-v1") ?? (() => {});
 
         this.routes = Router();
         this.infoRoute = Router();
 
         this.setup_routes();
+    }
+
+    /**
+     * Logs a message against a request. WebAPI installs a buffered
+     * per-request logger on `req.log`, and that buffer is where the
+     * authenticated principal for the request is recorded, so we
+     * prefer it: messages logged this way are attributable. Falls
+     * back to the module logger when there is no request logger (the
+     * unit tests mount the routers on a bare Express app).
+     */
+    private log_req(req: Request, msg: string, ...args: any[]): void {
+        const rlog = (req as any).log;
+        if (rlog) rlog(msg, ...args);
+        else this.log(msg, ...args);
     }
 
     /**
@@ -311,19 +332,20 @@ export class APIv1 {
             // Try UNS cache first (real-time), fall back to InfluxDB last()
             const cached = this.valueCache.getValue(id);
             if (cached) {
-                console.log(`[VALUE] ${id.slice(0,16)} → UNS cache hit: value=${JSON.stringify(cached.value)} age=${Date.now() - new Date(cached.timestamp).getTime()}ms`);
+                this.log_req(req, "value %s: UNS cache hit, age %dms",
+                    id, Date.now() - new Date(cached.timestamp).getTime());
                 return { success: true, elementId: id, result: cached };
             }
-            console.log(`[VALUE] ${id.slice(0,16)} → UNS cache miss, querying InfluxDB...`);
+            this.log_req(req, "value %s: UNS cache miss, querying InfluxDB", id);
             const obj = this.objectTree.getObject(id);
             const item = obj?.isComposition
                 ? await this.history.getCompositionValue(id, effective)
                 : await this.history.getCurrentValue(id);
             if (item) {
-                console.log(`[VALUE] ${id.slice(0,16)} → InfluxDB hit: value=${JSON.stringify(item.value)} ts=${item.timestamp}`);
+                this.log_req(req, "value %s: InfluxDB hit, ts %s", id, item.timestamp);
                 return { success: true, elementId: id, result: item };
             }
-            console.log(`[VALUE] ${id.slice(0,16)} → no data`);
+            this.log_req(req, "value %s: no data", id);
             return { success: false, elementId: id, error: { code: 404, message: `No value for ${id}` } };
         }));
         if (clamped) res.status(206);
@@ -390,18 +412,20 @@ export class APIv1 {
         // Try UNS cache first (real-time), fall back to InfluxDB last()
         const cached = this.valueCache.getValue(id);
         if (cached) {
-            console.log(`[VALUE] ${id} → UNS cache hit: value=${JSON.stringify(cached.value)} ts=${cached.timestamp} age=${Date.now() - new Date(cached.timestamp).getTime()}ms`);
+            this.log_req(req, "value %s: UNS cache hit, ts %s, age %dms",
+                id, cached.timestamp,
+                Date.now() - new Date(cached.timestamp).getTime());
             res.json(cached);
             return;
         }
-        console.log(`[VALUE] ${id} → UNS cache miss, querying InfluxDB...`);
+        this.log_req(req, "value %s: UNS cache miss, querying InfluxDB", id);
         const result = obj?.isComposition
             ? await this.history.getCompositionValue(id)
             : await this.history.getCurrentValue(id);
         if (result) {
-            console.log(`[VALUE] ${id} → InfluxDB hit: value=${JSON.stringify(result.value)} ts=${result.timestamp}`);
+            this.log_req(req, "value %s: InfluxDB hit, ts %s", id, result.timestamp);
         } else {
-            console.log(`[VALUE] ${id} → InfluxDB miss: no data`);
+            this.log_req(req, "value %s: InfluxDB miss, no data", id);
         }
         if (!result) return next(notFound(`No value for ${id}`));
         res.json(result);

--- a/acs-i3x/lib/routes.ts
+++ b/acs-i3x/lib/routes.ts
@@ -14,6 +14,7 @@ export function routes(opts: {
     subscriptions: SubscriptionManager;
     mcpServer?: McpServer;
     maxDepthCap?: number;
+    debug?: any;
 }) {
     const api = new APIv1(opts);
 

--- a/acs-i3x/test/api-v1.test.ts
+++ b/acs-i3x/test/api-v1.test.ts
@@ -167,13 +167,16 @@ describe("APIv1", () => {
 
             expect(res.status).toBe(200);
             expect(res.body).toEqual({
-                specVersion: I3X_SPEC_VERSION,
-                serverName: "AMRC Connectivity Stack",
-                serverVersion: Version,
-                capabilities: {
-                    query: { history: true },
-                    update: { current: false, history: false },
-                    subscribe: { stream: true },
+                success: true,
+                result: {
+                    specVersion: I3X_SPEC_VERSION,
+                    serverName: "AMRC Connectivity Stack",
+                    serverVersion: Version,
+                    capabilities: {
+                        query: { history: true },
+                        update: { current: false, history: false },
+                        subscribe: { stream: true },
+                    },
                 },
             });
         });
@@ -183,7 +186,8 @@ describe("APIv1", () => {
             const res = await request(app).get("/info");
 
             expect(res.status).toBe(200);
-            expect(res.body.capabilities.query).toEqual({
+            expect(res.body.success).toBe(true);
+            expect(res.body.result.capabilities.query).toEqual({
                 history: true,
                 maxDepthCap: 5,
             });
@@ -193,7 +197,7 @@ describe("APIv1", () => {
             const { app } = createApp();
             const res = await request(app).get("/info");
 
-            expect(res.body.capabilities.query).not.toHaveProperty("maxDepthCap");
+            expect(res.body.result.capabilities.query).not.toHaveProperty("maxDepthCap");
         });
     });
 
@@ -217,6 +221,7 @@ describe("APIv1", () => {
             const res = await request(app).get("/info");
 
             expect(res.status).toBe(200);
+            expect(res.body.success).toBe(true);
         });
     });
 

--- a/acs-i3x/test/e2e.test.ts
+++ b/acs-i3x/test/e2e.test.ts
@@ -347,7 +347,8 @@ describe("E2E Compliance Tests", () => {
             expect(res.status).toBe(200);
             expect(res.headers["content-type"]).toMatch(/application\/json/);
 
-            const info = res.body;
+            expect(res.body).toHaveProperty("success", true);
+            const info = res.body.result;
             expect(info).toHaveProperty("specVersion");
             expect(info).toHaveProperty("serverName");
             expect(info).toHaveProperty("serverVersion");
@@ -362,7 +363,7 @@ describe("E2E Compliance Tests", () => {
             const { app } = createE2eApp();
             const res = await request(app).get("/v1/info");
 
-            const caps = res.body.capabilities;
+            const caps = res.body.result.capabilities;
             expect(caps.query.history).toBe(true);
             expect(caps.update.current).toBe(false);
             expect(caps.subscribe.stream).toBe(true);
@@ -372,8 +373,8 @@ describe("E2E Compliance Tests", () => {
             const { app } = createE2eApp();
             const res = await request(app).get("/v1/info");
 
-            expect(res.body.specVersion).toBe(I3X_SPEC_VERSION);
-            expect(res.body.serverVersion).toBe(Version);
+            expect(res.body.result.specVersion).toBe(I3X_SPEC_VERSION);
+            expect(res.body.result.serverVersion).toBe(Version);
         });
     });
 
@@ -785,7 +786,8 @@ describe("E2E Compliance Tests", () => {
             const res = await request(app).get("/v1/info");
 
             expect(res.status).toBe(200);
-            expect(res.body.capabilities.query).toEqual({
+            expect(res.body.success).toBe(true);
+            expect(res.body.result.capabilities.query).toEqual({
                 history: true,
                 maxDepthCap: 4,
             });
@@ -1155,9 +1157,8 @@ describe("E2E Compliance Tests", () => {
         it("every success response has { success: true, result: ... }", async () => {
             const { app } = createE2eApp();
 
-            /* /v1/info is excluded: the info route does not use the
-               envelope middleware and returns raw data. */
             const responses = await Promise.all([
+                request(app).get("/v1/info"),
                 request(app).get("/v1/namespaces"),
                 request(app).get("/v1/objecttypes"),
                 request(app).get("/v1/objecttypes/type-cnc"),
@@ -1268,7 +1269,8 @@ describe("E2E Compliance Tests", () => {
 
             const res = await request(app).get("/v1/info");
             expect(res.status).toBe(200);
-            expect(res.body).toHaveProperty("specVersion");
+            expect(res.body).toHaveProperty("success", true);
+            expect(res.body.result).toHaveProperty("specVersion");
         });
     });
 

--- a/deploy/templates/i3x/i3x.yaml
+++ b/deploy/templates/i3x/i3x.yaml
@@ -47,6 +47,8 @@ spec:
               value: i3x.{{ .Release.Namespace }}.svc.cluster.local
             - name: REALM
               value: {{ .Values.identity.realm | required "values.identity.realm is required!" }}
+            - name: ROOT_PRINCIPAL
+              value: admin@{{ .Values.identity.realm | required "values.identity.realm is required!" }}
 {{ include "amrc-connectivity-stack.oidc-env" . | indent 12 }}
             - name: SPARKPLUG_ADDRESS
               value: {{ .Values.acs.organisation | required "values.acs.organisation is required!" }}-Service-Core/i3X

--- a/docs/auth/oauth-clients.md
+++ b/docs/auth/oauth-clients.md
@@ -257,17 +257,43 @@ Use this when authorization is dynamic, fine-grained, or per-object
 
 1. Reads `fp_principal_uuid` from the JWT.
 2. Calls the F+ auth service (e.g. `GET /authz/acl`) on behalf of
-   the user. Either:
-   - mint a service-to-service token and ask "what can principal
-     `<uuid>` do?" - acs-i3x is taking this approach, or
-   - support the OAuth2 token-exchange flow once the i3x shim work
-     lands (planned, not yet shipped).
+   the user, by minting a service-to-service token and asking "what
+   can principal `<uuid>` do?".
 3. Caches the answer for whatever TTL fits the app's freshness
    needs.
+
+OAuth2 token exchange is not supported by the F+ auth service today,
+so a service-to-service call is the only option for Option B.
 
 Either option avoids the duplicate-source-of-truth problem that
 existed before this branch (where Keycloak roles and F+ ACLs had to
 be administered separately).
+
+#### What acs-i3x does today
+
+`acs-i3x` is **not** an example of either option. It authenticates
+callers and then serves them the whole object tree.
+
+Authentication is the shared `FplusHttpAuth` middleware from
+`@amrc-factoryplus/service-api`, so it accepts:
+
+- Kerberos, via `Negotiate` or via `Basic` with a UPN and password;
+- an opaque bearer token obtained from `POST /token`;
+- a Keycloak-issued JWT carrying `fp_principal_uuid`.
+
+`GET /v1/info` is public; every other endpoint requires one of the
+above.
+
+There is currently **no authorization**. `acs-i3x` performs no ACL
+check and does not consult the F+ auth service about the calling
+principal, so any principal that authenticates can read every object,
+value, history series and subscription the service exposes. Per-object
+access control is not yet implemented.
+
+The practical consequence: a credential handed to an acs-i3x consumer
+is not scoped by Factory+ ACLs. Treat it as granting read access to
+the whole tree, and scope it by deciding who gets the credential at
+all.
 
 ## Worked example: minimal Express + openid-client
 


### PR DESCRIPTION
Four preparatory fixes ahead of adding access control to `acs-i3x`. **No enforcement is added here** - the service still authorizes nothing. This clears the ground so the enforcement PR is a single, reviewable change.

## 1. The OAuth guide described authorization that does not exist

`docs/auth/oauth-clients.md` cited `acs-i3x` as an example of "Option B - call back into Factory+ with the user's identity", specifically minting a service-to-service token and asking "what can principal `<uuid>` do?".

That is false. `grep -rn "check_acl\|fetch_acl\|req.auth" acs-i3x/lib acs-i3x/bin` returns nothing. This is the harmful direction to be wrong in: it would lead an integrator to assume a shared acs-i3x credential is scoped by Factory+ ACLs when it grants read access to the entire object tree.

Replaced with a "What acs-i3x does today" subsection that states what the service actually does:

- authenticates via the shared `FplusHttpAuth` middleware - Kerberos (`Negotiate`, or `Basic` with UPN + password), an opaque bearer from `POST /token`, or a Keycloak JWT carrying `fp_principal_uuid`;
- `GET /v1/info` is public, everything else requires auth;
- performs **no** ACL check and never consults the auth service about the caller. Per-object access control is not yet implemented.

No date promised, and no overclaiming the other way - the service does authenticate.

Other claim fixed in the same file: the guide offered OAuth2 token exchange as an alternative under Option B, "once the i3x shim work lands". The F+ auth service does not implement token exchange today, so that has been replaced with a plain statement that a service-to-service call is the only option.

## 2. `ROOT_PRINCIPAL` on the i3x deployment

`deploy/templates/i3x/i3x.yaml` was the only ACL-relevant service without it. Added `admin@{{ .Values.identity.realm }}`, copying `deploy/templates/data-access/data-access.yaml` exactly.

**The point worth not losing:** the client-side root bypass in `lib/js-service-client/lib/service/auth.js` (`fetch_acl`, ~line 141) is **Kerberos-UPN-only**:

```js
if (this.root_principal
    && type == "kerberos"
    && principal == this.root_principal
) {
```

`FplusHttpAuth.auth_jwt` sets `req.auth` to the `fp_principal_uuid` claim, which decodes as a `uuid`-type principal, not `kerberos`. So a Keycloak-authenticated administrator can **never** hit the root bypass, no matter what `ROOT_PRINCIPAL` is set to. Once enforcement lands, the admin either authenticates with Kerberos to get root, or needs an explicit ACL grant against their principal UUID. This should be decided deliberately in the enforcement PR rather than discovered in the field.

## 3. Metric values in stdout at info level

`acs-i3x/lib/api-v1.ts` printed value-lookup traces with raw `console.log`, including the metric values themselves - real plant data landing in cluster logs.

Two fixes:

- **Values removed from the messages.** Kept element id, cache hit/miss, source, and the source timestamp, which is what these were actually useful for when debugging a stale reading.
- **Routed through the request logger.** `WebAPI` installs a buffered per-request logger on `req.log` (`lib/js-service-api/lib/webapi.js` ~54-67), and that buffer is where `FplusHttpAuth` records the authenticated principal. `console.log` bypasses it entirely, so the messages were unattributable. A small `log_req` helper prefers `req.log` and falls back to a house-pattern `opts.fplus.debug.bound("api-v1")` module logger, which is what the unit tests hit (they mount the routers on a bare Express app with no `req.log`).

`debug` is plumbed `bin/api.ts` -> `routes()` -> `APIv1` as `fplus.debug`, matching how `ObjectTree` already takes its logger.

## 4. `GET /v1/info` envelope - reasoning

**Conclusion: the spec requires the envelope. The bug was in acs-i3x, not acs-admin.**

`acs-admin/src/composables/useI3xClient.js` unwraps `body.result` for every call including `getInfo()`, and was getting `undefined`. Two candidate fixes; I checked rather than assumed.

The evidence:

- The in-repo notes are ambiguous. `acs-i3x/docs/design.md` says "Express middleware wraps **all** responses in the i3X envelope" and `pitch.md` item 10 says "All responses wrapped in `{ success: true, result: ... }`" - but `pitch.md` item 2 shows the `GET /info` example as a bare object, which is presumably where the implementation took its cue.
- The authority is the i3X OpenAPI spec (`https://api.i3x.dev/v0/openapi.json`). It types the 200 response of `GET /info` as `SuccessResponse_ServerInfo_`, i.e. `{ success, result: ServerInfo }` - the same `SuccessResponse` wrapper used by `/namespaces`, `/objecttypes`, `/objects/{id}/value` and the rest. The only genuinely un-enveloped responses in the spec are `PUT /objects/{id}/history` and `POST /subscriptions/stream`, both of which return `{}`.

So `/info` is enveloped like everything else. The separate `infoRoute` exists only so `/info` can bypass auth and the readiness gate, which is orthogonal to the response shape - the envelope should always have applied to it.

One implementation detail worth a look during review: the middleware is attached **to the route**, not via `infoRoute.use()`. Both routers are mounted on `/v1`, so a router-level `use()` on `infoRoute` runs for every request destined for the main router too and double-wraps them. I hit exactly this - 91 test failures - before switching to the per-route form.

No change to `acs-admin`; its unwrapping was already correct and now gets a defined value.

## Test results

Full `acs-i3x` suite, after the change:

```
Test Suites: 13 passed, 13 total
Tests:       342 passed, 342 total
Snapshots:   0 total
Time:        3.517 s
```

Baseline on the unmodified tree was also 13/13 and 342/342, so nothing was already failing and nothing regressed. `npx tsc --noEmit` is clean.

Test changes: `test/api-v1.test.ts` and `test/e2e.test.ts` updated for the new `/info` shape, and `/v1/info` **added** to the "every success response has `{ success: true, result }`" compliance sweep in `e2e.test.ts` - it was previously excluded with a comment explaining that the info route returns raw data. That exclusion is now gone.

`acs-i3x/dist/` is gitignored (root `.gitignore`, `dist/`) and not tracked, so no rebuild was needed.

## Helm

`helm lint` and `helm template` both pass and the deployment renders `ROOT_PRINCIPAL: admin@EXAMPLE.COM`. Rendered from a scratch copy of the chart with the `dependencies:` block stripped, because the subcharts (traefik, grafana, influxdb2, cert-manager) are not vendored into `deploy/charts/`. No command was run against a live cluster.

## Noticed, not fixed

- `acs-i3x/lib/subscriptions.ts` has the same problem as item 3: seven raw `console.log` calls, and the one at line 216 prints `value=${JSON.stringify(vqt.value)}` for every SSE frame - i.e. plant data on the hot path, at higher volume than the ones fixed here. Left alone because another agent is working in that file.
- `acs-i3x/docs/design.md` (~line 262) claims "ACL checks via `Auth.check_acl()` per request" under Authentication. Same false claim as item 1, in the service's own design doc. Out of scope for this PR, which was scoped to `docs/auth/oauth-clients.md`, but it should be corrected by whoever lands enforcement - by which point it may become true.
- `deploy/templates/i3x/i3x.yaml` hardcodes `VERBOSE: ALL`, unlike siblings which template it from a `verbosity` value. With `ALL` every debug tag prints, so the new `api-v1` logger will be verbose in production. Worth templating, but it is a values-schema change and did not belong in this PR.

## How to test

1. `cd acs-i3x && npm install && npm test` - expect 13 suites, 342 tests, all passing.
2. `npx tsc --noEmit` - expect no output.
3. Envelope, by hand: start the service and `curl -s http://i3x.<baseUrl>/v1/info | jq`. Expect `{ "success": true, "result": { "specVersion": ..., "serverName": ..., "capabilities": {...} } }`, not a bare object.
4. Confirm nothing else double-wrapped: `curl -s -u <user> http://i3x.<baseUrl>/v1/namespaces | jq` - expect `{ success: true, result: [...] }` with `result` an array, **not** `result.result`.
5. acs-admin: open the i3X tree view. `getInfo()` now resolves to the server info object instead of `undefined`.
6. Logging: request a value (`GET /v1/objects/<id>/value`) and check the pod logs. Expect lines like `value <elementId>: UNS cache hit, ts ..., age 1234ms`, grouped with the `>>> GET ...` / `Auth succeeded for [...]` lines for that request. Expect **no** metric values in the output.
7. Deployment: `helm template` the chart and confirm the i3x Deployment carries `ROOT_PRINCIPAL: admin@<your realm>`.
8. Docs: read the "What acs-i3x does today" subsection in `docs/auth/oauth-clients.md` and check it matches your reading of the code.

## Release notes

- **`acs-i3x`: `GET /v1/info` now returns the i3X success envelope.** The endpoint previously returned the bare server-info object while every other endpoint returned `{ success, result }`. This is a breaking change for any client that read `specVersion` and friends off the top level of the response; read them from `.result` instead. The ACS admin UI already expected the enveloped form and was receiving `undefined` from this route.
- **`acs-i3x`: metric values are no longer written to the service log.** Value lookups were logged with the process value included. They now log the element id, cache hit/miss and source timestamp only, and go through the standard per-request logger so entries are attributable to the authenticated caller.
- **`acs-i3x`: `ROOT_PRINCIPAL` is now set on the deployment**, matching every other ACL-checking ACS service. No behavioural change today, since acs-i3x performs no ACL checks; this prepares for access control being added.
- **Documentation:** the OAuth client integration guide previously stated that acs-i3x authorizes callers against Factory+ ACLs. It does not. The guide now states plainly that acs-i3x authenticates callers but does not authorize them, and that any principal that authenticates can read the whole object tree. If you have issued an acs-i3x credential on the assumption that F+ ACLs scoped it, review who holds it.
