### PR TITLE
java-service-client: stop caching failed Directory lookups forever

### DIFF
--- a/lib/java-service-client/src/main/java/uk/co/amrc/factoryplus/client/FPDirectory.java
+++ b/lib/java-service-client/src/main/java/uk/co/amrc/factoryplus/client/FPDirectory.java
@@ -51,14 +51,16 @@ public class FPDirectory {
                 .appendPath(service.toString())
             )
             .fetch()
-            .map(res -> res.ifOk()
-                .flatMap(r -> r.getBody())
+            .flatMap(res -> res.ifOk()
+                .flatMap(r -> r.getBodyArray())
+                .map(Single::just)
                 .orElseGet(() -> {
                     log.error("Can't find {} via the Directory: {}",
                         service, res.getCode());
-                    return new JSONArray();
+                    return Single.error(new Exception(
+                        "Directory lookup of %s failed: %s"
+                            .formatted(service, res.getCode())));
                 }))
-            .cast(JSONArray.class)
             .flatMapObservable(Observable::fromIterable)
             .doOnNext(o -> log.info("Service URL: {}", o))
             .cast(JSONObject.class)

--- a/lib/java-service-client/src/main/java/uk/co/amrc/factoryplus/client/FPDiscovery.java
+++ b/lib/java-service-client/src/main/java/uk/co/amrc/factoryplus/client/FPDiscovery.java
@@ -6,6 +6,7 @@
 package uk.co.amrc.factoryplus.client;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -21,12 +22,14 @@ import io.reactivex.rxjava3.core.*;
 
 import uk.co.amrc.factoryplus.http.*;
 
-/* XXX The JS client performs a (cached) fetch every time, with a Map of
- * overrides. This client caches the responses from the Directory
- * indefinitely, which is definitely incorrect. However, we perform
- * not-entirely-trivial processing on the response, so even if there
- * will be no network activity I would like to know that I got a 304 and
- * can reuse the existing derived value... */
+/* Responses from the Directory are cached for a limited time, after
+ * which they are refetched on the next request. If the refetch fails
+ * the stale value is used, so a Directory outage does not break
+ * services which already know where to go. Empty responses and errors
+ * are never cached; previously a failed lookup was cached as an empty
+ * set indefinitely, which left long-running services (notably the MQTT
+ * broker auth plugin) permanently broken if they started up while the
+ * Directory was unavailable. */
 
 /** Service discovery.
  *
@@ -36,12 +39,15 @@ import uk.co.amrc.factoryplus.http.*;
 public class FPDiscovery {
     private static final Logger log = LoggerFactory.getLogger(FPDiscovery.class);
 
+    private static final Duration CACHE_EXPIRY = Duration.ofMinutes(5);
+
     private RequestCache<UUID, Set<URI>> cache;
 
     public FPDiscovery (FPServiceClient fplus)
     {
         var dir = fplus.directory();
-        this.cache = new RequestCache<UUID, Set<URI>>(dir::getServiceURLs);
+        this.cache = new RequestCache<UUID, Set<URI>>(dir::getServiceURLs,
+            CACHE_EXPIRY, urls -> !urls.isEmpty());
 
         var url = fplus.getUriConf("directory_url");
         log.info("Using Directory {}", url);

--- a/lib/java-service-client/src/main/java/uk/co/amrc/factoryplus/client/RequestCache.java
+++ b/lib/java-service-client/src/main/java/uk/co/amrc/factoryplus/client/RequestCache.java
@@ -9,8 +9,11 @@
 package uk.co.amrc.factoryplus.client;
 
 import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,35 +27,77 @@ public class RequestCache<Key, Value>
 {
     private static final Logger log = LoggerFactory.getLogger(RequestCache.class);
 
+    /* An expiry of null means the entry never expires. */
+    private static record Entry<V> (V value, Instant expiry)
+    {
+        boolean expired ()
+        {
+            return expiry != null && Instant.now().isAfter(expiry);
+        }
+    }
+
     private Function<Key, Single<Value>> source;
-    private ConcurrentHashMap<Key, Value> cache;
+    private Duration expiry;
+    private Predicate<Value> cacheable;
+    private ConcurrentHashMap<Key, Entry<Value>> cache;
     private ConcurrentHashMap<Key, Single<Value>> inFlight;
 
     public RequestCache (Function<Key, Single<Value>> tokenSource)
     {
-        source = tokenSource;
-        cache = new ConcurrentHashMap<Key, Value>();
+        this(tokenSource, null, v -> true);
+    }
+
+    /** Cache with expiry.
+     *
+     * Values fetched from the source are cached for the given duration,
+     * then refetched on the next request. If the refetch fails the
+     * stale value is returned instead, so a source outage does not
+     * invalidate values we already hold. Values failing the cacheable
+     * predicate are returned to the caller but not cached, so they are
+     * refetched every time.
+     *
+     * @param tokenSource Fetches the value for a key.
+     * @param expiry How long fetched values are cached for; null means
+     *      forever.
+     * @param cacheable Values failing this test are not cached.
+     */
+    public RequestCache (Function<Key, Single<Value>> tokenSource,
+        Duration expiry, Predicate<Value> cacheable)
+    {
+        this.source = tokenSource;
+        this.expiry = expiry;
+        this.cacheable = cacheable;
+        cache = new ConcurrentHashMap<Key, Entry<Value>>();
         inFlight = new ConcurrentHashMap<Key, Single<Value>>();
     }
 
     public Single<Value> get (Key key)
     {
         var existing = cache.get(key);
-        if (existing != null)
-            return Single.just(existing);
+        if (existing != null && !existing.expired())
+            return Single.just(existing.value());
 
-        return inFlight.computeIfAbsent(key, k -> {
-            var promise = source.apply(key).cache();
-            //log.info("In-flight: add {} {}", key, promise);
-
-            promise
-                .doAfterTerminate(() -> {
-                    //log.info("In-flight: remove {} {}", key, promise);
-                    inFlight.remove(key, promise);
+        /* The fetch must not start until the promise is in the map, or
+         * a synchronously-completing source will try to remove itself
+         * before it has been inserted and leak a completed promise.
+         * cache() defers the fetch to the first subscriber, which is
+         * always after computeIfAbsent has returned. */
+        var promise = inFlight.computeIfAbsent(key, k ->
+            source.apply(k)
+                .doOnSuccess(rv -> {
+                    if (cacheable.test(rv))
+                        cache.put(k, new Entry<Value>(rv,
+                            expiry == null ? null
+                                : Instant.now().plus(expiry)));
                 })
-                .subscribe(rv -> cache.put(key, rv), e -> {});
-            return promise;
-        });
+                .doAfterTerminate(() -> inFlight.remove(k))
+                .cache());
+
+        /* If we hold an expired value, fall back to it when the refetch
+         * fails rather than propagating the error. */
+        if (existing != null)
+            return promise.onErrorReturnItem(existing.value());
+        return promise;
     }
 
     public void put (Key key, Value value)
@@ -60,11 +105,14 @@ public class RequestCache<Key, Value>
         /* XXX If we have an in-flight request we need to cancel it, and
          * arrange for the get() call to return this value instead.
          * Otherwise it will overwrite the value we set here. */
-        cache.put(key, value);
+        /* Values set explicitly never expire. */
+        cache.put(key, new Entry<Value>(value, null));
     }
 
     public void remove (Key service, Value token)
     {
-        cache.remove(service, token);
+        var existing = cache.get(service);
+        if (existing != null && existing.value().equals(token))
+            cache.remove(service, existing);
     }
 }

--- a/lib/java-service-client/src/test/java/uk/co/amrc/factoryplus/client/RequestCacheTest.java
+++ b/lib/java-service-client/src/test/java/uk/co/amrc/factoryplus/client/RequestCacheTest.java
@@ -1,0 +1,137 @@
+/* Factory+ Java client library.
+ * Request cache tests.
+ * Copyright 2026 University of Sheffield
+ */
+
+package uk.co.amrc.factoryplus.client;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import io.reactivex.rxjava3.core.Single;
+
+public class RequestCacheTest {
+
+    /* A source which counts its calls and returns whatever Single is
+     * currently configured. */
+    private static class Source {
+        AtomicInteger calls = new AtomicInteger();
+        AtomicReference<Single<String>> result =
+            new AtomicReference<>(Single.just("value"));
+
+        Single<String> fetch (String key)
+        {
+            return Single.defer(() -> {
+                calls.incrementAndGet();
+                return result.get();
+            });
+        }
+    }
+
+    @Test
+    public void cachesSuccessfulResults ()
+    {
+        var src = new Source();
+        var cache = new RequestCache<String, String>(src::fetch);
+
+        assertEquals("value", cache.get("key").blockingGet());
+        assertEquals("value", cache.get("key").blockingGet());
+        assertEquals(1, src.calls.get());
+    }
+
+    @Test
+    public void doesNotCacheErrors ()
+    {
+        var src = new Source();
+        var cache = new RequestCache<String, String>(src::fetch);
+
+        src.result.set(Single.error(new Exception("directory down")));
+        assertThrows(Exception.class,
+            () -> cache.get("key").blockingGet());
+
+        src.result.set(Single.just("value"));
+        assertEquals("value", cache.get("key").blockingGet());
+        assertEquals(2, src.calls.get());
+    }
+
+    @Test
+    public void doesNotCacheUncacheableValues ()
+    {
+        var src = new Source();
+        var cache = new RequestCache<String, String>(src::fetch,
+            null, v -> !v.isEmpty());
+
+        src.result.set(Single.just(""));
+        assertEquals("", cache.get("key").blockingGet());
+        assertEquals("", cache.get("key").blockingGet());
+        assertEquals(2, src.calls.get());
+
+        src.result.set(Single.just("value"));
+        assertEquals("value", cache.get("key").blockingGet());
+        assertEquals("value", cache.get("key").blockingGet());
+        assertEquals(3, src.calls.get());
+    }
+
+    @Test
+    public void refetchesAfterExpiry () throws Exception
+    {
+        var src = new Source();
+        var cache = new RequestCache<String, String>(src::fetch,
+            Duration.ofMillis(20), v -> true);
+
+        assertEquals("value", cache.get("key").blockingGet());
+        Thread.sleep(50);
+        src.result.set(Single.just("new value"));
+        assertEquals("new value", cache.get("key").blockingGet());
+        assertEquals(2, src.calls.get());
+    }
+
+    @Test
+    public void servesStaleValueWhenRefetchFails () throws Exception
+    {
+        var src = new Source();
+        var cache = new RequestCache<String, String>(src::fetch,
+            Duration.ofMillis(20), v -> true);
+
+        assertEquals("value", cache.get("key").blockingGet());
+        Thread.sleep(50);
+        src.result.set(Single.error(new Exception("directory down")));
+        assertEquals("value", cache.get("key").blockingGet());
+        assertEquals(2, src.calls.get());
+    }
+
+    @Test
+    public void putValuesNeverExpire () throws Exception
+    {
+        var src = new Source();
+        var cache = new RequestCache<String, String>(src::fetch,
+            Duration.ofMillis(20), v -> true);
+
+        cache.put("key", "pinned");
+        Thread.sleep(50);
+        assertEquals("pinned", cache.get("key").blockingGet());
+        assertEquals(0, src.calls.get());
+    }
+
+    @Test
+    public void removeOnlyRemovesMatchingValue ()
+    {
+        var src = new Source();
+        var cache = new RequestCache<String, String>(src::fetch);
+
+        cache.put("key", "pinned");
+        cache.remove("key", "other");
+        assertEquals("pinned", cache.get("key").blockingGet());
+        assertEquals(0, src.calls.get());
+
+        cache.remove("key", "pinned");
+        assertEquals("value", cache.get("key").blockingGet());
+        assertEquals(1, src.calls.get());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a failure mode in the Java service client's Directory discovery that can take down all MQTT data flow until the broker is restarted.

If a client using `java-service-client` (notably the HiveMQ Kerberos auth extension) starts while the Directory cannot reach its database, the failed lookup is returned as an empty URL set and cached forever. The broker then rejects every MQTT CONNECT with "Bad User Name or Password" because it can never find the Auth service to fetch ACLs, even after the Directory recovers. This was observed in production after a node reschedule moved the broker and the Directory's Postgres at the same time.

Three changes in `lib/java-service-client`:

1. **`FPDirectory.getServiceURLs`**: a non-OK Directory response is now an error, not an empty array. Errors are never cached, so the lookup is retried.
2. **`RequestCache`**: supports an optional expiry and a cacheability predicate. Expired entries are refetched on the next request; if the refetch fails the stale value is served, so a Directory outage does not invalidate URLs a service already holds. Entries set with `put()` (explicit config such as `directory_url`) never expire. Also fixes a latent race where a synchronously-completing source leaked a completed promise into the in-flight map.
3. **`FPDiscovery`**: caches lookups for five minutes and never caches an empty result. The long-standing `XXX` comment about indefinite caching being incorrect is resolved.

## How to test

1. `cd lib/java-service-client && mvn test` - 8 tests pass, including new `RequestCacheTest` coverage for error handling, empty results, expiry, stale fallback, and pinned entries.
2. `cd acs-mqtt && mvn compile` against the installed library - compiles unchanged.
3. Manual reproduction: start the MQTT broker while the Directory returns 500 (for example while its database is unreachable). Previously every MQTT client is rejected forever; with this change the broker recovers as soon as the Directory does, on the next connection attempt.

## Release notes

- Fixed: an MQTT broker (or any Java service client) that started while the Directory was unavailable would cache the failed service lookup forever and reject all connections until restarted. Service URL lookups now expire after five minutes, failed and empty lookups are retried, and a known-good URL is kept if the Directory is temporarily unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
