### PR TITLE
Add Dev Container Config

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,64 @@
+# Dev container
+
+This gives you a ready-to-use environment for working on ACS: Node/TS,
+Python, Rust (`lib/rs-edge-driver`), and Java/Maven (`lib/java-service-client`),
+plus Docker, `kubectl`, and `helm`.
+
+## Getting started
+
+1. Open the repo in VS Code and run **Dev Containers: Reopen in
+   Container**, or, from the CLI:
+   ```sh
+   devcontainer up --workspace-folder .
+   ```
+2. First build runs `onCreateCommand` (installs Kerberos headers, build
+   tools, and a JDK/Maven via `apt-get`) and `postCreateCommand` (`npm
+   install` in `lib/`, which other subdirs depend on per the top-level
+   `Makefile`). Each individual service still needs its own `npm install`
+   before you work on it - the container doesn't bootstrap every service.
+3. Optional: set up kubeconfig access (see below) if you want
+   `kubectl`/`helm` in the container to reach your existing clusters.
+
+## Kubeconfig access (optional)
+
+By default `kubectl`/`helm` in the container have no cluster contexts -
+the kubeconfig mount falls back to a harmless no-op (`/tmp`) when
+unconfigured, so the container builds and works fine without it. To opt
+in, copy the template and point it at a kubeconfig directory on your
+host:
+
+```sh
+cp .devcontainer/devcontainer.env.example .devcontainer/devcontainer.env
+# then edit KUBE_HOST_DIR in that file
+```
+
+`devcontainer.env` is gitignored - it's machine-specific. `KUBE_HOST_DIR`
+can point at your real `~/.kube`, or a smaller directory containing just
+the kubeconfig(s) you want available in the container, if `~/.kube` has
+contexts or plugin caches you'd rather not share. Whatever directory you
+point at is bind-mounted to `/home/node/.kube`.
+
+Notes:
+- `kubectl`/`helm` only auto-read `/home/node/.kube/config`. If your
+  directory has multiple kubeconfig files, use `--kubeconfig=...` or set
+  `KUBECONFIG` to a colon-separated list to merge them.
+- Contexts that rely on a cloud auth plugin (`gcloud`, `aws`, `az`, etc.)
+  need that CLI installed in the container too - the mount only shares
+  the config file, not the plugin binaries.
+- `devcontainer.json` can't dynamically fall back to "your real `~/.kube`"
+  when `KUBE_HOST_DIR` is unset - variable substitution doesn't support
+  nesting another variable inside a default value. That's why the
+  unconfigured state is a fixed `/tmp` no-op rather than any real
+  kubeconfig directory.
+
+## Forwarded ports
+
+`3000` (common Node service API default) and `5173` (`acs-admin`'s Vite
+dev server) are forwarded automatically. Add others as needed for
+whatever service you're running.
+
+## Building component images / using Docker
+
+The `docker-in-docker` feature gives you a working `docker` CLI so you
+can `docker build` and run `make` targets in this repo that shell out to
+Docker.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -11,10 +11,10 @@ plus Docker, `kubectl`, and `helm`.
    ```sh
    devcontainer up --workspace-folder .
    ```
-2. First build runs `onCreateCommand` (installs Kerberos headers, build
-   tools, and a JDK/Maven via `apt-get`) and `postCreateCommand` (`npm
-   install` in `lib/`, which other subdirs depend on per the top-level
-   `Makefile`). Each individual service still needs its own `npm install`
+2. First build runs `onCreateCommand`, which installs Kerberos headers,
+   build tools, and a JDK/Maven via `apt-get`. Run `npm install` in `lib/`
+   yourself afterwards - other subdirs depend on it per the top-level
+   `Makefile`. Each individual service still needs its own `npm install`
    before you work on it - the container doesn't bootstrap every service.
 3. Optional: set up kubeconfig access (see below) if you want
    `kubectl`/`helm` in the container to reach your existing clusters.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -22,10 +22,9 @@ plus Docker, `kubectl`, and `helm`.
 ## Kubeconfig access (optional)
 
 By default `kubectl`/`helm` in the container have no cluster contexts -
-the kubeconfig mount falls back to a harmless no-op (`/tmp`) when
+the kubeconfig mount falls back to a harmless no-op (`/dev/null`) when
 unconfigured, so the container builds and works fine without it. To opt
