### PR TITLE
Fix secret placeholders never being substituted on an HTTP Manager

### DIFF
--- a/acs-admin/src/components/EdgeManager/Connections/NewConnectionDialog.vue
+++ b/acs-admin/src/components/EdgeManager/Connections/NewConnectionDialog.vue
@@ -434,13 +434,36 @@ export default {
   },
 
   methods: {
+    /* A v4-shaped identifier for a secret placeholder.
+     *
+     * The Edge Agent finds these by pattern, so the shape matters. This used
+     * to return crypto.randomUUID() when available and 32 unhyphenated hex
+     * characters otherwise, and the Edge Agent only recognised the first
+     * form. crypto.randomUUID is restricted to secure contexts, so on a
+     * Manager served over plain HTTP every secret came out in a shape the
+     * Edge Agent silently ignored.
+     *
+     * The fallback now produces the same 8-4-4-4-12 layout, so both paths
+     * yield something recognisable. It also no longer relies on
+     * Uint8Array.prototype.toHex, which is recent enough to be missing from
+     * browsers that are otherwise perfectly current. */
     random() {
       if (crypto.randomUUID)
         return crypto.randomUUID();
 
       const buf = new Uint8Array(16);
       crypto.getRandomValues(buf);
-      return buf.toHex();
+
+      /* Set the version and variant bits, so this is a real v4 rather than
+       * something merely shaped like one. */
+      buf[6] = (buf[6] & 0x0f) | 0x40;
+      buf[8] = (buf[8] & 0x3f) | 0x80;
+
+      const hex = Array.from(buf, b => b.toString(16).padStart(2, '0')).join('');
+      return [
+        hex.slice(0, 8), hex.slice(8, 12), hex.slice(12, 16),
+        hex.slice(16, 20), hex.slice(20),
+      ].join('-');
     },
 
     async encryptSensitiveInfo(value) {

--- a/acs-edge/lib/translator.ts
+++ b/acs-edge/lib/translator.ts
@@ -357,7 +357,26 @@ export class Translator extends EventEmitter {
             // If the SECRETS_PATH is set in the environment, use that as the secret path, otherwise use the default
             const secretBasePath = process.env.SECRETS_PATH || '/etc/secrets';
 
-            const secretReplacedConfig = configString.replace(/__FPSI__[a-f0-9-]{36}/g, (match) => {
+            /* Two token shapes exist in the field, and both must resolve.
+             *
+             * The Manager mints these with crypto.randomUUID(), giving 36
+             * characters with hyphens. That API only exists in a secure
+             * context, so a Manager served over plain HTTP falls back to 32
+             * hex characters with none. This pattern only accepted the first,
+             * so on an HTTP deployment every secret passed through
+             * unsubstituted and the driver received the literal placeholder,
+             * which it then sent to the remote service as the credential.
+             *
+             * The failure was silent from here: nothing matched, so nothing
+             * was reported missing, and the error surfaced as an
+             * authentication rejection from a third party.
+             *
+             * The alternation is deliberate rather than a {32,36} range. A
+             * range is greedy and, next to a hyphenated token, could consume
+             * part of a neighbouring value. */
+            const FPSI = /__FPSI__(?:[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}|[a-f0-9]{32})/g;
+
+            const secretReplacedConfig = configString.replace(FPSI, (match) => {
                 try {
                     // Attempt to get the secret contents from the file in /etc/secrets with the same name
                     const secretPath = `${secretBasePath}/${match}`;


### PR DESCRIPTION
A driver on a live cluster received its connection secret as the literal placeholder and sent *that* to the remote service as the credential:

```
clientSecret: '__FPSI__0202c510720d50772b51d36c279571a3'
```

The secret existed, was correct, and was stored in the right place. It was never substituted.

## Two halves disagreeing about the token shape

The Manager mints placeholders in `NewConnectionDialog.vue`:

```js
random() {
  if (crypto.randomUUID) return crypto.randomUUID();  // 36 chars, hyphenated
  const buf = new Uint8Array(16);
  crypto.getRandomValues(buf);
  return buf.toHex();                                  // 32 chars, no hyphens
}
```

The Edge Agent finds them in `translator.ts`:

```js
configString.replace(/__FPSI__[a-f0-9-]{36}/g, ...)   // only the first form
```

**`crypto.randomUUID` is restricted to secure contexts.** A Manager served over plain HTTP, which is a supported deployment, therefore *always* takes the fallback and *always* produces tokens the Edge Agent will never match. Every secret on such a deployment passes straight through.

## Why nobody noticed sooner

The failure is silent in the worst possible way. A token that doesn't match isn't a token as far as the substitution is concerned, so nothing reports a missing secret — the existing `SECRET_NOT_FOUND` path only fires for a token that matched but has no file.

The first symptom is a *third party* rejecting an authentication attempt, which sends the investigation towards credentials and away from the config pipeline. In this case that cost most of a morning chasing a suspected typo, then request headers, then whitespace.

## Both halves fixed

Fixing either alone leaves someone broken, so:

**Edge Agent** recognises both shapes, so secrets already stored on HTTP deployments resolve with no re-entry. The alternation is written out rather than `{32,36}` — a range is greedy and, next to a hyphenated token, could swallow part of a neighbouring value.

**Manager** fallback emits the same 8-4-4-4-12 layout, with version and variant bits set so it's a genuine v4 rather than merely UUID-shaped. It also drops `Uint8Array.prototype.toHex`, which is recent enough to be missing from otherwise-current browsers and would have thrown rather than degraded.

## Verification

```
yours (32 hex)     match=__FPSI__0202c510720d50772b51d36c279571a3
yours (2nd token)  match=__FPSI__e3ce98abf20b7174916755893986277a
uuid (36)          match=__FPSI__3f2504e0-4f89-41d3-9a0c-0305e82c3301
adjacent values    not over-matched
```

2000/2000 generated fallback tokens match the new pattern and are valid v4. The Vue component compiles.

`acs-edge`'s dependencies aren't installed in this worktree so I couldn't run `tsc`; the change is a regex literal and one added `const`, but worth a CI check.

## Impact beyond this driver

This affects **any driver with a secret** on **any HTTP-served Manager** — the REST driver's password included. Anyone who hit it would have seen an unexplained auth failure from their device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
