### PR TITLE
Stop data-access retrying ConfigDB 4xx forever

### DIFF
--- a/acs-data-access/lib/retry.js
+++ b/acs-data-access/lib/retry.js
@@ -1,0 +1,93 @@
+/*
+ * ACS Data Access Service
+ * Bounded retry for ConfigDB writes.
+ */
+
+import * as rx from "rxjs";
+
+import { retryBackoff } from "@amrc-factoryplus/rx-util";
+import { APIError } from "@amrc-factoryplus/service-api";
+
+/* Base delay before the first retry. The backoff doubles each time, so
+ * MAX_RETRIES retries take 500 + 1000 + 2000 + 4000 = 7.5s in total.
+ * That covers a ConfigDB pod restart or a short database stall without
+ * holding an HTTP request open for long enough to matter. */
+export const RETRY_DELAY = 500;
+
+/* Number of retries after the first attempt, so five attempts in all.
+ * Any cap at all removes the failure mode this replaces: an error that
+ * never clears used to be retried forever. Five is enough for a
+ * transient fault and small enough that a client which keeps retrying
+ * cannot generate meaningful load on ConfigDB. */
+export const MAX_RETRIES = 4;
+
+/* Status reported by the service client when it could not connect at
+ * all. */
+const CONNECTION_FAILED = 0;
+
+/** Decide whether an error is worth retrying.
+ * A 4xx from ConfigDB is a settled answer: the request is not allowed,
+ * or the object does not exist. Asking again cannot change it, and each
+ * attempt costs ConfigDB a permission check. A 5xx, a connection
+ * failure, or an error with no status at all may clear on its own.
+ * @arg err The error thrown by the service client.
+ * @returns True if the operation should be retried.
+ */
+export function is_transient_error (err) {
+    const status = err?.status;
+    if (typeof status != "number") return true;
+    if (status == CONNECTION_FAILED) return true;
+    return status < 400 || status > 499;
+}
+
+/** Map a ConfigDB error onto a status to return to our client.
+ * A ServiceError which reaches the WebAPI error handler unchanged is
+ * reported as 503, which tells the client to try again. That is wrong
+ * for a 4xx. Pass the ConfigDB status through instead, so a caller who
+ * is not allowed to link to a source sees 403 and a caller naming a
+ * source which no longer exists sees 404.
+ */
+function api_status (err) {
+    const status = err?.status;
+    if (typeof status != "number") return 500;
+    if (status >= 400 && status <= 499) return status;
+    return 503;
+}
+
+/** Run a ConfigDB write with a bounded retry.
+ * Transient failures are retried with backoff, up to MAX_RETRIES times.
+ * Non-transient failures fail at once. Either way a failure is logged
+ * with the dataset UUID and the status, and then thrown as an APIError
+ * so the dataset operation fails rather than reporting success with the
+ * relationship missing.
+ * @arg opts.log The logging function to use.
+ * @arg opts.dataset The dataset UUID the write belongs to.
+ * @arg opts.what A description of the write, for the log.
+ * @arg opts.op A function returning a promise for the write.
+ * @arg opts.delay Base backoff in ms. Defaults to RETRY_DELAY. Used by
+ * the tests to keep the backoff short.
+ */
+export async function retry_cdb_write (opts) {
+    const { log, dataset, what, op } = opts;
+    const delay = opts.delay ?? RETRY_DELAY;
+
+    try {
+        await rx.lastValueFrom(
+            rx.defer(op).pipe(retryBackoff(delay, e => log(
+                "Retrying %s for dataset %s: %s", what, dataset, e), {
+                count:          MAX_RETRIES,
+                shouldRetry:    is_transient_error,
+            })),
+            /* class_add_subclass resolves with no value. */
+            { defaultValue: undefined });
+    }
+    catch (err) {
+        const status = err?.status ?? "no status";
+        const reason = is_transient_error(err)
+            ? `gave up after ${MAX_RETRIES} retries`
+            : "will not retry";
+        log("ConfigDB %s for dataset %s failed (status %s), %s: %s",
+            what, dataset, status, reason, err);
+        throw new APIError(api_status(err));
+    }
+}