-in, copy the template and point it at a kubeconfig directory on your
-host:
+in, copy the template and point it at a kubeconfig file on your host:
 
 ```sh
 cp .devcontainer/devcontainer.env.example .devcontainer/devcontainer.env
@@ -33,23 +32,24 @@ cp .devcontainer/devcontainer.env.example .devcontainer/devcontainer.env
 ```
 
 `devcontainer.env` is gitignored - it's machine-specific. `KUBE_HOST_DIR`
-can point at your real `~/.kube`, or a smaller directory containing just
-the kubeconfig(s) you want available in the container, if `~/.kube` has
-contexts or plugin caches you'd rather not share. Whatever directory you
-point at is bind-mounted to `/home/node/.kube`.
+is the absolute path to a single kubeconfig yaml file - your real
+`~/.kube/config`, or a separate file containing just the contexts you
+want available in the container, if `~/.kube/config` has contexts you'd
+rather not share. It's bind-mounted to `/home/node/.kube/config`.
 
 Notes:
-- `kubectl`/`helm` only auto-read `/home/node/.kube/config`. If your
-  directory has multiple kubeconfig files, use `--kubeconfig=...` or set
-  `KUBECONFIG` to a colon-separated list to merge them.
+- `KUBE_HOST_DIR` must point at a file, not a directory. If you need to
+  merge multiple kubeconfig files, do that on the host first (e.g.
+  `KUBECONFIG=a:b kubectl config view --flatten > merged`) and point
+  `KUBE_HOST_DIR` at the merged result.
 - Contexts that rely on a cloud auth plugin (`gcloud`, `aws`, `az`, etc.)
   need that CLI installed in the container too - the mount only shares
   the config file, not the plugin binaries.
-- `devcontainer.json` can't dynamically fall back to "your real `~/.kube`"
-  when `KUBE_HOST_DIR` is unset - variable substitution doesn't support
-  nesting another variable inside a default value. That's why the
-  unconfigured state is a fixed `/tmp` no-op rather than any real
-  kubeconfig directory.
+- `devcontainer.json` can't dynamically fall back to "your real
+  `~/.kube/config`" when `KUBE_HOST_DIR` is unset - variable substitution
+  doesn't support nesting another variable inside a default value. That's
+  why the unconfigured state is a fixed `/dev/null` no-op rather than any
+  real kubeconfig file.
 
 ## Forwarded ports
 

--- a/.devcontainer/devcontainer.env.example
+++ b/.devcontainer/devcontainer.env.example
@@ -1,0 +1,11 @@
+# Copy this file to devcontainer.env (same directory) and fill in your own
+# values. devcontainer.env is gitignored - it's machine-specific and is
+# read by the Dev Containers extension/CLI to resolve ${localEnv:...}
+# references in devcontainer.json.
+
+# Directory bind-mounted into the container at /home/node/.kube, giving
+# kubectl/helm access to your existing cluster contexts. Point this at your
+# real ~/.kube if you want everything in it available, or at a smaller
+# directory containing just the kubeconfig file(s) you want in the
+# container (useful if ~/.kube has many unrelated contexts/plugin caches).
+KUBE_HOST_DIR=/home/you/.kube

--- a/.devcontainer/devcontainer.env.example
+++ b/.devcontainer/devcontainer.env.example
@@ -3,9 +3,12 @@
 # read by the Dev Containers extension/CLI to resolve ${localEnv:...}
 # references in devcontainer.json.
 
