### PR TITLE
edge: say something when a payload format has no parser

### DIFF
--- a/acs-edge/lib/helpers/typeHandler.ts
+++ b/acs-edge/lib/helpers/typeHandler.ts
@@ -553,8 +553,38 @@ export function parseValueFromPayload(msg: any, metric: sparkplugMetric, payload
         case serialisationType.serialisedBuffer:
             break;
         default:
+            /* Nothing here knows how to read this payload, so the metric
+             * gets no value. Say so.
+             *
+             * This branch used to return undefined in silence, and the
+             * commonest way to reach it is a real misconfiguration: an
+             * external driver connection left on "Defined by Protocol".
+             * Such a driver hands over a raw Buffer expecting the Edge Agent
+             * to parse it, so the data arrives intact, is discarded here
+             * without a word, and the metric sits at null forever. There is
+             * nothing in the logs, nothing in the birth certificate, and no
+             * error anywhere to suggest the payload ever existed.
+             *
+             * Logged once per format so a per-metric, per-poll hot path
+             * cannot flood the log. */
+            warn_unparsed(payloadFormat);
             break;
     }
+}
+
+/* Payload formats already complained about; see the default branch above. */
+const unparsed_warned = new Set<string>();
+
+function warn_unparsed (payloadFormat: serialisationType | string) {
+    const key = String(payloadFormat);
+    if (unparsed_warned.has(key)) return;
+    unparsed_warned.add(key);
+
+    log(`Payload format "${key}" has no parser, so every metric using it `
+        + `will stay empty. If this connection uses an external driver, the `
+        + `driver sends a payload for the Edge Agent to decode and the format `
+        + `must name it, usually JSON. "Defined by Protocol" only suits `
+        + `connections that decode internally.`);
 }
 
 /**

--- a/acs-edge/lib/translator.ts
+++ b/acs-edge/lib/translator.ts
@@ -22,7 +22,7 @@ import { SparkplugNode } from "./sparkplugNode.js";
 import * as UUIDs from "./uuids.js";
 
 import { log } from "./helpers/log.js";
-import { sparkplugConfig, } from "./helpers/typeHandler.js";
+import { serialisationType, sparkplugConfig, } from "./helpers/typeHandler.js";
 
 import { RestConnection } from "./devices/REST.js";
 import { S7Connection } from "./devices/S7.js";
@@ -198,11 +198,39 @@ export class Translator extends EventEmitter {
             connection.name,
             this.broker);
 
+        this.checkPayloadFormats(connection);
+
         if (connection.scout?.scoutDetails?.isEnabled) {
             this.runScout(connection, newConn);
         }
         else {
             this.runDevices(connection, newConn);
+        }
+    }
+
+    /* Warn about a configuration that cannot ever produce data.
+     *
+     * An external driver publishes a payload for the Edge Agent to decode, so
+     * its devices must name a format. "Defined by Protocol" means the
+     * opposite: the connection has already decoded the value itself, which is
+     * true of the internal connections and never of a driver. Left on that
+     * setting the payload arrives, finds no parser, and is dropped, leaving
+     * every metric on the device empty with nothing logged.
+     *
+     * Checked here rather than per read, so it is said once at startup where
+     * someone will see it. */
+    checkPayloadFormats (connection: any) {
+        if (connection.connType !== "Driver") return;
+
+        for (const device of connection.devices ?? []) {
+            if (device.payloadFormat !== serialisationType.ignored) continue;
+
+            log(`Device ${device.deviceId} on driver connection `
+                + `${connection.name} has payload format `
+                + `"${serialisationType.ignored}". An external driver sends a `
+                + `payload for the Edge Agent to decode, so this device will `
+                + `produce no data. Set the device's payload format to the `
+                + `format the driver publishes, usually JSON.`);
         }
     }
 


### PR DESCRIPTION
A driver published valid JSON every poll, the Edge Agent discarded all of it, and every metric on the device sat at `null`. Nothing logged, birth certificate looked correct, and the driver's own logs showed `DATA <Buffer 7b 22 ...>` going out. The only evidence was an absence.

## Cause

`parseValueFromPayload` switches on the payload format and ends:

```ts
case serialisationType.serialisedBuffer:
    break;
default:
    break;
}
}   // <- returns undefined
```

`"Defined by Protocol"` has **no case**, so it fell straight through and returned `undefined` in silence.

That value isn't nonsense. It means *the connection has already decoded the payload itself*, which is true of the internal connections (see `REST.ts:56`). It is never true of an external driver, which hands over a raw `Buffer` for the Edge Agent to decode. So a driver connection left on that setting **cannot produce data**, and said so nowhere.

## Fix

Two places now say so:

- **The default branch logs**, once per format, guarded by a `Set`. It's a per-metric, per-poll hot path and must not flood the log.
- **Connection setup checks driver connections** and names any device carrying the setting, at startup, where someone will actually read it.

Neither changes behaviour; both turn an invisible failure into a stated one.

## Testing

`tsc --noEmit` clean. The only error in a source checkout is the generated `lib/git-version.js`, which the Docker build writes.

Found the hard way: this cost most of an afternoon on a live cluster, chasing a driver that was working perfectly the whole time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)