### PR TITLE
configdb: targeted class-relation lookups instead of full closures

### DIFF
--- a/acs-configdb/lib/model.js
+++ b/acs-configdb/lib/model.js
@@ -15,7 +15,7 @@ import { DB } from '@amrc-factoryplus/pg-client'
 import { App, Class, Perm, Service, SpecialObj } from './constants.js'
 import { SpecialApps } from './special.js'
 
-const DB_Version = 13;
+const DB_Version = 14;
 
 /* Well-known object IDs. This is cheating but it's stupid to keep
  * looking them up. */
@@ -219,15 +219,63 @@ export default class Model extends EventEmitter {
         `, [object]);
     }
 
-    _class_lookup (query, id, table) {
-        return _q_uuids(query, `
-            select distinct o.uuid
-            from ${table} k join object o on o.id = k.id
-            where k.class = $1
-        `, [id]);
+    /* The ids of a class and all its subclasses, as an array.
+     *
+     * Callers pass this to the database as an `integer[]` rather than
+     * as a subquery. A recursive CTE has no useful row estimate, so a
+     * subquery makes the planner hash the whole `membership` table; a
+     * literal array lets it use the (class, id) index. */
+    async _subclass_ids (query, id) {
+        const rows = await _q_set(query,
+            `select id from class_subclasses($1)`, [id]);
+        return rows.map(r => r.id);
     }
 
+    /* Look up one class relation for one class.
+     *
+     * The `all_*` views compute the whole class closure and cannot have
+     * a `where class = $1` predicate pushed into them, so reading them
+     * costs O(total objects) per call. The v14 functions walk the graph
+     * from the given class instead and return the same answers. See
+     * sql/v14.sql. */
+    async _class_lookup (query, id, table) {
+        switch (table) {
+        case "all_subclass":
+            return _q_uuids(query, `
+                select distinct o.uuid
+                from class_subclasses($1) k join object o on o.id = k.id
+            `, [id]);
+        case "all_membership": {
+            const classes = await this._subclass_ids(query, id);
+            if (!classes.length) return [];
+            return _q_uuids(query, `
+                select distinct o.uuid
+                from membership m join object o on o.id = m.id
+                where m.class = any($1::integer[])
+            `, [classes]);
+        }
+        default:
+            return _q_uuids(query, `
+                select distinct o.uuid
+                from ${table} k join object o on o.id = k.id
+                where k.class = $1
+            `, [id]);
+        }
+    }
+
+    /* Existence test for one class relation. For the `all_*` relations
+     * this walks up from the object rather than materialising the
+     * class's whole membership. */
     _class_has (query, klass, table, obj) {
+        const fn = {
+            all_subclass:   "class_has_subclass",
+            all_membership: "class_has_member",
+        }[table];
+
+        if (fn)
+            return query(`select ${fn}($1, $2) has`, [klass, obj])
+                .then(r => r.rows[0].has);
+
         return query(`
             select 1 from ${table} r
             where r.class = $1 and r.id = $2
@@ -544,15 +592,13 @@ export default class Model extends EventEmitter {
         });
     }
 
