### PR TITLE
acs-edge: support per-item timestampNs in JSON (Batched) payloads

### DIFF
--- a/acs-edge/lib/device.ts
+++ b/acs-edge/lib/device.ts
@@ -376,7 +376,7 @@ export class Device {
 
                             // Create a metric for each item in the batch
                             batchResults.forEach(result => {
-                                const { value, timestamp } = result;
+                                const { value, timestamp, timestampNs } = result;
 
                                 // Test if the value is a bigint and convert it to a Long
                                 let processedValue = value;
@@ -386,9 +386,11 @@ export class Device {
 
                                 // If it has a sensible value and is different from the current value
                                 if ((processedValue || processedValue === 0) && (metric.value !== processedValue)) {
-                                    // Create a copy of the metric with the new value and timestamp
+                                    // Create a copy of the metric with the new value and timestamp.
+                                    // timestampNs takes precedence for sub-ms precision, same as
+                                    // the non-batched JSON path.
                                     const updatedMetric = {
-                                        ...this._metrics.setValueByAddrPath(addr, path, processedValue, timestamp || Date.now())
+                                        ...this._metrics.setValueByAddrPath(addr, path, processedValue, timestamp || Date.now(), timestampNs)
                                     };
 
                                     // Add to the list of changed metrics

--- a/acs-edge/lib/helpers/typeHandler.ts
+++ b/acs-edge/lib/helpers/typeHandler.ts
@@ -384,10 +384,10 @@ export class Metrics {
  * This function expects an array of objects and uses the metric's path to extract values
  * @param payload The JSON array payload to process
  * @param metric The metric to use for processing (including path configuration)
- * @returns An array of objects with value and timestamp properties
+ * @returns An array of objects with value, timestamp and timestampNs properties
  */
-export function processJSONBatchedPayload(payload: any[], metric: sparkplugMetric): { value: any, timestamp?: number }[] {
-    const results: { value: any, timestamp?: number }[] = [];
+export function processJSONBatchedPayload(payload: any[], metric: sparkplugMetric): { value: any, timestamp?: number, timestampNs?: bigint }[] {
+    const results: { value: any, timestamp?: number, timestampNs?: bigint }[] = [];
     const path = (typeof metric.properties !== "undefined" && typeof metric.properties.path !== "undefined" ? metric.properties.path.value as string : "");
 
     // Validate that payload is an array
@@ -447,7 +447,19 @@ export function processJSONBatchedPayload(payload: any[], metric: sparkplugMetri
             }
         }
 
-        results.push({ value, timestamp });
+        // Extract a nanosecond-precision timestamp if available. As with
+        // parseNsTimestampFromPayload, this must be a numeric string (not a
+        // number) to avoid float64 precision loss.
+        let timestampNs: bigint | undefined;
+        if (item.timestampNs != null) {
+            try {
+                timestampNs = BigInt(item.timestampNs);
+            } catch {
+                log(`JSON (Batched) payload item ${index} has invalid timestampNs: ${item.timestampNs}`);
+            }
+        }
+
+        results.push({ value, timestamp, timestampNs });
     });
 
     return results;


### PR DESCRIPTION
This adds support for custom drivers to provide nanosecond timestamp resolution with a batched payload format. This was left as an open item after the switch to nanosecond timestamps in Sparkplug.

This works in the same way as the non-batched JSON format, where a driver provides each individual `{ "timestampNs": "123456", "value": "654321" }` in a batch.