### PR TITLE
edge-pathfindr: name the likely cause when auth is rejected

### DIFF
--- a/edge-pathfindr/lib/api.js
+++ b/edge-pathfindr/lib/api.js
@@ -189,7 +189,14 @@ export class PathfindrAPI {
         }
         catch (e) {
             if (e.kind == "auth") {
-                this.log("Authentication rejected: %s", e.message);
+                /* Name the likely cause. Pathfindr returns an empty 500 for
+                 * a wrong client id or secret rather than saying so, and the
+                 * secrets are long random strings where l and 1, O and 0 are
+                 * easy to transpose. Someone reading this line at 3am should
+                 * not have to already know that. */
+                this.log("Authentication rejected: %s. Pathfindr answers 500 "
+                    + "to a wrong client id or secret, so check those first: "
+                    + "watch for l/1 and O/0 in the secret.", e.message);
                 return "AUTH";
             }
             this.log("Cannot reach %s: %s", this.base, e.message);


### PR DESCRIPTION
A connection failed on a live cluster with 126 identical lines of `Authentication rejected: token endpoint returned 500`.

The driver was already right about *what* had happened, thanks to the auth mapping in #714, but `returned 500` doesn't tell anyone where to look. Pathfindr answers an empty 500 for a wrong client id or secret instead of saying so, and these are long random strings where visually similar characters are easy to transpose by eye. The log line now says that.

One line of behaviour change. No logic touched.

## Superseded diagnosis

The root cause turned out to be #720: secret placeholders were never substituted on an HTTP-served Manager, so the driver received the literal placeholder and sent it as the credential. This PR's log message is still useful, but it names the wrong likely cause. Worth rewording to point at placeholder substitution instead.

## What this replaced

I had a branch rewriting the transport from `fetch` to `node:http`, on the theory that undici's default headers (`accept-encoding`, `user-agent: node`, `accept-language: *`, `sec-fetch-mode: cors`) were upsetting the endpoint. **That theory was wrong** and the rewrite is reverted. A bisect written without a control row appeared to implicate all four headers; adding the control showed the baseline failing too. `fetch` is fine.

## Verified end to end against a live tenant

First time the driver has run against the real API rather than a fake:

```
login: UP
location/<serial>   zone and building resolve
beacon/<serial>     battery and last heartbeat
enviro/<serial>     temperature, humidity, recorded_at
height/<serial>     UWB height in cm
activity/<serial>   ok
attrs/<serial>      {} (none defined)
runtime/<serial>    undefined (no GPS tracker, non-fatal)

8 reads -> 5 HTTP calls
```

beacon, enviro and height shared a single `/assets/{id}` call, which is exactly what the detail projections in #715 were built to do.

Still not tested inside a running Edge Agent; the Sparkplug publish path remains unexercised.