-# Directory bind-mounted into the container at /home/node/.kube, giving
-# kubectl/helm access to your existing cluster contexts. Point this at your
-# real ~/.kube if you want everything in it available, or at a smaller
-# directory containing just the kubeconfig file(s) you want in the
-# container (useful if ~/.kube has many unrelated contexts/plugin caches).
-KUBE_HOST_DIR=/home/you/.kube
+# Absolute path to a kubeconfig yaml file, bind-mounted into the container
+# at /home/node/.kube/config, giving kubectl/helm access to your existing
+# cluster contexts. Point this at your real ~/.kube/config, or at a
+# separate file containing just the contexts you want available in the
+# container (useful if ~/.kube/config has unrelated contexts you'd rather
+# not share). Must be a single file, not a directory - if you need to
+# merge multiple kubeconfig files, do that on the host first (e.g.
+# `KUBECONFIG=a:b kubectl config view --flatten > merged`) and point here.
+KUBE_HOST_DIR=/home/you/.kube/config

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,86 @@
+{
+  "name": "amrc-connectivity-stack",
+
+  // Node/TS/Vue is the dominant language mix, so use the Node dev container
+  // image as the base and layer on everything else as features.
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22-bookworm",
+
+  "features": {
+    // Lets you `docker build` the component images and run `make` targets
+    // that shell out to Docker from inside the container.
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "latest"
+    },
+
+    // ACS ships as a Helm chart onto Kubernetes; this gives you kubectl
+    // and helm. Minikube is skipped - see the kubeconfig mount below for
+    // connecting to a real cluster instead.
+    "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+      "version": "latest",
+      "helm": "latest",
+      "minikube": "none"
+    },
+
+    // Some tooling/scripts in the repo are Python.
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.11"
+    },
+
+    // lib/rs-edge-driver is a Rust crate (edition 2024).
+    "ghcr.io/devcontainers/features/rust:1": {},
+
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "installZsh": true,
+      "configureZshAsDefaultShell": true
+    },
+
+    // Installs the Claude Code CLI (and the VS Code extension, when opened
+    // in VS Code). This version tag pins the installer script, not the
+    // Claude Code release — it always installs latest and auto-updates.
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {}
+  },
+
+  "mounts": [
+    // Optionally shares a kubeconfig directory from your host into the
+    // container, so `kubectl`/`helm` can talk to your existing clusters.
+    // Set KUBE_HOST_DIR in .devcontainer/devcontainer.env (gitignored,
+    // not checked in - see devcontainer.env.example) to the .kube
+    // directory (or a curated subset of it) you want mounted.
+    //
+    // If KUBE_HOST_DIR isn't set, this falls back to /tmp: devcontainer.json
+    // variable substitution doesn't support a *dynamic* default (nesting
+    // another ${...} inside the default value breaks - verified against
+    // @devcontainers/cli, it mis-parses at the inner closing brace), so we
+    // can't fall back to "your real ~/.kube" automatically. /tmp always
+    // exists, so this is a harmless no-op mount rather than a build
+    // failure - kubectl/helm simply won't find a config and behave as if
+    // none was mounted.
+    "source=${localEnv:KUBE_HOST_DIR:/tmp},target=/home/node/.kube,type=bind"
+  ],
+  "containerEnv": {
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1"
+  },
+
+  // Several @amrc-factoryplus packages have native (node-gyp) dependencies
+  // that need Kerberos headers to build, plus GSSAPI tooling used at
+  // runtime by the service clients.
+  "onCreateCommand": "sudo apt-get update && sudo apt-get install -y --no-install-recommends libkrb5-dev krb5-user build-essential openjdk-17-jdk-headless maven",
+
+  "customizations": {
+    "vscode": {
+      "extensions": [],
+      "settings": {
+        "files.eol": "\n"
+      }
+    }
+  },
+
+  // Handy inside-container ports if you're running any of the ACS services
+  // or their web UIs locally for development. 5173 is acs-admin's Vite
+  // dev server (default port, unconfigured in vite.config.js); 3000 is
+  // the common default for the Node service APIs.
+  "forwardPorts": [3000, 5173],
+
+  "remoteUser": "node"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -42,21 +42,21 @@
   },
 
   "mounts": [
-    // Optionally shares a kubeconfig directory from your host into the
+    // Optionally shares a single kubeconfig file from your host into the
     // container, so `kubectl`/`helm` can talk to your existing clusters.
     // Set KUBE_HOST_DIR in .devcontainer/devcontainer.env (gitignored,
-    // not checked in - see devcontainer.env.example) to the .kube
-    // directory (or a curated subset of it) you want mounted.
+    // not checked in - see devcontainer.env.example) to the absolute path
+    // of the kubeconfig yaml file you want mounted.
     //
-    // If KUBE_HOST_DIR isn't set, this falls back to /tmp: devcontainer.json
-    // variable substitution doesn't support a *dynamic* default (nesting
-    // another ${...} inside the default value breaks - verified against
-    // @devcontainers/cli, it mis-parses at the inner closing brace), so we
-    // can't fall back to "your real ~/.kube" automatically. /tmp always
-    // exists, so this is a harmless no-op mount rather than a build
-    // failure - kubectl/helm simply won't find a config and behave as if
-    // none was mounted.
-    "source=${localEnv:KUBE_HOST_DIR:/tmp},target=/home/node/.kube,type=bind"
+    // If KUBE_HOST_DIR isn't set, this falls back to /dev/null:
+    // devcontainer.json variable substitution doesn't support a *dynamic*
+    // default (nesting another ${...} inside the default value breaks -
+    // verified against @devcontainers/cli, it mis-parses at the inner
+    // closing brace), so we can't fall back to "your real ~/.kube/config"
+    // automatically. /dev/null always exists, so this is a harmless no-op
+    // mount rather than a build failure - kubectl/helm see an empty config
+    // file and behave as if none was mounted.
+    "source=${localEnv:KUBE_HOST_DIR:/dev/null},target=/home/node/.kube/config,type=bind"
   ],
   "containerEnv": {
     "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1"

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ node_modules/
 /.claude/scheduled_tasks.lock
 /.env.worktree
 .grepai/
+/.devcontainer/devcontainer.env


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                    
  Adds a VS Code Dev Container / `devcontainer` CLI setup for this repo, so                                                                                                                                                                                                                                         
  contributors get a ready-to-use environment (Node/TS, Python, Rust, Java/Maven,                                                                                                                                                                                                                                   
  Docker, `kubectl`, `helm`) without manual setup, plus a README explaining how                                                                                                                                                                                                                                     
  to use it.                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                    
  ## What's included                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                    
  - **`.devcontainer/devcontainer.json`** — Node 22 base image, with                                                                                                                                                                                                                                                
    `docker-in-docker`, `kubectl`/`helm` (minikube disabled), Python 3.11, Rust,                                                                                                                                                                                                                                    
    GitHub CLI, and Claude Code added as features. `onCreateCommand` installs                                                                                                                                                                                                                                       
    Kerberos headers and a JDK/Maven via `apt-get` (needed for native                                                                                                                                                                                                                                               
    `node-gyp` deps in `@amrc-factoryplus` packages and for `lib/java-service-client`).                                                                                                                                                                                                                             
    Forwards ports 3000 and 5173 (Node service API / `acs-admin` Vite dev server                                                                                                                                                                                                                                    
    defaults).                                                                                                                                                                                                                                                                                                      
  - **Optional kubeconfig mount** — `KUBE_HOST_DIR` (set via a gitignored                                                                                                                                                                                                                                           
    `.devcontainer/devcontainer.env`, templated by `devcontainer.env.example`)                                                                                                                                                                                                                                      
    bind-mounts a host `.kube`-style directory into the container at                                                                                                                                                                                                                                                
    `/home/node/.kube`. Unset, it falls back to a harmless `/tmp` no-op mount                                                                                                                                                                                                                                       
    since `devcontainer.json` variable substitution can't nest a dynamic                                                                                                                                                                                                                                            
    default (verified against `@devcontainers/cli`).                                                                                                                                                                                                                                                                
  - **`.devcontainer/README.md`** — usage instructions, including the                                                                                                                                                                                                                                               
    kubeconfig opt-in and its caveats (only `/home/node/.kube/config` is                                                                                                                                                                                                                                            
    auto-read; cloud auth plugins like `gcloud`/`aws` need to be installed                                                                                                                                                                                                                                          
    separately since only the config file is shared).                                                                                                                                                                                                                                                               
  - **`.gitignore`** — ignores `.devcontainer/devcontainer.env`, the                                                                                                                                                                                                                                                
    machine-specific file holding `KUBE_HOST_DIR`.                                                                                                                                                                                                                                                                  
                                                                
## Notes                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                    
  - `lib/` still needs a manual `npm install` after first build (other                                                                                                                                                                                                                                              
    subdirs depend on it per the top-level `Makefile`); there's no                                                                                                                                                                                                                                                  
    `postCreateCommand` that automates this — the README has been corrected                                                                                                                                                                                                                                         
    to reflect that rather than adding one, to keep first-boot behaviour                                                                                                                                                                                                                                            
    minimal and predictable.                                                                                                                                                                                                                                                                                        
  - No existing files/behaviour outside `.devcontainer/` and `.gitignore`                                                                                                                                                                                                                                           
    are touched.                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                    
  ## How to test                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                    
  1. `devcontainer up --workspace-folder .` (or VS Code: Dev Containers →                                                                                                                                                                                                                                           
     Reopen in Container).                                                                                                                                                                                                                                                                                          
  2. Confirm `node`, `python3`, `cargo`, `mvn`, `docker`, `kubectl`, `helm`                                                                                                                                                                                                                                         
     are all available in the container shell.                                                                                                                                                                                                                                                                      
  3. `npm install` in `lib/`, then spot-check a service (e.g. `acs-configdb`)                                                                                                                                                                                                                                       
     builds/runs.                                                                                                                                                                                                                                                                                                   
  4. Optionally set `KUBE_HOST_DIR` in a local `devcontainer.env` and confirm                                                                                                                                                                                                                                       
     `kubectl config get-contexts` sees your host contexts after a rebuild.    
 