### PR TITLE
admin: drop 'unsafe-inline' from the console CSP

### DIFF
--- a/acs-admin/.docker/nginx.conf
+++ b/acs-admin/.docker/nginx.conf
@@ -31,31 +31,33 @@ server {
     }
 
     location / {
-        # The console's own policy. Read the next three paragraphs before
-        # tightening any of it, because the obvious tightening breaks the app.
+        # The console's own policy. script-src carries no 'unsafe-inline',
+        # which means it genuinely protects against script injection, and
+        # keeping it that way costs a little care elsewhere.
         #
-        # script-src has to allow 'unsafe-inline'. index.html carries two
-        # inline scripts: Monaco's worker environment, injected at build, and
-        # the environment block that import-meta-env rewrites when the
-        # container starts. Hashes cannot cover the second one, since its
-        # content depends on deployment values, and a nonce needs a server
-        # that renders the page rather than nginx serving a static file.
-        # Note that 'unsafe-inline' also disables any hash or nonce, so there
-        # is no point adding either alongside it.
+        # index.html must stay free of inline scripts. It had two. The
+        # environment block now lives in public/env.js, loaded as an ordinary
+        # same-origin file, because import-meta-env rewrites it when the
+        # container starts and no build-time hash could ever cover content
+        # that varies per deployment. Monaco's worker environment is now set
+        # in src/main.js, inside the bundle, and a plugin in vite.config.js
+        # strips the copy vite-plugin-monaco-editor-esm injects. That plugin
+        # fails the build if the injection ever stops matching, so this
+        # cannot rot silently.
         #
-        # So this policy does NOT protect against script injection. What it
-        # still does is worth keeping: frame-ancestors stops clickjacking,
-        # object-src kills plugin content, base-uri stops base-tag injection,
-        # form-action stops form exfiltration, and frame-src 'self' means the
-        # only thing the console can frame is the driver UI shell above,
-        # which is the part that actually matters for driver UIs.
+        # Adding an inline script anywhere in index.html will break the
+        # console. Put it in a file under public/ instead.
+        #
+        # style-src still needs 'unsafe-inline': Vue's scoped styles and the
+        # Font Awesome kit both inject style elements at runtime. Inline
+        # style is a far smaller problem than inline script.
         #
         # kit.fontawesome.com serves the icon kit, which index.html loads
         # directly and which then pulls its CSS and fonts from sibling hosts
         # under the same domain. connect-src is open because the console's
         # service URLs are injected at deploy time and are not known at build
         # time. worker-src needs blob: for Monaco's editor workers.
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://*.fontawesome.com; style-src 'self' 'unsafe-inline' https://*.fontawesome.com; img-src 'self' data: blob:; font-src 'self' data: https://*.fontawesome.com; connect-src * data: blob:; worker-src 'self' blob:; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://*.fontawesome.com; style-src 'self' 'unsafe-inline' https://*.fontawesome.com; img-src 'self' data: blob:; font-src 'self' data: https://*.fontawesome.com; connect-src * data: blob:; worker-src 'self' blob:; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "same-origin" always;
 

--- a/acs-admin/Dockerfile
+++ b/acs-admin/Dockerfile
@@ -41,4 +41,7 @@ COPY .docker/nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 8080
 
 # Start Nginx
-CMD ["sh", "-c", "./import-meta-env-alpine -x .env -p /usr/share/nginx/html/index.html && nginx -g 'daemon off;'"]
+# Substitute into env.js, not index.html. The environment lives in its own
+# file so the console needs no inline script and can run under a CSP with no
+# 'unsafe-inline'; see public/env.js and .docker/nginx.conf.
+CMD ["sh", "-c", "./import-meta-env-alpine -x .env -p /usr/share/nginx/html/env.js && nginx -g 'daemon off;'"]

--- a/acs-admin/index.html
+++ b/acs-admin/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <script>
-      globalThis.import_meta_env = JSON.parse('"import_meta_env_placeholder"')
-    </script>
+    <!-- Deployment environment. A separate file rather than an inline script
+       - so the console can run without 'unsafe-inline'; see public/env.js. -->
+    <script src="/env.js"></script>
     <link rel="icon" href="/favicon.svg">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AMRC Connectivity Stack</title>

--- a/acs-admin/public/env.js
+++ b/acs-admin/public/env.js
@@ -1,0 +1,16 @@
+/* Deployment environment, substituted at container start.
+ *
+ * This lives in its own file rather than inline in index.html so the console
+ * can run under a Content-Security-Policy with no 'unsafe-inline'. The
+ * placeholder below is rewritten by import-meta-env when the container
+ * starts, which means its content differs per deployment and no build-time
+ * hash could ever cover it. As a separate same-origin file it needs neither
+ * a hash nor an exemption.
+ *
+ * Loaded as a classic script in <head>, so it runs before the deferred
+ * application module and globalThis.import_meta_env is set by the time
+ * anything reads it.
+ *
+ * See acs-admin/.docker/nginx.conf and the CMD in the Dockerfile.
+ */
+globalThis.import_meta_env = JSON.parse('"import_meta_env_placeholder"')

--- a/acs-admin/src/main.js
+++ b/acs-admin/src/main.js
@@ -4,6 +4,31 @@
 
 import './assets/main.css'
 
+/* Where Monaco finds its web workers.
+ *
+ * vite-plugin-monaco-editor-esm normally injects this as an inline script in
+ * index.html, which would force the console's CSP to allow 'unsafe-inline'.
+ * Setting it here instead puts it in the bundle, which is same-origin, and
+ * a small plugin in vite.config.js strips the injected copy. The plugin is
+ * still needed: it emits the worker bundles these paths point at.
+ *
+ * The plugin's version also carried a blob: fallback for workers served from
+ * another origin. These are all local, so that path was dead code and is not
+ * reproduced here.
+ */
+const MONACO_WORKERS = {
+  editorWorkerService: '/monacoeditorwork/editor.worker.bundle.js',
+  json:                '/monacoeditorwork/json.worker.bundle.js',
+  yaml:                '/monacoeditorwork/monaco-yaml.bundle.js',
+}
+
+self.MonacoEnvironment = {
+  globalAPI: true,
+  getWorkerUrl (moduleId, label) {
+    return MONACO_WORKERS[label] ?? MONACO_WORKERS.editorWorkerService
+  },
+}
+
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import piniaPersist from 'pinia-plugin-persist'

--- a/acs-admin/vite.config.js
+++ b/acs-admin/vite.config.js
@@ -17,6 +17,39 @@ import monacoEditorEsmPlugin from 'vite-plugin-monaco-editor-esm'
 const EMPTY = path.resolve(__dirname, './emptyModule.js');
 const src = d => fileURLToPath(new URL(`./src/${d}`, import.meta.url));
 
+/* Remove the inline script vite-plugin-monaco-editor-esm injects.
+ *
+ * The plugin has no option to skip it, and an inline script would force the
+ * console's Content-Security-Policy to allow 'unsafe-inline', which disables
+ * hashes and nonces along with it. src/main.js sets MonacoEnvironment
+ * instead, from inside the bundle.
+ *
+ * Only the HTML injection goes. The plugin's writeBundle still emits the
+ * worker files those paths point at, so it stays in the plugin list.
+ *
+ * Runs at enforce: 'post' so it sees the plugin's output. If the plugin ever
+ * stops injecting, or renames the global, the build fails loudly rather than
+ * silently leaving an inline script behind for the CSP to trip over.
+ */
+function stripMonacoInlineScript () {
+  const MARKER = 'self["MonacoEnvironment"]';
+  return {
+    name: 'acs-strip-monaco-inline-script',
+    enforce: 'post',
+    transformIndexHtml (html) {
+      const re = /<script>[^<]*self\["MonacoEnvironment"\][\s\S]*?<\/script>/;
+      if (!re.test(html)) {
+        throw new Error(
+          `acs-strip-monaco-inline-script: no script containing ${MARKER} `
+          + `found in index.html. The Monaco plugin's injection has changed; `
+          + `check whether src/main.js still needs to define MonacoEnvironment, `
+          + `and whether the worker paths there are still correct.`);
+      }
+      return html.replace(re, '');
+    },
+  };
+}
+
 // https://vitejs.dev/config/
 export default defineConfig({
   define: {
@@ -45,7 +78,7 @@ export default defineConfig({
     importMetaEnv.vite({
       env: '.env',
       example: '.env.example',
-      files: ['dist/index.html'], // explicitly define the correct path
+      files: ['dist/env.js'], // the placeholder lives here, not in index.html
     }),
     vue(),
     VueDevTools(),
@@ -66,6 +99,7 @@ export default defineConfig({
       ],
       globalAPI: true,
     }),
+    stripMonacoInlineScript(),
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
Follow-up to #716. That PR restored the console by allowing `'unsafe-inline'`, which also disables hashes and nonces and left the policy with **no protection against script injection at all**. Right call to unbreak a live cluster, wrong place to stop.

You asked why Font Awesome and Monaco couldn't just be let through. They can. Once both inline scripts are gone, `script-src 'self'` works with no exemptions and no runtime hashing.

Targets `main`, which already has #716 and #717.

## The two inline scripts, and why each could go

**The environment block** was hand-written in `index.html`:

```html
<script>globalThis.import_meta_env = JSON.parse('"import_meta_env_placeholder"')</script>
```

`import-meta-env` rewrites it when the container starts, so its content varies per deployment and no build-time hash could ever cover it. Moved to `public/env.js` and loaded with `<script src>`, it needs neither a hash nor an exemption. Still a classic script in `<head>`, so it runs before the deferred application module. The Dockerfile now substitutes into `env.js`.

**Monaco's worker environment** is injected by `vite-plugin-monaco-editor-esm`, which offers no way to turn it off. It now lives in `src/main.js`, inside the bundle, and a small plugin in `vite.config.js` strips the injected copy.

The Monaco plugin stays in the list: its `writeBundle` emits the worker files those paths point at. The stripper **throws if the injected script stops matching**, so an upstream change fails the build rather than silently reintroducing an inline script for the CSP to trip over. Its version also carried a `blob:` fallback for cross-origin workers, dead code here since all three are local, so that isn't reproduced.

## The policy now

```
script-src 'self' https://*.fontawesome.com
```

`style-src` still needs `'unsafe-inline'`: Vue's scoped styles and the Font Awesome kit both inject style elements at runtime. Inline style is a far smaller problem than inline script.

## Verification

Against the built image in a real browser, not by reading the header:

| | 6.7.0 | #716 | This PR |
|---|---|---|---|
| CSP violations | 3 | 0 | **0** |
| `script-src` allows inline | n/a | **yes** | **no** |
| Font Awesome initialises | ✗ | ✓ | ✓ |

Also confirmed on this build:

- no inline `<script>` remains in the built `index.html`, all three have `src`
- all three Monaco workers serve `200` at the paths `main.js` references
- `getWorkerUrl` resolves `json` correctly and falls back for unknown labels
- `globalThis.import_meta_env` is set
- `env.js` ships with the placeholder intact for the entrypoint to substitute

## Worth flagging

The container couldn't be started normally on my arm64 machine because `import-meta-env-alpine` is an x86 musl binary, so nginx was run directly for these checks. That means **the substitution step itself is unexercised here** and should be watched on first deploy: if `env.js` still contains `import_meta_env_placeholder` after startup, the `-p` path in the Dockerfile is wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