--- a/acs-data-access/lib/session-limits-handler.js
+++ b/acs-data-access/lib/session-limits-handler.js
@@ -1,8 +1,5 @@
-import * as rx from "rxjs";
-
-import { retryBackoff } from "@amrc-factoryplus/rx-util";
-
 import {BaseStructureHandler} from './base-structure-handler.js';
+import { retry_cdb_write } from './retry.js';
 import { fail } from './utils.js';
 import { valid_uuid, valid_datetime } from "./validate.js";
 import { DataAccess as Constants } from "./constants.js";
@@ -70,15 +67,21 @@ export class SessionLimitsHandler extends BaseStructureHandler {
   }
 
   async create_subclass_relationships(dataset_uuid, config) {
-    await rx.lastValueFrom(
-      rx.defer(() =>
-        this.cdb.class_add_subclass(config.source, dataset_uuid)
-      ).pipe(retryBackoff(500, e => this.log(e)))
-    );
+    await retry_cdb_write({
+      log:      this.log,
+      dataset:  dataset_uuid,
+      what:     `add subclass ${dataset_uuid} to ${config.source}`,
+      op:       () => this.cdb.class_add_subclass(config.source, dataset_uuid),
+    });
   }
 
   async remove_subclass_relationships(dataset_uuid, config) {
-    await this.cdb.class_remove_subclass(config.source, dataset_uuid);
+    await retry_cdb_write({
+      log:      this.log,
+      dataset:  dataset_uuid,
+      what:     `remove subclass ${dataset_uuid} from ${config.source}`,
+      op:       () => this.cdb.class_remove_subclass(config.source, dataset_uuid),
+    });
     this.log(`Removed ${dataset_uuid} from ${config.source} subclasses.`)
   }
 }

--- a/acs-data-access/lib/unions-components-handler.js
+++ b/acs-data-access/lib/unions-components-handler.js
@@ -1,8 +1,5 @@
-import * as rx from "rxjs";
-
-import { retryBackoff } from "@amrc-factoryplus/rx-util";
-
 import {BaseStructureHandler} from './base-structure-handler.js';
+import { retry_cdb_write } from './retry.js';
 import { fail } from './utils.js';
 import { valid_uuid } from "./validate.js";
 import { DataAccess as Constants } from "./constants.js";
