### PR TITLE
Keep OPC UA reconnecting indefinitely

### DIFF
--- a/acs-edge/lib/devices/OPCUA.ts
+++ b/acs-edge/lib/devices/OPCUA.ts
@@ -84,7 +84,8 @@ export class OPCUAConnection extends DeviceConnection {
             keepSessionAlive: true,
             connectionStrategy: {
                 initialDelay: 1000,
-                maxDelay: 20000
+                maxDelay: 20000,
+                maxRetry: -1 // node-opcua uses -1 for unlimited retries
             },
             securityMode: getOpcSecurityMode(connDetails.securityMode),
             securityPolicy: getOpcSecurityPolicy(connDetails.securityPolicy),


### PR DESCRIPTION
## Summary

Keep the ACS Edge OPC UA client retrying its initial connection until the southbound server becomes available.

`node-opcua` fills an omitted `maxRetry` in a partial connection strategy with `10`. Setting it to `-1` selects the library's documented unlimited-retry behavior while retaining the existing 1–20 second backoff.

## Validation

- `npm run build` (with the same generated `lib/git-version` placeholder used by the container build)
- verified emitted JavaScript contains `connectionStrategy.maxRetry: -1`
- `git diff --check`

Closes #165