-    async class_has (klass, table, obj) {
-        const dbr = await this.db.query(`
-            select 1
-            from ${table} r
-                join object c on c.id = r.class
-                join object o on o.id = r.id
-            where c.uuid = $1 and o.uuid = $2
-        `, [klass, obj]);
-        return !!dbr.rows.length;
+    class_has (klass, table, obj) {
+        return this.db.txn({}, async query => {
+            const c_id = await this._class_id(query, klass);
+            const o_id = await this._obj_id(query, obj);
+            if (c_id == null || o_id == null) return false;
+            return this._class_has(query, c_id, table, o_id);
+        });
     }
 
     async _class_relation (klass, obj, perform) {
@@ -594,12 +640,13 @@ export default class Model extends EventEmitter {
                 throw "Individuals cannot be subclasses";
             if (c.rank != o.rank)
                 throw "Subclasses must match in rank";
+            /* Drop any superclass link on `obj` that `klass` already
+             * implies. Walking up from `klass` beats materialising
+             * `all_subclass`. */
             await q(`
                 delete from subclass r
-                using all_subclass s
-                where s.id = $1
-                    and s.class = r.class
-                    and r.id = $2
+                where r.id = $2
+                    and class_has_subclass(r.class, $1)
             `, [c.id, o.id]);
             await this._class_add(q, c.id, "subclass", o.id);
         });
@@ -638,15 +685,17 @@ export default class Model extends EventEmitter {
             if (app_id == null) return null;
             const class_id = await this._class_id(query, klass);
             if (class_id == null) return null;
+            const classes = await this._subclass_ids(query, class_id);
+            if (!classes.length) return [];
 
             return _q_uuids(query, `
                 select o.uuid
                 from config c
                     join object o on o.id = c.object
-                    join all_membership m on m.id = c.object
+                    join membership m on m.id = c.object
                 where c.app = $1
-                    and m.class = $2
-            `, [app_id, class_id]);
+                    and m.class = any($2::integer[])
+            `, [app_id, classes]);
         });
     }
 
@@ -855,15 +904,21 @@ export default class Model extends EventEmitter {
             if (a_id === undefined || c_id === undefined)
                 return [];
 
-            return await this._do_config_search(q, c_id, a_id, where, select);
+            /* Expand the class to its subclasses once, and pass the ids
+             * down as an array. See `_subclass_ids`. */
+            const c_ids = c_id == null
+                ? null : await this._subclass_ids(q, c_id);
+            if (c_ids && !c_ids.length) return [];
+
+            return await this._do_config_search(q, c_ids, a_id, where, select);
         });
     }
 
-    async _do_config_search(query, klass, app, where, select) {
-        const k_join = klass ? `join all_membership m on m.id = o.id` : "";
-        const k_whre = klass ? `and m.class = $4` : "";
+    async _do_config_search(query, classes, app, where, select) {
+        const k_join = classes ? `join membership m on m.id = o.id` : "";
+        const k_whre = classes ? `and m.class = any($4::integer[])` : "";
         const bind = [app, where, select];
-        if (klass) bind.push(klass);
+        if (classes) bind.push(classes);
 
         return _q_set(query, `
             with results as (

--- a/acs-configdb/sql/grant.sql
+++ b/acs-configdb/sql/grant.sql
@@ -18,3 +18,8 @@ to :"role";
 grant usage on
     object_id_seq, config_id_seq
 to :"role";
+grant execute on function
+    is_class(integer),
+    class_subclasses(integer), class_members(integer),
+    class_has_subclass(integer, integer), class_has_member(integer, integer)
+to :"role";

--- a/acs-configdb/sql/migrate.sql
+++ b/acs-configdb/sql/migrate.sql
@@ -52,6 +52,7 @@ BEGIN;
 \ir v10.sql
 \ir v11.sql
 \ir v13.sql
+\ir v14.sql
 
 \ir grant.sql
 

--- a/acs-configdb/sql/v14.sql
+++ b/acs-configdb/sql/v14.sql
@@ -1,0 +1,100 @@
+-- Factory+ config DB
+-- DB schema v14: targeted class-relation lookups
+-- Copyright 2026 University of Sheffield AMRC
+
+-- The `all_subclass` and `all_membership` views compute the whole class
+-- closure. Postgres cannot push a `where class = $1` predicate into a
+-- recursive CTE, and the `all_class` seed reads every row of
+-- `membership`, so a lookup of one class costs a full scan of
+-- `membership` plus a full hash of `object`. That is O(total objects)
+-- per lookup, whatever the class.
+--
+-- These functions walk the class graph from a single starting point
+-- instead. Downward for lookups, upward for existence tests. They
+-- return exactly the same answers as the views; the views are kept for
+-- ad-hoc querying and for callers that want the whole relation.
+
+call migrate_to(14, $$
+    -- The unique constraints give us (class, id) indexes. The reverse
+    -- direction has no index, so every upward walk and every
+    -- `where id = $1` was a sequential scan.
+    create index if not exists subclass_id_idx on subclass (id);
+    create index if not exists membership_id_idx on membership (id);
+
+    -- `config` has unique (app, object), which cannot answer a lookup
+    -- by object alone. `object_delete` and the `config.object` foreign
+    -- key both do exactly that, so deleting an object was a sequential
+    -- scan of `config`.
+    create index if not exists config_object_idx on config (object);
+
+    -- `object.class` and `object.owner` are self-references with no
+    -- index, so every object delete scanned `object` twice to check
+    -- them.
+    create index if not exists object_class_idx on object (class);
+    create index if not exists object_owner_idx on object (owner);
+
+    -- Is this object a class? Equivalent to `exists (select 1 from
+    -- all_class where id = _obj)`, but index-driven.
+    create or replace function is_class (_obj integer)
+    returns boolean
+    language sql stable
+    as $fn$
+        select exists (select 1 from subclass s where s.class = _obj)
+            or exists (select 1 from subclass s where s.id = _obj)
+            or exists (select 1 from membership m where m.class = _obj)
+    $fn$;
+
+    -- Equivalent to `select id from all_subclass where class = _class`.
+    create or replace function class_subclasses (_class integer)
+    returns table (id integer)
+    language sql stable
+    as $fn$
+        with recursive sc as (
+            select _class id where is_class(_class)
+            union
+            select c.id from sc p join subclass c on c.class = p.id)
+        select id from sc
+    $fn$;
+
+    -- Equivalent to `select id from all_membership where class = _class`.
+    -- The seed needs no is_class() guard: if _class is not a class then
+    -- it has no members and no subclasses, so the join drops it.
+    create or replace function class_members (_class integer)
+    returns table (id integer)
+    language sql stable
+    as $fn$
+        with recursive sc as (
+            select _class id
+            union
+            select c.id from sc p join subclass c on c.class = p.id)
+        select distinct m.id from sc join membership m on m.class = sc.id
+    $fn$;
+
+    -- Equivalent to `exists (select 1 from all_subclass where
+    -- class = _class and id = _obj)`. Walks up from _obj, which is
+    -- bounded by the depth of the class graph rather than by the
+    -- number of objects.
+    create or replace function class_has_subclass (_class integer, _obj integer)
+    returns boolean
+    language sql stable
+    as $fn$
+        with recursive up as (
+            select _obj id where is_class(_obj)
+            union
+            select s.class from up u join subclass s on s.id = u.id)
+        select exists (select 1 from up where id = _class)
+    $fn$;
+
+    -- Equivalent to `exists (select 1 from all_membership where
+    -- class = _class and id = _obj)`.
+    create or replace function class_has_member (_class integer, _obj integer)
+    returns boolean
+    language sql stable
+    as $fn$
+        with recursive up as (
+            select m.class id from membership m where m.id = _obj
+            union
+            select s.class from up u join subclass s on s.id = u.id)
+        select exists (select 1 from up where id = _class)
+    $fn$;
+$$);


### PR DESCRIPTION
## Review this first

The `is_class()` guard in `class_subclasses` and `class_has_subclass`. `all_subclass` only contains the reflexive pair `(x, x)` when `x` is in `all_class`, so the seed of both walks has to reproduce that condition exactly. `class_members` deliberately has no guard, on the reasoning that a non-class has no members so the join drops the seed. Confirm that holds.

This is a schema migration. It adds functions and indexes and does not alter or drop existing objects. The views are untouched and still available.

## What this does

Replaces full class-closure scans with graph walks from a single starting point, and adds the indexes the schema was missing.

## Why

`all_subclass` and `all_membership` are non-materialised views over a recursive CTE (`sql/v8.sql`). Two consequences:

1. PostgreSQL cannot push a qualifier into a recursive CTE, so `where k.class = $1` is applied after the whole closure is built.
2. The seed, `all_class`, includes `select class from membership`, a sequential scan of the entire table.

So looking up one leaf class with 333 members reads and hashes every row in `membership` and every row in `object`. At 100,000 objects:

```
HashAggregate (actual time=78.832..79.028 rows=333)
  -> Hash Join (actual rows=333)
       -> CTE Scan on sc (actual rows=1)
            Filter: (class = 22)
            Rows Removed by Filter: 940
            CTE sc -> Recursive Union (actual rows=941)
                 -> Append (actual rows=100960)
                      -> Seq Scan on membership (rows=100320)
       -> Hash (actual time=62.416..62.417 rows=100320)
```

`CDBNotify.class_watch` re-runs one of these per watcher on every class change, and `acs-auth` is several of those watchers. These are the two queries seen running repeatedly on fpd-ago while PostgreSQL was saturated:

```sql
select distinct o.uuid from all_membership k join object o on o.id = k.id where k.class = $1
select distinct o.uuid from all_subclass  k join object o on o.id = k.id where k.class = $1
```

## Changes

Schema v14 adds four functions:

| Function | Direction |
| --- | --- |
| `class_subclasses(class)` | walks down |
| `class_members(class)` | walks down |
| `class_has_subclass(class, obj)` | walks up from the object |
| `class_has_member(class, obj)` | walks up from the object |

Walking up means an existence test never materialises a class's membership.

`model.js` uses them in `_class_lookup`, `_class_has`, `class_has`, `config_class_list`, `config_search`, and the redundant-superclass delete in `class_add_subclass`.

Indexes added. `subclass` and `membership` had only `unique(class, id)`, so any lookup by object was a sequential scan. `config` had only `unique(app, object)`, which cannot answer a lookup by object. `object.class` and `object.owner` are self-references with no index at all.

## Numbers

PostgreSQL 16.14, real ConfigDB schema, best of three, warm cache. Class tree of 1 root, 20 mid, 300 leaf.

| Objects | Operation | Before | After |
| --- | --- | --- | --- |
| 1,000,337 | is this object a member? | 186.64 ms | 0.45 ms |
| 1,000,337 | subclasses of the root class | 360.92 ms | 0.54 ms |
| 1,000,337 | members of a leaf class | 199.61 ms | 11.97 ms |
| 1,000,337 | members of the root class | 1398.23 ms | 745.10 ms |
| 1,000,337 | delete one object, end to end | 0.112 s | 0.015 s |

Existence tests are flat in object count: 0.42 / 0.46 / 0.46 / 0.45 ms at 1,647 / 10,337 / 100,337 / 1,000,337 objects.

Listing the members of a class that genuinely holds a million objects is still about a second. That is the cost of returning a million uuids, not a query problem.

## Testing

`acs-configdb` has no test suite, so this is differential testing against the views on a live PostgreSQL running the real migration chain, v6 through v14.

| Level | Comparisons | Mismatches |
| --- | --- | --- |
| SQL, layered tree | every object, both lookups, `config_class_list`, the `class_add_subclass` delete | 0 |
| SQL, random DAG | 1,126 subclass edges, 12,896 closure pairs, 55,586 `all_membership` rows | 0 |
| Application, through `Model` | 50,708 | 0 |

`migrate.sql` runs clean from an empty server to v14, and applies v14 on top of an existing v13 database.

There is no regression net after this lands, because the service has no test suite.

## What this does not fix

`acs-auth` expands a class-scoped grant into one ACL entry per object and returns the whole list from `GET /v2/acl/:principal`. On fpd-ago that was 8,897 entries from 149 stored ACEs over 1,310 datasets.

That grows linearly with object count. At 1M datasets it is roughly 6.8M entries and 690 MB of JSON per principal, rebuilt and resent whole on every relevant change, with no delta protocol. There is no targeted "may P do X to O" endpoint.

That needs an API change, not an index, and is written up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtATkkjtiFF8L6z98NFD8A