@@ -66,11 +63,12 @@ export class UnionComponentsHandler extends BaseStructureHandler {
 
   async create_subclass_relationships(datasetUuid, config) {
     for (const source of config) {
-      await rx.lastValueFrom(
-        rx.defer(() =>
-          this.cdb.class_add_subclass(datasetUuid, source)
-        ).pipe(retryBackoff(500, e => this.log(e)))
-      );
+      await retry_cdb_write({
+        log:      this.log,
+        dataset:  datasetUuid,
+        what:     `add subclass ${source} to ${datasetUuid}`,
+        op:       () => this.cdb.class_add_subclass(datasetUuid, source),
+      });
     }
   }
 
@@ -78,7 +76,12 @@ export class UnionComponentsHandler extends BaseStructureHandler {
     if(config.length <= 0) return;
 
     for (const src of config){
-      await this.cdb.class_remove_subclass(dataset_uuid, src);
+      await retry_cdb_write({
+        log:      this.log,
+        dataset:  dataset_uuid,
+        what:     `remove subclass ${src} from ${dataset_uuid}`,
+        op:       () => this.cdb.class_remove_subclass(dataset_uuid, src),
+      });
       this.log(`Removed ${dataset_uuid} from ${src} subclasses.`);
     }
   }

--- a/acs-data-access/tests/current/retry.test.js
+++ b/acs-data-access/tests/current/retry.test.js
@@ -1,0 +1,215 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { APIError } from "@amrc-factoryplus/service-api";
+import { ServiceError } from "@amrc-factoryplus/service-client";
+
+import { MAX_RETRIES, is_transient_error, retry_cdb_write }
+    from "../../lib/retry.js";
+import { SessionLimitsHandler } from "../../lib/session-limits-handler.js";
+import { UnionComponentsHandler } from "../../lib/unions-components-handler.js";
+
+const SERVICE = "af15f175-78a0-4e05-97c0-2a0bb82b9f3b";
+const DATASET = "e2a4c530-dc0f-417d-b00b-329b0e90e033";
+const SOURCE = "1f2b8d1a-4b53-4c9a-9c0d-9a1c2e3f4a5b";
+
+/* Keep the backoff short so the tests run quickly. The production
+ * delay is RETRY_DELAY. */
+const FAST = { delay: 1 };
+
+function cdb_error (status) {
+    return new ServiceError(SERVICE, "ConfigDB says no", status);
+}
+
+/* Capture the outcome of a promise without try/catch in every test. */
+function settle (promise) {
+    return promise.then(
+        value => ({ ok: true, value }),
+        error => ({ ok: false, error }));
+}
+
+function write (opts) {
+    return settle(retry_cdb_write({
+        log: () => {}, dataset: DATASET, what: "add subclass",
+        ...FAST, ...opts,
+    }));
+}
+
+function fake_handler (Handler, cdb) {
+    return new Handler({ auth: null, cdb, log: () => {} });
+}
+
+describe("is_transient_error", () => {
+    test.for([400, 401, 403, 404, 409, 422, 499])
+        ("treats %i as permanent", st => {
+            expect(is_transient_error(cdb_error(st))).toBe(false);
+        });
+
+    test.for([500, 502, 503, 504])
+        ("treats %i as transient", st => {
+            expect(is_transient_error(cdb_error(st))).toBe(true);
+        });
+
+    test("treats a connection failure as transient", () => {
+        expect(is_transient_error(cdb_error(0))).toBe(true);
+    });
+
+    test("treats an error with no status as transient", () => {
+        expect(is_transient_error(new Error("boom"))).toBe(true);
+    });
+});
+
+describe("retry_cdb_write", () => {
+    test("does not retry a 403", async () => {
+        const op = vi.fn().mockRejectedValue(cdb_error(403));
+
+        const res = await write({ op });
+
+        expect(op).toHaveBeenCalledTimes(1);
+        expect(res.ok).toBe(false);
+        expect(res.error).toBeInstanceOf(APIError);
+        expect(res.error.status).toBe(403);
+    });
+
+    test("does not retry a 404", async () => {
+        const op = vi.fn().mockRejectedValue(cdb_error(404));
+
+        const res = await write({ op });
+
+        expect(op).toHaveBeenCalledTimes(1);
+        expect(res.error.status).toBe(404);
+    });
+
+    test("succeeds without retrying", async () => {
+        const op = vi.fn().mockResolvedValue(undefined);
+
+        const res = await write({ op });
+
+        expect(op).toHaveBeenCalledTimes(1);
+        expect(res.ok).toBe(true);
+    });
+
+    test("retries a 503 and succeeds", async () => {
+        const op = vi.fn()
+            .mockRejectedValueOnce(cdb_error(503))
+            .mockRejectedValueOnce(cdb_error(503))
+            .mockResolvedValue(undefined);
+
+        const res = await write({ op });
+
+        expect(op).toHaveBeenCalledTimes(3);
+        expect(res.ok).toBe(true);
+    });
+
+    test("caps the attempts when a 503 never clears", async () => {
+        const op = vi.fn().mockRejectedValue(cdb_error(503));
+
+        const res = await write({ op });
+
+        expect(op).toHaveBeenCalledTimes(MAX_RETRIES + 1);
+        expect(res.ok).toBe(false);
+        expect(res.error).toBeInstanceOf(APIError);
+        expect(res.error.status).toBe(503);
+    });
+
+    test("caps the attempts when the connection never comes back",
+        async () => {
+            const op = vi.fn().mockRejectedValue(cdb_error(0));
+
+            const res = await write({ op });
+
+            expect(op).toHaveBeenCalledTimes(MAX_RETRIES + 1);
+            expect(res.error.status).toBe(503);
+        });
+
+    test("caps the attempts for an error with no status", async () => {
+        const op = vi.fn().mockRejectedValue(new Error("boom"));
+
+        const res = await write({ op });
+
+        expect(op).toHaveBeenCalledTimes(MAX_RETRIES + 1);
+        expect(res.error.status).toBe(500);
+    });
+
+    test("logs the dataset and the status when it gives up", async () => {
+        const log = vi.fn();
+        const op = vi.fn().mockRejectedValue(cdb_error(403));
+
+        await write({ log, op });
+
+        const failure = log.mock.calls.at(-1).join(" ");
+        expect(failure).toContain(DATASET);
+        expect(failure).toContain("403");
+    });
+});
+
+describe("handlers", () => {
+    test("SessionLimits create does not retry a 403", async () => {
+        const cdb = {
+            class_add_subclass: vi.fn().mockRejectedValue(cdb_error(403)),
+        };
+        const handler = fake_handler(SessionLimitsHandler, cdb);
+
+        const res = await settle(handler.create_subclass_relationships(
+            DATASET, { source: SOURCE }));
+
+        expect(cdb.class_add_subclass).toHaveBeenCalledTimes(1);
+        expect(cdb.class_add_subclass).toHaveBeenCalledWith(SOURCE, DATASET);
+        expect(res.error).toBeInstanceOf(APIError);
+        expect(res.error.status).toBe(403);
+    });
+
+    test("SessionLimits remove does not retry a 403", async () => {
+        const cdb = {
+            class_remove_subclass: vi.fn().mockRejectedValue(cdb_error(403)),
+        };
+        const handler = fake_handler(SessionLimitsHandler, cdb);
+
+        const res = await settle(handler.remove_subclass_relationships(
+            DATASET, { source: SOURCE }));
+
+        expect(cdb.class_remove_subclass).toHaveBeenCalledTimes(1);
+        expect(res.error.status).toBe(403);
+    });
+
+    test("UnionComponents create does not retry a 403", async () => {
+        const cdb = {
+            class_add_subclass: vi.fn().mockRejectedValue(cdb_error(403)),
+        };
+        const handler = fake_handler(UnionComponentsHandler, cdb);
+
+        const res = await settle(handler.create_subclass_relationships(
+            DATASET, [SOURCE]));
+
+        expect(cdb.class_add_subclass).toHaveBeenCalledTimes(1);
+        expect(res.error.status).toBe(403);
+    });
+
+    test("UnionComponents create stops at the first bad source",
+        async () => {
+            const other = "3c4d5e6f-7a8b-49c0-8d1e-2f3a4b5c6d7e";
+            const cdb = {
+                class_add_subclass: vi.fn()
+                    .mockRejectedValue(cdb_error(403)),
+            };
+            const handler = fake_handler(UnionComponentsHandler, cdb);
+
+            const res = await settle(handler.create_subclass_relationships(
+                DATASET, [SOURCE, other]));
+
+            expect(cdb.class_add_subclass).toHaveBeenCalledTimes(1);
+            expect(res.ok).toBe(false);
+        });
+
+    test("UnionComponents remove does not retry a 403", async () => {
+        const cdb = {
+            class_remove_subclass: vi.fn().mockRejectedValue(cdb_error(403)),
+        };
+        const handler = fake_handler(UnionComponentsHandler, cdb);
+
+        const res = await settle(handler.remove_subclass_relationships(
+            DATASET, [SOURCE]));
+
+        expect(cdb.class_remove_subclass).toHaveBeenCalledTimes(1);
+        expect(res.error.status).toBe(403);
+    });
+});

--- a/lib/js-rx-util/lib/util.js
+++ b/lib/js-rx-util/lib/util.js
@@ -26,13 +26,30 @@ export const consoleObserver = logObserver.bind(null, console.log);
 export { consoleObserver as console_observer };
 
 /* Retry with backoff. Logs caught errors to the optional log function.
- * Retry delay defaults to 5s and will back off to 64*. */
-export function retryBackoff (delay, log) {
+ * Retry delay defaults to 5s and will back off to 64*.
+ *
+ * The optional third argument accepts:
+ *   count       Maximum number of retries. Defaults to Infinity.
+ *   shouldRetry Predicate called with the error. Return false to give
+ *               up at once and rethrow. Defaults to retrying every
+ *               error.
+ *
+ * Errors which are not retried, and the final error once the retry
+ * count is used up, are passed on to the subscriber. */
+export function retryBackoff (delay, log, opts) {
     delay ??= 5000;
     log ??= (e => {});
 
+    const count = opts?.count ?? Infinity;
+    const shouldRetry = opts?.shouldRetry ?? (e => true);
+
     return rx.retry({
+        count,
         delay: (err, n) => {
+            /* An erroring notifier passes the error on to the
+             * subscriber instead of resubscribing to the source. */
+            if (!shouldRetry(err))
+                return rx.throwError(() => err);
             log(err);
             const p = n < 7 ? n - 1 : 6;
             return rx.timer(delay * (2 ** p));


### PR DESCRIPTION
## Review this first

`lib/js-rx-util/lib/util.js`. This PR changes a shared package, not only data-access. The change is additive and both new options default to today's behaviour, so the only other caller (`acs-cluster-manager/lib/clusters.js`) is unaffected. Confirm you are happy with that.

## What this does

Stops `acs-data-access` retrying ConfigDB writes forever. Two changes:

1. Never retry a 4xx. It will not turn into a 200 by asking again.
2. Cap the retries at 5 attempts regardless of the error.

## Why

One bad reference in one service took out authentication for a whole cluster.

On fpd-ago, 18 union datasets referenced dataset objects that had been deleted. Each one produced a permanent 403 from ConfigDB. Both structure handlers wrapped that write in `retryBackoff`, which had no attempt cap and never looked at the error:

```js
await rx.lastValueFrom(
  rx.defer(() => this.cdb.class_add_subclass(config.source, dataset_uuid))
    .pipe(retryBackoff(500, e => this.log(e))));
```

What followed, measured on the cluster:

| Stage | Measured |
| --- | --- |
| Retry rate, sustained | ~90 per minute |
| ACL list expanded per attempt | 8,897 entries |
| Result | PostgreSQL saturated, `acs-auth` starved |
| Visible symptom | Keycloak timed out, sign-in down cluster-wide |

## Changes

| File | Change |
| --- | --- |
| `lib/js-rx-util/lib/util.js` | `retryBackoff(delay, log, { count, shouldRetry })`. Both new options optional. |
| `acs-data-access/lib/retry.js` | New. `retry_cdb_write` and `is_transient_error`. |
| `acs-data-access/lib/session-limits-handler.js` | Create and remove both go through the helper. |
| `acs-data-access/lib/unions-components-handler.js` | Same. |
| `acs-data-access/tests/current/retry.test.js` | New. |

Retried: 5xx, connection failures (the client reports status 0), errors with no status. Not retried: any 4xx.

Cap is 4 retries after the first attempt, so 5 attempts over 7.5s of backoff. That rides out a ConfigDB restart or a short database stall, and is small enough that a client hammering the endpoint cannot build load on ConfigDB. The number matters less than having one.

## Testing

`npm test` in `acs-data-access`: **26 passed, 0 failed**, 0.8s.

Note: `npm test` pointed at `./tests/current`, which did not exist, so the script had always exited 1. The new tests live there. `tests/http/*` still needs a live cluster and is not run by `npm test`.

## Calls to check

1. **`remove_subclass_relationships` now retries.** It had no retry before, so it used to fail immediately on a transient error. Confirm bounded retry is wanted there.
2. **Failure throws rather than proceeding.** `_update_dataset_config` does not catch, so the request aborts. The ConfigDB status is mapped onto an `APIError`: 4xx passes through, anything else becomes 503. Without that mapping a bare `ServiceError` is reported as 503, which tells the client a permanent 403 is worth retrying.
3. **`package-lock.json` is not committed.** It was generated locally by `npm install` and the service has never had one in the repo.

To run the tests locally you also need `npm install` in `lib/js-service-api`, `lib/js-service-client` and `lib/js-rx-util`, because the `file:` dependencies resolve from their own real paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtATkkjtiFF8L6z98NFD8A
