### PR TITLE
Bump npm in the JS base image to unblock every service build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: Build & Release ACS
 
 env:
-  BASE_JS_VERSION: v4.0.0
+  BASE_JS_VERSION: v4.1.0
 
 on:
   workflow_call: {}

--- a/acs-base-images/Dockerfile.js-build
+++ b/acs-base-images/Dockerfile.js-build
@@ -2,11 +2,22 @@
 # This includes the krb5 libraries and the build tools needed to build
 # gssapi.js.
 
-FROM node:lts-alpine
+# Node is pinned to a major version rather than tracking lts-alpine so
+# that rebuilding this image cannot move the Node runtime under every
+# service by surprise. Bump it deliberately.
+FROM node:22-alpine
 
 # Install system packages we need to build.
 RUN apk add gcc g++ cmake make python3 \
     krb5-dev libedit-dev
+
+# The npm shipped with Node 22 (10.9.x) crashes in @npmcli/arborist
+# while resolving vitest 4.x now that vitest 5 exists:
+#   TypeError: Cannot read properties of null (reading 'edgesOut')
+#       at #loadPeerSet (build-ideal-tree.js)
+# Fixed upstream in npm 11.6.0. Every service build runs npm install,
+# so the fix belongs here rather than in each service.
+RUN npm install -g npm@11.6.0
 
 USER node
 WORKDIR /home/node

--- a/acs-base-images/Dockerfile.js-run
+++ b/acs-base-images/Dockerfile.js-run
@@ -1,7 +1,8 @@
 # ACS base image for running JS services.
 # This includes the krb5 libraries and k5start.
 
-FROM node:lts-alpine
+# Pinned to match Dockerfile.js-build - see the note there.
+FROM node:22-alpine
 
 # Install system packages we need for runtime.
 RUN apk add libedit krb5-libs kstart \


### PR DESCRIPTION
## What was wrong

`vitest 5.0.0` was published to npm on 2026-09-03 at 12:24 UTC. From that
moment every JS service build failed at `npm install`:

```
npm error Cannot read properties of null (reading 'edgesOut')
    at #loadPeerSet (@npmcli/arborist/lib/arborist/build-ideal-tree.js:1289:38)
```

The npm baked into `acs-base-js-build:v4.0.0` is 10.9.2, and it crashes in
arborist while resolving `vitest` 4.x's peer set now that a 5.x exists. The
crash is in `buildIdealTree`, so it happens before install even starts.

`v6.9.0-rc.3` built green at 12:16. `v6.9.0` (12:36) and `v6.9.1` (12:49)
both failed on the identical commit. `acs-data-access` is the first x86
service to reach `npm install`, so it failed and fail-fast cancelled the
other 18 jobs - which is why the run looked like a wholesale collapse.

Reproduced standalone in the CI image: `npm install vitest@^4.1.8` is
enough. Nothing in the repo changed.

## The fix

Install npm 11.6.0 in the JS base build image. Every service build runs
`npm install`, so the fix belongs in one place rather than in 19
Dockerfiles.

Also pin both base images to `node:22-alpine`. They tracked
`node:lts-alpine`, so bumping `BASE_JS_VERSION` to force a rebuild would
have moved every service from Node 22 to Node 24 as an unannounced side
effect of an npm fix. The pin keeps the runtime byte-identical in intent
to what `v4.0.0` shipped. A Node LTS bump should be its own PR.

`BASE_JS_VERSION` goes to `v4.1.0` because the workflow skips the base
build when the tag already exists.

### Rejected alternatives, each tested in the CI image

| Attempt | Result |
| --- | --- |
| `--omit=dev` | Still crashes - the ideal tree includes dev deps regardless |
| Committed `package-lock.json` | Still crashes - `npm install` rebuilds the ideal tree |
| npm 10.9.9, 11.1.0, 11.5.0 | Still crash. Fixed between 11.5.0 and 11.6.0 |
| Pin `vitest@4.1.11` | Still crashes - arborist fetches the packument anyway |
| Bump to `vitest@^5.0.0` | Works, but a test-framework major bump on 3 packages to dodge one npm bug |
| npm 11.19.1 (latest) | Works, but 11.19 gates install scripts, which breaks the gssapi native build |

## How to test

1. Build the base images from this branch:
   ```sh
   docker build --platform linux/amd64 -f acs-base-images/Dockerfile.js-build -t acs-base-js-build:test acs-base-images
   docker build --platform linux/amd64 -f acs-base-images/Dockerfile.js-run  -t acs-base-js-run:test  acs-base-images
   ```
2. Build the service that was failing:
   ```sh
   docker build --platform linux/amd64 -f acs-data-access/Dockerfile \
     --build-context lib=./lib --build-arg base_prefix=acs-base --build-arg base_version=test \
     -t acs-data-access:test acs-data-access
   ```
   Expect a clean build. Against `base_version=v4.0.0` it fails with `edgesOut`.
3. Confirm the gssapi native module still builds and loads:
   ```sh
   docker run --rm --platform linux/amd64 acs-data-access:test \
     node -e 'import("@amrc-factoryplus/gssapi").then(m => console.log(Object.keys(m)))'
   ```
4. Run the service tests:
   ```sh
   docker build --platform linux/amd64 --target build -f acs-data-access/Dockerfile \
     --build-context lib=./lib --build-arg base_prefix=acs-base --build-arg base_version=test \
     -t acs-data-access:build acs-data-access
   docker run --rm --platform linux/amd64 -w /home/node/app acs-data-access:build npm test
   ```
   Expect 9 passing tests, and vitest still resolving to 4.1.11.

## Verified locally before pushing

- **amd64 base + 11 services:** acs-data-access, acs-i3x, acs-service-setup, acs-krb-keys-operator, acs-files, acs-admin, acs-monitor, uns-ingester-sparkplug, historian-uns, edge-helm-charts
- **arm64 base + 2 services:** acs-edge, edge-sim (the edge drivers build on arm runners off the same base)
- **pg base + 3 services:** acs-auth, acs-configdb, acs-directory
- **Runtime:** gssapi native module loads in the final image
- **Tests:** `acs-data-access` vitest suite, 9/9 passing

## Release notes

Fixed a build failure that made every JS service image fail to build after
`vitest 5.0.0` was published upstream. No runtime behaviour changes; the
Node version in the service images is unchanged.

## After merge

`v6.9.0` and `v6.9.1` are both published releases with no artifacts behind
them. `v6.9.2` needs cutting off `main` once this lands, and those two
should probably be deleted or marked as drafts.
