### PR TITLE
admin: fix the CSP blocking the console

### DIFF
--- a/acs-admin/.docker/nginx.conf
+++ b/acs-admin/.docker/nginx.conf
@@ -31,11 +31,31 @@ server {
     }
 
     location / {
-        # connect-src is open because the console's service URLs are injected
-        # at deploy time by import-meta-env and are not known at build time.
-        # frame-src is 'self' so the only thing the console can frame is the
-        # driver UI shell above.
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src *; worker-src 'self' blob:; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'" always;
+        # The console's own policy. Read the next three paragraphs before
+        # tightening any of it, because the obvious tightening breaks the app.
+        #
+        # script-src has to allow 'unsafe-inline'. index.html carries two
+        # inline scripts: Monaco's worker environment, injected at build, and
+        # the environment block that import-meta-env rewrites when the
+        # container starts. Hashes cannot cover the second one, since its
+        # content depends on deployment values, and a nonce needs a server
+        # that renders the page rather than nginx serving a static file.
+        # Note that 'unsafe-inline' also disables any hash or nonce, so there
+        # is no point adding either alongside it.
+        #
+        # So this policy does NOT protect against script injection. What it
+        # still does is worth keeping: frame-ancestors stops clickjacking,
+        # object-src kills plugin content, base-uri stops base-tag injection,
+        # form-action stops form exfiltration, and frame-src 'self' means the
+        # only thing the console can frame is the driver UI shell above,
+        # which is the part that actually matters for driver UIs.
+        #
+        # kit.fontawesome.com serves the icon kit, which index.html loads
+        # directly and which then pulls its CSS and fonts from sibling hosts
+        # under the same domain. connect-src is open because the console's
+        # service URLs are injected at deploy time and are not known at build
+        # time. worker-src needs blob: for Monaco's editor workers.
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://*.fontawesome.com; style-src 'self' 'unsafe-inline' https://*.fontawesome.com; img-src 'self' data: blob:; font-src 'self' data: https://*.fontawesome.com; connect-src * data: blob:; worker-src 'self' blob:; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "same-origin" always;
 


### PR DESCRIPTION
Regression from 6.7.0, mine, found on a live cluster. The CSP I added blocked the console it was supposed to protect.

## What broke

`script-src 'self'` blocked three things the console needs:

```
✗ Executing inline script violates ... 'script-src 'self''   (×2)
✗ Loading the script 'https://kit.fontawesome.com/...' violates ...
```

Icons disappeared and Monaco's worker setup never ran.

## Why `'unsafe-inline'` is unavoidable

`index.html` carries two inline scripts. One is Monaco's worker environment, injected at build. The other is the environment block that `import-meta-env` rewrites **when the container starts**, so its content varies per deployment and no build-time hash can cover it. A nonce needs a server that renders the page, and nginx here serves a static file.

Since `'unsafe-inline'` also disables any hash or nonce, adding either alongside would achieve nothing.

## What this policy is now honestly worth

It **no longer protects against script injection**, and the config says so plainly instead of implying otherwise. What survives is still worth keeping:

- `frame-ancestors 'none'` — clickjacking
- `object-src 'none'` — plugin content
- `base-uri 'self'` — base-tag injection
- `form-action 'self'` — form exfiltration
- `frame-src 'self'` — the only frameable thing is the driver UI shell

**The shell's own `default-src 'none'` policy is untouched.** That is the one that actually contains driver UIs, stopping a vendor's document from reaching the network at all, and none of this weakens it.

## The check I should have written first

I verified the header was *present* before shipping, and never loaded the console *under* it. There is now a check that drives the built image in a real browser and counts violations:

| Image | CSP violations | Font Awesome loads |
|---|---|---|
| 6.7.0 | **3** | ✗ |
| This branch | **0** | ✓ |

It reproduces the exact three failures against the shipped image, so it can fail rather than just agreeing with me.

## Scope

One file, `acs-admin/.docker/nginx.conf`. Nothing to do with the driver. The Sparkplug type regression from the same release is separate, in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
