### PR TITLE
Bump Keycloak to 26.7.2 to fix CVE-2026-18963

### DIFF
--- a/acs-keycloak-spi/pom.xml
+++ b/acs-keycloak-spi/pom.xml
@@ -24,7 +24,7 @@
              the base assumes (lib/X), so acs.top must point at the repo root. -->
         <acs.top>..</acs.top>
 
-        <keycloak.version>26.6.3</keycloak.version>
+        <keycloak.version>26.7.2</keycloak.version>
         <!-- 5.18.0 supports inline-mocking on JDK 24/25; 5.11 throws
              "Could not modify all classes [interface
              org.keycloak.models.KeycloakSession]" on JDK 25. -->

--- a/acs-keycloak/Dockerfile
+++ b/acs-keycloak/Dockerfile
@@ -8,14 +8,6 @@
 #   * lib  -> ../lib (provides java-base-pom and the in-tree mvn repo)
 #   * spi  -> ../acs-keycloak-spi (the SPI source tree)
 
-# 26.6.3: first line we ship with pgjdbc >= 42.7.5, fixing the
-# GSSInputStream partial-read bug (pgjdbc #3373) that corrupts GSS
-# encrypted Postgres streams under unlucky TCP segmentation, seen as
-# "Could not use AES128 Cipher - Checksum failed" crash loops on
-# amrc-fp. Also covers pgjdbc CVE-2025-49146.
-# 26.7.2: fixes CVE-2026-18963, a critical (CVSS 9.1) auth bypass in
-# the reset-credentials flow that lets an unauthenticated attacker set
-# a new password on any account without completing email verification.
 ARG keycloak_version=26.7.2
 ARG maven_image=docker.io/library/maven:3.9-eclipse-temurin-21
 ARG revision=unknown

--- a/acs-keycloak/Dockerfile
+++ b/acs-keycloak/Dockerfile
@@ -13,7 +13,10 @@
 # encrypted Postgres streams under unlucky TCP segmentation, seen as
 # "Could not use AES128 Cipher - Checksum failed" crash loops on
 # amrc-fp. Also covers pgjdbc CVE-2025-49146.
-ARG keycloak_version=26.6.3
+# 26.7.2: fixes CVE-2026-18963, a critical (CVSS 9.1) auth bypass in
+# the reset-credentials flow that lets an unauthenticated attacker set
+# a new password on any account without completing email verification.
+ARG keycloak_version=26.7.2
 ARG maven_image=docker.io/library/maven:3.9-eclipse-temurin-21
 ARG revision=unknown
 


### PR DESCRIPTION
**Summary**                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                    
  - Bumps the bundled Keycloak base image from 26.6.3 to 26.7.2 (acs-keycloak/Dockerfile), and the acs-keycloak-spi build's target API version to match (acs-keycloak-spi/pom.xml), so the SPI compiles and runs against the same Keycloak release.                                                                 
  - 26.7.2 fixes CVE-2026-18963 (CVSS 9.1): an auth bypass in Keycloak's reset-credentials flow caused by improper state validation, which let an unauthenticated remote attacker skip email verification and set a new password on any account, including admins.                                                  
                                                                                                                                                                                                                                                                                                                    
**Why**                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                    
  Our openid deployment runs upstream quay.io/keycloak/keycloak (not the Red Hat build), so the applicable fix is upstream 26.7.2, released 2026-08-19.                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                    
**Verification**                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                  
  - mvn package on acs-keycloak-spi against keycloak.version=26.7.2 builds clean — no API breakage between 26.6 and 26.7 affecting our custom User Storage Provider / Kerberos authenticator.                                                                                                                       
  - docker buildx build of the full acs-keycloak image succeeds: the 26.7.2 base image pulls, and the SPI jar copies into /opt/keycloak/providers/ as expected.                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                    
**How to test**                                                                                                                                                                                                                                                                                                               
  1. make -C acs-keycloak to build the image.                                                                                                                                                                                                                                                                       
  2. Deploy to a test cluster (helm upgrade) and confirm the openid pod starts healthy (/health/ready).                                                                                                                                                                                                             
  3. Confirm Kerberos login through the SPI still works end-to-end.                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                    
**Files changed**                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                    
  - acs-keycloak/Dockerfile — keycloak_version ARG default, plus updated comment.                                                                                                                                                                                                                                   
  - acs-keycloak-spi/pom.xml — keycloak.version property.      