### PR TITLE
Directory: don't add a duplicate index in the v14 migration

### DIFF
--- a/acs-directory/sql/v14.sql
+++ b/acs-directory/sql/v14.sql
@@ -15,7 +15,7 @@ call migrate_to(14, $migrate$
     -- outside world is concerned. It goes back on at the end, without
     -- the DELETE, because a notification naming a pruned session
     -- refers to a row which can no longer be looked up.
-    drop trigger mqtt_notify on session;
+    drop trigger if exists mqtt_notify on session;
 
     -- What to keep: for each device, and for each address, the current
     -- session and the one before it. The predecessor is load bearing -
@@ -87,8 +87,15 @@ call migrate_to(14, $migrate$
     --
     -- Built after the prune, so they are built against the pruned
     -- table rather than the full history.
-    create index on session (device);
-    create index on session (address);
+    --
+    -- Named explicitly and guarded, because an operator who noticed
+    -- device queries crawling may well have added one of these by
+    -- hand already. An unnamed CREATE INDEX picks the same name
+    -- Postgres would have generated, collides, and takes the whole
+    -- migration - prune included - down with it. IF NOT EXISTS needs
+    -- the name to have something to test, so the two go together.
+    create index if not exists session_device_idx  on session (device);
+    create index if not exists session_address_idx on session (address);
 
     create trigger mqtt_notify
         after insert or update on session


### PR DESCRIPTION
## Summary

`v14.sql` created its two indexes with unnamed `CREATE INDEX`. If an install already has an index on `session (device)` — which is the obvious thing for an operator to add when device queries start taking a minute — Postgres does **not** error. It appends a digit and creates `session_device_idx1` alongside the existing `session_device_idx`.

The result is two identical indexes on the same column, both maintained on every insert, for no benefit. On the very table this migration exists to shrink.

Naming them explicitly and guarding with `IF NOT EXISTS` fixes it. The two changes go together: `IF NOT EXISTS` needs a name to test against, so an unnamed `CREATE INDEX ... IF NOT EXISTS` is not valid.

The trigger drop is now `DROP TRIGGER IF EXISTS` for the same reason — the migration shouldn't care whether someone has been in there before it.

## How this was found

Taking a pre-upgrade `pg_dump` of an affected install and reading the TOC:

```
3306; 1259 40258 INDEX public session_device_idx
3307; 1259 16591 INDEX public session_next_for_address_idx
3308; 1259 16590 INDEX public session_next_for_device_idx
```

`session_device_idx` is present with a much later OID than its neighbours — added by hand well after the schema was created. `session_address_idx` is absent, so only one of the two collides.

The scale tests never caught this because they build the database from the migration chain, where neither index pre-exists.

## Test plan

Reproduced against `postgres:16` with a database seeded to v13 and a hand-added `session (device)` index, matching the affected install:

- [x] **Before the fix**: migration succeeds but leaves `session_device_idx` *and* `session_device_idx1`, both `btree (device)`
- [x] **After the fix**: `NOTICE: relation "session_device_idx" already exists, skipping`, no duplicate, migration completes, sessions pruned 261 → 11
- [x] All 7 invariants still 0, including `device_status rows changed` / `rows missing`
- [x] Clean chain v5→v14 on a fresh database still produces exactly `session_device_idx` and `session_address_idx`
- [x] Re-running v14 is still a no-op

## Note

This is a correctness/efficiency fix, not a blocker — v14 as shipped in `v6.6.0-rc.1` completes successfully either way. It just leaves a redundant index behind on installs that had one already.
