### PR TITLE
acs-admin: refresh bun.lock to unblock the release build

### DIFF
--- a/acs-admin/bun.lock
+++ b/acs-admin/bun.lock
@@ -11,6 +11,7 @@
         "@apidevtools/json-schema-ref-parser": "file:../lib/js-json-schema-ref-parser",
         "@import-meta-env/cli": "^0.6.9",
         "@import-meta-env/unplugin": "^0.5.0",
+        "@internationalized/date": "^3.12.2",
         "@jsdevtools/ono": "^7.1.3",
         "@microsoft/fetch-event-source": "^2.0.1",
         "@rollup/plugin-inject": "^5.0.5",
@@ -76,6 +77,7 @@
         "zod": "^3.24.2",
       },
       "devDependencies": {
+        "typescript": "^5.9.3",
         "vitest": "^3.2.7",
       },
     },


### PR DESCRIPTION
## What this fixes

The `v6.9.0-rc.1` release run failed in `build-x86-js (acs-admin)` with:

```
error: lockfile had changes, but lockfile is frozen
```

`acs-admin/package.json` declares `@internationalized/date` (added with the
Calendar component) and a `typescript` devDependency, but `bun.lock` was never
regenerated. The Dockerfile runs `bun install --production --frozen-lockfile`,
which refuses the drift and fails the build.

This commit regenerates the lockfile. The only change is two entries added to
the workspace block; no dependency versions move.

## How to test

1. `cd acs-admin`
2. `bun install --production --frozen-lockfile`
3. It completes instead of erroring.

`acs-edge/bun.lock` was checked too and is already in sync.

## Release notes

Fixed the `acs-admin` container build failing on an out-of-date `bun.lock`.
